### PR TITLE
Auto-trigger SAM3 feature detection when images load (#107)

### DIFF
--- a/tools/unified_gcp_tool.py
+++ b/tools/unified_gcp_tool.py
@@ -2640,6 +2640,9 @@ def generate_unified_html(session: UnifiedSession) -> str:
                     enableCameraToggle();
                     updateCameraVisualization();
 
+                    // Auto-trigger SAM3 detection for newly captured GCP frame
+                    detectFeatures('gcp');
+
                     updateStatus('Camera frame captured successfully');
                 }} else {{
                     updateStatus('Error: ' + data.error);


### PR DESCRIPTION
## Summary
- Automatically trigger SAM3 feature detection on both KML and GCP tabs when images load
- Use default "road markings" prompt for automatic detection
- Each tab triggers detection independently
- Manual "Detect Features" buttons remain functional

## Changes
- Add guard flags to prevent duplicate auto-detections on initial page load
- Add auto-detection call to KML tab image onload handler
- Add auto-detection call to GCP tab when switching to tab (initial frame load)
- Add auto-detection call to GCP tab when capturing new frames

## Test plan
- [ ] Load the unified GCP tool - verify KML tab auto-detects road markings on startup
- [ ] Switch to GCP tab - verify camera frame auto-detects road markings
- [ ] Capture new frame on GCP tab - verify new frame auto-detects road markings
- [ ] Manually click "Detect Features" buttons - verify they still work
- [ ] Verify mask toggle buttons appear after auto-detection completes
- [ ] Verify status messages display during detection

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)