### PR TITLE
Add --kml command-line argument to pre-load KML points on startup

### DIFF
--- a/tools/unified_gcp_tool.py
+++ b/tools/unified_gcp_tool.py
@@ -1851,6 +1851,29 @@ def generate_unified_html(session: UnifiedSession) -> str:
             }}
         }}
 
+        // Load existing points from server on page load
+        function loadExistingPoints() {{
+            fetch('/api/get_points', {{
+                method: 'POST',
+                headers: {{ 'Content-Type': 'application/json' }},
+                body: JSON.stringify({{}})
+            }})
+            .then(r => r.json())
+            .then(data => {{
+                if (data.points && data.points.length > 0) {{
+                    points = data.points;
+                    redrawMarkers();
+                    updatePointsList();
+                    updateTabStatus();
+                    updateStatus('Loaded ' + points.length + ' pre-existing points');
+                }}
+            }})
+            .catch(err => console.error('Failed to load existing points:', err));
+        }}
+
+        // Load existing points on page load
+        loadExistingPoints();
+
         function zoom(factor) {{
             currentZoom *= factor;
             img.style.width = (img.naturalWidth * currentZoom) + 'px';


### PR DESCRIPTION
## Summary
- Add `--kml` optional argument to pre-load KML points on startup
- Validate KML file exists before session creation
- Parse and pre-populate session points during initialization
- Add error handling for malformed KML files with clear messages
- Add warning when KML contains zero valid points
- Specify explicit UTF-8 encoding for cross-platform consistency

## Test plan
- [ ] Verify `--help` shows new `--kml` argument
- [ ] Test with valid KML file - points should be pre-loaded and visible on first page load
- [ ] Test with non-existent KML file - should show "KML file not found" error
- [ ] Test with malformed KML file - should show "Malformed KML file" error  
- [ ] Test with empty KML file (no points) - should show warning message
- [ ] Test without `--kml` argument - should behave identically to current version

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)