### PR TITLE
Remove image undistortion from calibration pipeline

### DIFF
--- a/tests/test_calibration_distortion_handling.py
+++ b/tests/test_calibration_distortion_handling.py
@@ -5,7 +5,6 @@ Verifies that the calibration pipeline operates entirely in distorted image spac
 with original K matrix, using cv2.projectPoints() and cv2.solvePnP() with
 distortion coefficients rather than undistorting frames.
 """
-import ast
 import re
 import pytest
 


### PR DESCRIPTION
## Summary

- Remove `cv2.undistort()` and `cv2.getOptimalNewCameraMatrix()` calls from the calibration pipeline to fix systematic projection errors caused by inconsistent camera intrinsics
- Implement industry-standard approach: work entirely in distorted image space using `cv2.projectPoints()` and `cv2.solvePnP()` with distortion coefficients
- Extend distortion coefficient support from 4 to 5 parameters [k1, k2, p1, p2, k3] for full OpenCV compatibility
- Add comprehensive unit tests verifying calibration uses distorted coordinates throughout

## Test plan

- [x] Run `pytest tests/test_calibration_distortion_handling.py -v` - all 8 tests pass
- [x] Verify no `cv2.undistort()` calls remain in `tools/unified_gcp_tool.py`
- [x] Verify no `getOptimalNewCameraMatrix()` calls remain in `tools/unified_gcp_tool.py`
- [x] Verify all `solvePnP`/`projectPoints` calls include `dist_coeffs`
- [x] Verify `camera_params['undistorted']` is always set to `False`

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)