### PR TITLE
Fix camera GPS export to use lat/lon keys with DMS conversion

### DIFF
--- a/tools/capture_gcps_web.py
+++ b/tools/capture_gcps_web.py
@@ -1670,14 +1670,16 @@ class GCPCaptureWebSession:
         ]
 
         # Add camera GPS if available
-        if CAMERA_CONFIG_AVAILABLE:
+        if CAMERA_CONFIG_AVAILABLE and GPS_CONVERTER_AVAILABLE:
             try:
                 cam_info = get_camera_by_name(self.camera_name)
-                if cam_info and 'gps' in cam_info:
+                if cam_info and 'lat' in cam_info and 'lon' in cam_info:
+                    camera_lat = dms_to_dd(cam_info['lat'])
+                    camera_lon = dms_to_dd(cam_info['lon'])
                     lines.extend([
                         "      camera_gps:",
-                        f"        latitude: {cam_info['gps'].get('latitude')}",
-                        f"        longitude: {cam_info['gps'].get('longitude')}",
+                        f"        latitude: {camera_lat}",
+                        f"        longitude: {camera_lon}",
                     ])
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- Fixed bug where camera GPS was never exported because code checked for non-existent `'gps'` key
- Changed conditional to check for `'lat'` and `'lon'` keys in camera config
- Added DMS to decimal degree conversion using existing `dms_to_dd()` function
- Added `GPS_CONVERTER_AVAILABLE` guard check for consistency with other usages in the file

## Test plan
- [ ] Run `python tools/capture_gcps_web.py Valte` and capture at least one GCP
- [ ] Save the YAML output and verify `camera_gps` section is present
- [ ] Verify latitude ≈ 39.640478 and longitude ≈ -0.230175 (Valte camera position)

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)