### PR TITLE
feat(calibration): multi-zoom batch lens distortion calibration CLI

### DIFF
--- a/poc_homography/calibration/lens_distortion/cli.py
+++ b/poc_homography/calibration/lens_distortion/cli.py
@@ -101,6 +101,82 @@ def parse_ptz_from_filename(filename: str) -> PTZPosition:
     return PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(30.0), zoom_factor=1.0)
 
 
+def _resolve_images(args: argparse.Namespace) -> list[Path] | None:
+    """Resolve and validate image source from CLI arguments.
+
+    Handles --images and --survey-session flags used by calibrate commands.
+
+    Returns:
+        List of image paths, or None if resolution fails (errors are logged).
+    """
+    if getattr(args, "survey_session", None):
+        images_path = Path(args.survey_session)
+    elif getattr(args, "images", None):
+        images_path = Path(args.images)
+    else:
+        logger.error("Must specify --images or --survey-session")
+        return None
+
+    if not images_path.exists():
+        logger.error(f"Path not found: {images_path}")
+        return None
+
+    images = find_images(images_path)
+    if not images:
+        logger.error(f"No images found in {images_path}")
+        return None
+
+    return images
+
+
+def _detect_lines(
+    images: list[Path],
+    detector: LineDetector,
+    max_lines_per_image: int,
+    line_id_prefix: str = "line",
+    verbose: bool = False,
+) -> list[CameraLine]:
+    """Detect and collect lines from a set of images.
+
+    Args:
+        images: Image paths to process.
+        detector: Configured LineDetector instance.
+        max_lines_per_image: Maximum lines to keep per image.
+        line_id_prefix: Prefix for generated line IDs.
+        verbose: Log per-image detection details.
+
+    Returns:
+        List of detected CameraLine objects.
+    """
+    all_lines: list[CameraLine] = []
+    line_counter = 0
+
+    for img_path in images:
+        try:
+            candidates = detector.detect_from_file(img_path)
+            ptz = parse_ptz_from_filename(img_path.name)
+
+            for c in candidates[:max_lines_per_image]:
+                camera_line = c.to_camera_line(
+                    line_id=f"{line_id_prefix}_{line_counter:04d}",
+                    image_path=str(img_path),
+                    ptz_position=ptz,
+                )
+                all_lines.append(camera_line)
+                line_counter += 1
+
+            if verbose:
+                logger.info(
+                    f"  {img_path.name}: {len(candidates)} detected, "
+                    f"using top {min(len(candidates), max_lines_per_image)}"
+                )
+
+        except Exception as e:
+            logger.warning(f"  Failed to process {img_path}: {e}")
+
+    return all_lines
+
+
 def cmd_detect(args: argparse.Namespace) -> int:
     """Run line detection on images."""
     images_path = Path(args.images)
@@ -167,22 +243,8 @@ def cmd_detect(args: argparse.Namespace) -> int:
 
 def cmd_calibrate(args: argparse.Namespace) -> int:
     """Run full calibration pipeline."""
-    # Determine image source
-    if args.survey_session:
-        images_path = Path(args.survey_session)
-    elif args.images:
-        images_path = Path(args.images)
-    else:
-        logger.error("Must specify --images or --survey-session")
-        return 1
-
-    if not images_path.exists():
-        logger.error(f"Path not found: {images_path}")
-        return 1
-
-    images = find_images(images_path)
-    if not images:
-        logger.error(f"No images found in {images_path}")
+    images = _resolve_images(args)
+    if images is None:
         return 1
 
     logger.info(f"Found {len(images)} images for calibration")
@@ -205,32 +267,7 @@ def cmd_calibrate(args: argparse.Namespace) -> int:
     detector = LineDetector(config=detection_config)
 
     # Detect lines in all images
-    all_lines: list[CameraLine] = []
-    line_counter = 0
-
-    for img_path in images:
-        try:
-            candidates = detector.detect_from_file(img_path)
-            ptz = parse_ptz_from_filename(img_path.name)
-
-            # Take top N candidates per image
-            for c in candidates[: args.max_lines_per_image]:
-                camera_line = c.to_camera_line(
-                    line_id=f"line_{line_counter:04d}",
-                    image_path=str(img_path),
-                    ptz_position=ptz,
-                )
-                all_lines.append(camera_line)
-                line_counter += 1
-
-            if args.verbose:
-                logger.info(
-                    f"{img_path.name}: {len(candidates)} detected, "
-                    f"using top {min(len(candidates), args.max_lines_per_image)}"
-                )
-
-        except Exception as e:
-            logger.warning(f"Failed to process {img_path}: {e}")
+    all_lines = _detect_lines(images, detector, args.max_lines_per_image, verbose=args.verbose)
 
     if len(all_lines) < args.min_total_lines:
         logger.error(f"Only {len(all_lines)} lines detected, need at least {args.min_total_lines}")
@@ -363,22 +400,8 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
     runs calibration independently for each zoom, and outputs a single calibration
     table with all results.
     """
-    # Determine image source
-    if args.survey_session:
-        images_path = Path(args.survey_session)
-    elif args.images:
-        images_path = Path(args.images)
-    else:
-        logger.error("Must specify --images or --survey-session")
-        return 1
-
-    if not images_path.exists():
-        logger.error(f"Path not found: {images_path}")
-        return 1
-
-    images = find_images(images_path)
-    if not images:
-        logger.error(f"No images found in {images_path}")
+    images = _resolve_images(args)
+    if images is None:
         return 1
 
     logger.info(f"Found {len(images)} total images")
@@ -389,14 +412,13 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
 
     # Report zoom groups found
     zoom_summary = ", ".join(
-        f"{zoom:.1f} ({len(zoom_groups[zoom])} images)" for zoom in sorted_zooms
+        f"{zoom:.1f} ({len(imgs)} images)" for zoom, imgs in sorted(zoom_groups.items())
     )
     print(f"\nFound {len(sorted_zooms)} zoom levels: {zoom_summary}")
 
     # Check for default zoom (1.0) which might indicate parsing failures
     default_zoom_count = len(zoom_groups.get(1.0, []))
-    total_images = len(images)
-    if default_zoom_count > 0 and default_zoom_count == total_images:
+    if default_zoom_count > 0 and default_zoom_count == len(images):
         logger.warning(
             "All images have default zoom (1.0). "
             "Check that filenames follow pattern: prefix_pan_tilt_zoom_suffix.jpg"
@@ -404,10 +426,9 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
 
     # Validate zoom groups before calibration
     min_images = args.min_images_per_zoom
-    insufficient_zooms = []
-    for zoom, group_images in zoom_groups.items():
-        if len(group_images) < min_images:
-            insufficient_zooms.append((zoom, len(group_images)))
+    insufficient_zooms = [
+        (zoom, len(imgs)) for zoom, imgs in zoom_groups.items() if len(imgs) < min_images
+    ]
 
     if insufficient_zooms:
         for zoom, count in insufficient_zooms:
@@ -433,7 +454,7 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
     solver = DistortionSolver(config=solver_config)
 
     # Initialize calibration table
-    camera_id = args.camera_id or "unknown_camera"
+    camera_id = args.camera_id
     table = CameraCalibrationTable(camera_id=camera_id)
 
     # Track results for summary
@@ -449,32 +470,13 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
         print(f"\nProcessing zoom {zoom:.1f} ({len(group_images)} images)...")
 
         # Detect lines in all images for this zoom
-        all_lines: list[CameraLine] = []
-        line_counter = 0
-
-        for img_path in group_images:
-            try:
-                candidates = detector.detect_from_file(img_path)
-                ptz = parse_ptz_from_filename(img_path.name)
-
-                # Take top N candidates per image
-                for c in candidates[: args.max_lines_per_image]:
-                    camera_line = c.to_camera_line(
-                        line_id=f"zoom{zoom:.1f}_line_{line_counter:04d}",
-                        image_path=str(img_path),
-                        ptz_position=ptz,
-                    )
-                    all_lines.append(camera_line)
-                    line_counter += 1
-
-                if args.verbose:
-                    logger.info(
-                        f"  {img_path.name}: {len(candidates)} detected, "
-                        f"using top {min(len(candidates), args.max_lines_per_image)}"
-                    )
-
-            except Exception as e:
-                logger.warning(f"  Failed to process {img_path}: {e}")
+        all_lines = _detect_lines(
+            group_images,
+            detector,
+            args.max_lines_per_image,
+            line_id_prefix=f"zoom{zoom:.1f}_line",
+            verbose=args.verbose,
+        )
 
         print(f"  Detected {len(all_lines)} lines")
 
@@ -549,21 +551,19 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
             print(f"  RMSE: {result.overall_rmse:.2f} pixels ✗ (poor quality)")
             logger.warning(f"  RMSE > 5 pixels for zoom {zoom:.1f}, consider more/better lines")
 
-    # Check for failures
+    # Report failures (but save successful results)
     if failed_zooms:
         print("\n" + "=" * 60)
-        print("CALIBRATION FAILED")
+        print("WARNINGS: Some zoom levels failed")
         print("=" * 60)
         for zoom, error in failed_zooms:
             print(f"  Zoom {zoom:.1f}: {error}")
-        print("\nCalibration aborted. No output file written.")
-        return 1
 
     if not table.entries:
         logger.error("No successful calibrations. Check image quality and line detection.")
         return 1
 
-    # Save results
+    # Save results (including partial success)
     if args.output:
         output_path = Path(args.output)
         table.save(output_path)
@@ -584,11 +584,9 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
             "entries": results_summary,
         }
         print("\nJSON output:")
-        import json
-
         print(json.dumps(output, indent=2))
 
-    return 0
+    return 1 if failed_zooms else 0
 
 
 def cmd_visualize(args: argparse.Namespace) -> int:

--- a/tests/calibration/lens_distortion/test_cli_batch.py
+++ b/tests/calibration/lens_distortion/test_cli_batch.py
@@ -4,9 +4,12 @@ Tests the batch calibration workflow including image grouping by zoom,
 per-zoom calibration execution, validation, and output file generation.
 """
 
+import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from poc_homography.calibration.lens_distortion.calibration_table import (
@@ -15,6 +18,7 @@ from poc_homography.calibration.lens_distortion.calibration_table import (
 from poc_homography.calibration.lens_distortion.cli import (
     _DEFAULT_FX,
     group_images_by_zoom,
+    main,
     parse_ptz_from_filename,
 )
 from poc_homography.calibration.lens_distortion.models import PTZPosition
@@ -136,54 +140,16 @@ class TestCalibrateBatchCommand:
     def mock_images_dir(self, temp_dir):
         """Create mock images at multiple zoom levels.
 
-        The filename pattern must have PTZ values as the last 3 numeric parts
-        to be correctly parsed by parse_ptz_from_filename().
-        Pattern: prefix_pan_tilt_zoom.jpg (e.g., survey_30.0_15.0_1.0.jpg)
-
-        IMPORTANT: The parser finds the FIRST valid numeric triplet meeting:
-        - pan: -180 to 180
-        - tilt: -90 to 90
-        - zoom: > 0
-
-        To avoid the parser matching an index as part of a triplet, use
-        text prefixes that can't be parsed as numbers.
+        Pattern: survey_imgX_pan_tilt_zoom.jpg where imgX is non-numeric
+        to avoid the parser matching an index as part of a triplet.
         """
-        # Create empty files with PTZ-encoded names
-        # Pattern: survey_imgX_pan_tilt_zoom.jpg where imgX is non-numeric
         zooms = [1.0, 5.0, 10.0]
         for zoom in zooms:
             for i in range(4):  # 4 images per zoom
-                # imgX prefix ensures numeric triplet starts at pan/tilt/zoom
                 filename = f"survey_img{i}_30.0_15.0_{zoom:.1f}.jpg"
                 (temp_dir / filename).touch()
 
         return temp_dir
-
-    @pytest.fixture
-    def mock_solver_result(self):
-        """Create a mock solver result."""
-        from poc_homography.calibration.lens_distortion.distortion_solver import (
-            SolverResult,
-        )
-        from poc_homography.camera_parameters import DistortionCoefficients
-        from poc_homography.types import Unitless
-
-        return SolverResult(
-            distortion=DistortionCoefficients(
-                k1=Unitless(-0.02),
-                k2=Unitless(0.001),
-                k3=Unitless(0.0),
-                p1=Unitless(0.0),
-                p2=Unitless(0.0),
-            ),
-            initial_error=1.0,
-            final_error=0.3,
-            rmse_per_line=[0.2, 0.3, 0.4],
-            overall_rmse=2.5,
-            iterations=100,
-            success=True,
-            message="Optimization terminated successfully.",
-        )
 
     def test_groups_images_correctly(self, mock_images_dir):
         """Should group mock images by zoom level correctly."""
@@ -200,14 +166,28 @@ class TestCalibrateBatchCommand:
         assert len(groups[5.0]) == 4
         assert len(groups[10.0]) == 4
 
-    def test_intrinsics_scaling_formula(self):
-        """Should scale focal length by zoom factor: fx_zoom = base_fx * zoom."""
+    def test_intrinsics_scaling_builds_correct_matrix(self):
+        """Should build intrinsic matrix with zoom-scaled focal length and fixed principal point."""
         base_fx = _DEFAULT_FX
-        zoom_factors = [1.0, 5.0, 10.0, 25.0]
+        cx, cy = 960.0, 540.0
 
-        for zoom in zoom_factors:
-            expected_fx = base_fx * zoom
-            assert expected_fx == pytest.approx(base_fx * zoom)
+        for zoom in [1.0, 5.0, 10.0, 25.0]:
+            fx_zoom = base_fx * zoom
+            fy_zoom = base_fx * zoom
+            intrinsic_matrix = np.array(
+                [
+                    [fx_zoom, 0.0, cx],
+                    [0.0, fy_zoom, cy],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+
+            # Focal lengths scale with zoom
+            assert intrinsic_matrix[0, 0] == pytest.approx(base_fx * zoom)
+            assert intrinsic_matrix[1, 1] == pytest.approx(base_fx * zoom)
+            # Principal point remains constant across zoom levels
+            assert intrinsic_matrix[0, 2] == cx
+            assert intrinsic_matrix[1, 2] == cy
 
     def test_calibration_output_file_format(self, temp_dir):
         """Should create valid CameraCalibrationTable YAML output."""
@@ -249,6 +229,14 @@ class TestCalibrateBatchCommand:
         assert intrinsics is not None
         assert intrinsics["fx"] == pytest.approx(_DEFAULT_FX * 5.0)
 
+        # Verify distortion coefficients round-trip correctly
+        entry_1 = loaded.get_entry(1.0)
+        assert entry_1 is not None
+        assert entry_1.k1 == pytest.approx(-0.02)
+        entry_10 = loaded.get_entry(10.0)
+        assert entry_10 is not None
+        assert entry_10.k1 == pytest.approx(-0.2)
+
     def test_summary_includes_all_zoom_levels(self):
         """Should show all calibrated zoom levels in summary output."""
         table = CameraCalibrationTable(camera_id="test_camera")
@@ -280,8 +268,8 @@ class TestCalibrateBatchCommand:
         assert "1.0" in summary
         assert "5.0" in summary
         assert "10.0" in summary
-        # Should contain intrinsics columns
-        assert "fx" in summary.lower() or "fx" in summary
+        # Should contain intrinsics column header
+        assert "fx" in summary
         assert "Entries: 3" in summary
 
 
@@ -322,31 +310,48 @@ class TestCLIArgumentParsing:
     """Tests for CLI argument parsing."""
 
     def test_calibrate_batch_requires_camera_id(self):
-        """Should require --camera-id flag."""
+        """Should exit with error when --camera-id is missing."""
+        with patch.object(sys, "argv", ["cli", "calibrate-batch", "--images", "/tmp"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
 
-        # This test verifies the argument is marked as required
-        # We can't easily test actual argparse without running the CLI
-
-    def test_default_values(self):
-        """Should have sensible defaults for min-images-per-zoom and min-lines-per-zoom."""
-        # These are the expected defaults per the issue spec
-        expected_min_images = 3
-        expected_min_lines = 10
-
-        # Verify these match the implementation by checking the argparse defaults
-        # This is a documentation test more than a functional test
-        assert expected_min_images == 3
-        assert expected_min_lines == 10
+    def test_batch_defaults_accept_minimal_args(self):
+        """Batch command should work with only required args (defaults for the rest)."""
+        with patch.object(
+            sys,
+            "argv",
+            ["cli", "calibrate-batch", "--images", "/nonexistent/path", "--camera-id", "test"],
+        ):
+            # Should fail due to path not found, NOT due to missing args
+            result = main()
+            assert result == 1
 
 
 class TestBackwardsCompatibility:
     """Tests ensuring the existing calibrate command remains unchanged."""
 
-    def test_calibrate_command_signature_unchanged(self):
+    def test_calibrate_command_accepts_legacy_flags(self):
         """The calibrate command should still accept --fx, --fy, --zoom flags."""
-        # This is a design contract test
-        # The existing calibrate command should not be affected by adding calibrate-batch
-        pass
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "cli",
+                "calibrate",
+                "--images",
+                "/nonexistent/path",
+                "--fx",
+                "1000",
+                "--fy",
+                "1000",
+                "--zoom",
+                "2.0",
+            ],
+        ):
+            # Should fail due to path not found, NOT due to unrecognized args
+            result = main()
+            assert result == 1
 
     def test_ptz_parser_unchanged(self):
         """parse_ptz_from_filename should remain compatible with existing usage."""


### PR DESCRIPTION
## Summary

- Add new `calibrate-batch` CLI command for multi-zoom lens distortion calibration
- Automatically groups images by zoom factor extracted from filenames
- Scales intrinsics by zoom factor (fx_zoom = base_fx * zoom_factor)
- Validates per-zoom minimum images and lines requirements
- Outputs unified `CameraCalibrationTable` YAML with all zoom entries
- Maintains backward compatibility with existing `calibrate` command

## Usage Example

```bash
python -m poc_homography.calibration.lens_distortion.cli calibrate-batch \
    --images /path/to/multi_zoom_images/ \
    --output camera_calibration.yaml \
    --camera-id valte_cam01 \
    --min-images-per-zoom 3 \
    --min-lines-per-zoom 10
```

## Test plan

- [x] Unit tests for image grouping by zoom factor
- [x] Unit tests for PTZ filename parsing
- [x] Unit tests for intrinsics scaling formula
- [x] Unit tests for validation logic (insufficient images/lines)
- [x] Unit tests for output file format
- [x] All 254 calibration tests pass
- [ ] Manual test with real multi-zoom survey images

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)