### PR TITLE
Fix map marker highlights stuck after rapid mouse movement

### DIFF
--- a/poc_homography/map_debug_server.py
+++ b/poc_homography/map_debug_server.py
@@ -921,6 +921,18 @@ def generate_html(
 
         // Highlight GCP on both panels
         function highlightGCP(index) {{
+            // State reconciliation: unhighlight any previously highlighted marker first
+            // This prevents stuck highlights when mouseout events are missed during rapid movement
+            if (hoveredGcpIndex !== null && hoveredGcpIndex !== index) {{
+                // Restore ALL previous markers to original state (GCPs with error > 0.5m have 2 markers)
+                mapMarkers.filter(m => m.index === hoveredGcpIndex).forEach(prevMarker => {{
+                    const originalIcon = prevMarker.iconType === 'star'
+                        ? createStarIcon(prevMarker.color, prevMarker.size, 1)
+                        : createDiamondIcon(prevMarker.color, prevMarker.size, 1);
+                    prevMarker.marker.setIcon(originalIcon);
+                }});
+            }}
+
             hoveredGcpIndex = index;
             const gcp = gcpData[index];
             if (!gcp) return;


### PR DESCRIPTION
## Summary
- Add state reconciliation to `highlightGCP()` function that explicitly restores any previously highlighted markers before highlighting a new one
- Fix prevents stuck cyan highlights when `mouseout` events are missed during rapid mouse movement between closely-spaced markers
- Uses `filter().forEach()` to handle GCPs with multiple markers (original + projected when error > 0.5m)

## Test plan
- [ ] Rapid horizontal sweep: Move mouse quickly left-to-right across row of markers
- [ ] Rapid vertical sweep: Move mouse quickly top-to-bottom across column of markers
- [ ] Diagonal sweep: Move mouse diagonally across marker cluster
- [ ] Precision zoom enabled: Rapid movement with zoom animation active
- [ ] Precision zoom disabled: Rapid movement without zoom animation
- [ ] Mixed icon types: Rapid movement across both star and diamond markers
- [ ] Multi-marker GCPs: Test with GCPs that have both original and projected markers (error > 0.5m)

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)