### PR TITLE
Add W/E/R keyboard shortcuts for Move/Rotate/Scale All modes

### DIFF
--- a/tools/capture_gcps_web.py
+++ b/tools/capture_gcps_web.py
@@ -2588,13 +2588,13 @@ def generate_capture_html(session: GCPCaptureWebSession, frame_path: str) -> str
                     </div>
                     <div style="margin-top: 8px; display: flex; gap: 8px;">
                         <button class="btn btn-secondary" id="moveAllBtn" onclick="toggleMoveAllMode()" style="flex: 1;">
-                            Move All
+                            Move All (W)
                         </button>
                         <button class="btn btn-secondary" id="rotateAllBtn" onclick="toggleRotateAllMode()" style="flex: 1;">
-                            Rotate All
+                            Rotate All (E)
                         </button>
                         <button class="btn btn-secondary" id="scaleAllBtn" onclick="toggleScaleAllMode()" style="flex: 1;">
-                            Scale All
+                            Scale All (R)
                         </button>
                     </div>
                 </div>
@@ -4100,7 +4100,7 @@ def generate_capture_html(session: GCPCaptureWebSession, frame_path: str) -> str
                 `;
                 document.body.appendChild(indicator);
             }} else {{
-                btn.textContent = 'Move All Points';
+                btn.textContent = 'Move All (W)';
                 btn.style.background = '';
                 btn.style.borderColor = '';
             }}
@@ -4268,7 +4268,7 @@ def generate_capture_html(session: GCPCaptureWebSession, frame_path: str) -> str
                 `;
                 document.body.appendChild(indicator);
             }} else {{
-                btn.textContent = 'Rotate All';
+                btn.textContent = 'Rotate All (E)';
                 btn.style.background = '';
                 btn.style.borderColor = '';
             }}
@@ -4392,7 +4392,7 @@ def generate_capture_html(session: GCPCaptureWebSession, frame_path: str) -> str
                 `;
                 document.body.appendChild(indicator);
             }} else {{
-                btn.textContent = 'Scale All';
+                btn.textContent = 'Scale All (R)';
                 btn.style.background = '';
                 btn.style.borderColor = '';
             }}
@@ -5376,6 +5376,26 @@ def generate_capture_html(session: GCPCaptureWebSession, frame_path: str) -> str
                 }}
                 if (document.getElementById('addGcpModal').classList.contains('active')) {{
                     confirmAddGCP();
+                }}
+            }}
+
+            // W/E/R keys - toggle Move/Rotate/Scale All modes
+            // Skip if user is typing in an input field
+            if (e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {{
+                if (e.key === 'w' || e.key === 'W') {{
+                    toggleMoveAllMode();
+                    e.preventDefault();
+                    return;
+                }}
+                if (e.key === 'e' || e.key === 'E') {{
+                    toggleRotateAllMode();
+                    e.preventDefault();
+                    return;
+                }}
+                if (e.key === 'r' || e.key === 'R') {{
+                    toggleScaleAllMode();
+                    e.preventDefault();
+                    return;
                 }}
             }}
 


### PR DESCRIPTION
## Summary
- Added W key to toggle Move All mode on/off
- Added E key to toggle Rotate All mode on/off
- Added R key to toggle Scale All mode on/off
- Updated button labels to display shortcuts: "Move All (W)", "Rotate All (E)", "Scale All (R)"
- Shortcuts skip when user is typing in INPUT or TEXTAREA fields
- Shortcuts call existing toggle functions, preserving mutually exclusive mode behavior

## Test plan
- [ ] Press W when not in any mode → Move All mode activates
- [ ] Press W again when in Move All mode → Mode deactivates
- [ ] Press E to activate Rotate All mode, verify Move All deactivates
- [ ] Press R to activate Scale All mode, verify other modes deactivate
- [ ] Type 'w', 'e', 'r' in GPS coordinate input field → No mode changes
- [ ] Verify arrow keys, Escape, and Enter continue to work as before
- [ ] Verify button labels show "(W)", "(E)", "(R)" suffixes

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)