### PR TITLE
feat: add roll parameter (Δroll) to camera calibration model

### DIFF
--- a/poc_homography/camera_geometry.py
+++ b/poc_homography/camera_geometry.py
@@ -734,7 +734,6 @@ class CameraGeometry:
             )
 
         if abs(roll_deg) > self.ROLL_WARN_THRESHOLD:
-            import warnings
             warnings.warn(
                 f"Roll angle {roll_deg:.1f}° is unusually large (>{self.ROLL_WARN_THRESHOLD}°). "
                 f"Typical camera mount roll is ±2°. Verify configuration.",

--- a/tests/test_rotation_matrix_consistency.py
+++ b/tests/test_rotation_matrix_consistency.py
@@ -334,6 +334,34 @@ class TestComputeHomographyWithRoll:
         assert result.metadata['roll_deg'] == 0.0, \
             f"Expected metadata roll_deg=0.0, got {result.metadata['roll_deg']}"
 
+    def test_compute_homography_rejects_invalid_roll(self):
+        """Verify compute_homography raises error for |roll_deg| > 15.0."""
+        ieh = IntrinsicExtrinsicHomography(width=1920, height=1080)
+
+        K = np.array([
+            [1000, 0, 960],
+            [0, 1000, 540],
+            [0, 0, 1]
+        ])
+
+        reference = {
+            'camera_matrix': K,
+            'camera_position': np.array([0.0, 0.0, 5.0]),
+            'pan_deg': 0.0,
+            'tilt_deg': 30.0,
+            'roll_deg': 16.0,  # Invalid: > 15.0
+            'map_width': 640,
+            'map_height': 640
+        }
+
+        frame = np.zeros((1080, 1920, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError) as exc_info:
+            ieh.compute_homography(frame, reference)
+
+        assert "roll" in str(exc_info.value).lower(), \
+            "Error message should mention roll"
+
 
 class TestCameraViewingDirection:
     """Test that camera viewing direction is correct for various pan/tilt angles."""


### PR DESCRIPTION
## Summary
- Add roll_deg parameter to both `IntrinsicExtrinsicHomography` and `CameraGeometry` rotation matrix methods
- Implement rotation order: R = R_tilt @ R_roll @ R_base @ R_pan
- Add roll_deg extraction and metadata in `compute_homography()`
- Add roll_deg parameter to `set_camera_parameters()` with validation
- Validate roll angle with warning at |roll| > 5° and error at |roll| > 15°
- Add comprehensive tests for roll rotation, validation, and backward compatibility

All changes maintain full backward compatibility by defaulting roll to 0.0.

## Test plan
- [x] All 56 rotation matrix consistency tests pass
- [x] New roll rotation tests pass (10 tests)
- [x] Roll validation tests pass (4 tests)
- [x] compute_homography roll extraction tests pass (2 tests)
- [x] Existing homography consistency tests still pass
- [x] Full test suite passes (663 tests)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)