### PR TITLE
fix(camera-evaluation): add fixed axis value controls for non-swept PTZ axes

### DIFF
--- a/webapp/camera_evaluation/templates/camera_evaluation/index.html
+++ b/webapp/camera_evaluation/templates/camera_evaluation/index.html
@@ -951,12 +951,12 @@
         const surveyTimeoutInput = document.getElementById('survey-timeout-input');
         const surveyTagsInput = document.getElementById('survey-tags-input');
         const surveyRestorePtz = document.getElementById('survey-restore-ptz');
-        const fixedPanInput = document.getElementById('fixed-pan-input');
-        const fixedTiltInput = document.getElementById('fixed-tilt-input');
-        const fixedZoomInput = document.getElementById('fixed-zoom-input');
-        const fixedPanGroup = document.getElementById('fixed-pan-group');
-        const fixedTiltGroup = document.getElementById('fixed-tilt-group');
-        const fixedZoomGroup = document.getElementById('fixed-zoom-group');
+        const fixedPanInput = document.getElementById('survey-fixed-pan-input');
+        const fixedTiltInput = document.getElementById('survey-fixed-tilt-input');
+        const fixedZoomInput = document.getElementById('survey-fixed-zoom-input');
+        const fixedPanGroup = document.getElementById('survey-fixed-pan-group');
+        const fixedTiltGroup = document.getElementById('survey-fixed-tilt-group');
+        const fixedZoomGroup = document.getElementById('survey-fixed-zoom-group');
         const surveyStartBtn = document.getElementById('survey-start-btn');
         const surveyAbortBtn = document.getElementById('survey-abort-btn');
         const surveyProgressContainer = document.getElementById('survey-progress-container');
@@ -1101,16 +1101,16 @@
         // Show/hide fixed axis inputs based on selected survey axis
         function updateFixedAxisVisibility() {
             const axis = document.querySelector('input[name="survey-axis"]:checked').value;
-            fixedPanGroup.style.display = axis === 'pan' ? 'none' : '';
-            fixedTiltGroup.style.display = axis === 'tilt' ? 'none' : '';
-            fixedZoomGroup.style.display = axis === 'zoom' ? 'none' : '';
+            fixedPanGroup.style.display = axis === 'pan' ? 'none' : 'block';
+            fixedTiltGroup.style.display = axis === 'tilt' ? 'none' : 'block';
+            fixedZoomGroup.style.display = axis === 'zoom' ? 'none' : 'block';
         }
 
         // Auto-populate fixed axis inputs from camera's current position
         async function fetchAndPopulateFixedAxisPosition() {
             if (!surveyTenant || !surveyCamera) return;
             try {
-                const resp = await fetch(`{% url "camera_evaluation:api_camera_position" %}?tenant_id=${surveyTenant}&camera_id=${surveyCamera}`);
+                const resp = await fetch(`{% url "camera_evaluation:api_camera_position" %}?tenant_id=${encodeURIComponent(surveyTenant)}&camera_id=${encodeURIComponent(surveyCamera)}`);
                 const result = await resp.json();
                 if (result.status === 'success') {
                     const ptz = result.data;
@@ -1128,7 +1128,7 @@
             if (!surveyTenant || !surveyCamera) return;
 
             try {
-                const resp = await fetch(`{% url "camera_evaluation:api_camera_position" %}?tenant_id=${surveyTenant}&camera_id=${surveyCamera}`);
+                const resp = await fetch(`{% url "camera_evaluation:api_camera_position" %}?tenant_id=${encodeURIComponent(surveyTenant)}&camera_id=${encodeURIComponent(surveyCamera)}`);
                 const result = await resp.json();
 
                 if (result.status === 'success') {
@@ -1392,9 +1392,9 @@
                         restore_ptz: surveyRestorePtz.checked,
                         retry_timeout: retryTimeout,
                         session_tags: tags,
-                        fixed_pan: fixedPanInput.value ? parseFloat(fixedPanInput.value) : null,
-                        fixed_tilt: fixedTiltInput.value ? parseFloat(fixedTiltInput.value) : null,
-                        fixed_zoom: fixedZoomInput.value ? parseFloat(fixedZoomInput.value) : null,
+                        fixed_pan: axis !== 'pan' && fixedPanInput.value ? parseFloat(fixedPanInput.value) : null,
+                        fixed_tilt: axis !== 'tilt' && fixedTiltInput.value ? parseFloat(fixedTiltInput.value) : null,
+                        fixed_zoom: axis !== 'zoom' && fixedZoomInput.value ? parseFloat(fixedZoomInput.value) : null,
                     }),
                 });
 

--- a/webapp/camera_evaluation/views.py
+++ b/webapp/camera_evaluation/views.py
@@ -13,6 +13,7 @@ import logging
 from camera_survey.models import SurveyAxis, SurveyConfig
 from camera_survey.ptz import create_ptz_camera
 from camera_survey.services import get_survey_presets
+from camera_survey.validation import parse_fixed_axis_values, validate_fixed_axis_ranges
 
 # Import the shared survey service instance to avoid duplicate state
 from camera_survey.views import _survey_service
@@ -152,6 +153,9 @@ def api_survey_start(request: HttpRequest) -> JsonResponse:
         restore_ptz: Boolean (optional, default True)
         retry_timeout: Seconds (optional, default 60)
         session_tags: List of strings (optional)
+        fixed_pan: Fixed pan value (optional, float)
+        fixed_tilt: Fixed tilt value (optional, float)
+        fixed_zoom: Fixed zoom value (optional, float)
     """
     try:
         data = json.loads(request.body)
@@ -186,28 +190,16 @@ def api_survey_start(request: HttpRequest) -> JsonResponse:
     if isinstance(session_tags, str):
         session_tags = [t.strip() for t in session_tags.split(",") if t.strip()]
 
-    # Parse optional fixed axis values
-    fixed_pan: float | None = None
-    fixed_tilt: float | None = None
-    fixed_zoom: float | None = None
+    # Parse and validate optional fixed axis values
+    fixed_pan, fixed_tilt, fixed_zoom, parse_err = parse_fixed_axis_values(data)
+    if parse_err:
+        return _error_response(parse_err)
 
-    if "fixed_pan" in data and data["fixed_pan"] is not None:
-        try:
-            fixed_pan = float(data["fixed_pan"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_pan must be numeric")
-
-    if "fixed_tilt" in data and data["fixed_tilt"] is not None:
-        try:
-            fixed_tilt = float(data["fixed_tilt"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_tilt must be numeric")
-
-    if "fixed_zoom" in data and data["fixed_zoom"] is not None:
-        try:
-            fixed_zoom = float(data["fixed_zoom"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_zoom must be numeric")
+    range_err = validate_fixed_axis_ranges(
+        fixed_pan, fixed_tilt, fixed_zoom, data["camera_id"], data["tenant_id"]
+    )
+    if range_err:
+        return _error_response(range_err)
 
     # Create config
     config = SurveyConfig(

--- a/webapp/camera_survey/templates/camera_survey/includes/survey_config_fields.html
+++ b/webapp/camera_survey/templates/camera_survey/includes/survey_config_fields.html
@@ -26,23 +26,23 @@ Required context variables:
 </div>
 
 <!-- Fixed axis values (for non-swept axes) -->
-<div id="fixed-axis-container" style="margin-top: 12px;">
-    <div class="form-row" id="fixed-pan-group" style="display: none;">
+<div id="{{ id_prefix }}fixed-axis-container" style="margin-top: 12px;">
+    <div class="form-row" id="{{ id_prefix }}fixed-pan-group" style="display: none;">
         <div class="form-group">
-            <label for="fixed-pan-input">Pan (fixed)</label>
-            <input type="number" id="fixed-pan-input" step="0.1" placeholder="Current position">
+            <label for="{{ id_prefix }}fixed-pan-input">Pan (fixed)</label>
+            <input type="number" id="{{ id_prefix }}fixed-pan-input" step="0.1" placeholder="Current position">
         </div>
     </div>
-    <div class="form-row" id="fixed-tilt-group" style="display: none;">
+    <div class="form-row" id="{{ id_prefix }}fixed-tilt-group" style="display: none;">
         <div class="form-group">
-            <label for="fixed-tilt-input">Tilt (fixed)</label>
-            <input type="number" id="fixed-tilt-input" step="0.1" placeholder="Current position">
+            <label for="{{ id_prefix }}fixed-tilt-input">Tilt (fixed)</label>
+            <input type="number" id="{{ id_prefix }}fixed-tilt-input" step="0.1" placeholder="Current position">
         </div>
     </div>
-    <div class="form-row" id="fixed-zoom-group" style="display: none;">
+    <div class="form-row" id="{{ id_prefix }}fixed-zoom-group" style="display: none;">
         <div class="form-group">
-            <label for="fixed-zoom-input">Zoom (fixed)</label>
-            <input type="number" id="fixed-zoom-input" step="1" placeholder="Current position">
+            <label for="{{ id_prefix }}fixed-zoom-input">Zoom (fixed)</label>
+            <input type="number" id="{{ id_prefix }}fixed-zoom-input" step="1" placeholder="Current position">
         </div>
     </div>
 </div>

--- a/webapp/camera_survey/templates/camera_survey/index.html
+++ b/webapp/camera_survey/templates/camera_survey/index.html
@@ -1004,9 +1004,9 @@
                         restore_ptz: restorePtz.checked,
                         retry_timeout: retryTimeout,
                         session_tags: tags,
-                        fixed_pan: fixedPanInput.value ? parseFloat(fixedPanInput.value) : null,
-                        fixed_tilt: fixedTiltInput.value ? parseFloat(fixedTiltInput.value) : null,
-                        fixed_zoom: fixedZoomInput.value ? parseFloat(fixedZoomInput.value) : null,
+                        fixed_pan: axis !== 'pan' && fixedPanInput.value ? parseFloat(fixedPanInput.value) : null,
+                        fixed_tilt: axis !== 'tilt' && fixedTiltInput.value ? parseFloat(fixedTiltInput.value) : null,
+                        fixed_zoom: axis !== 'zoom' && fixedZoomInput.value ? parseFloat(fixedZoomInput.value) : null,
                     }),
                 });
 

--- a/webapp/camera_survey/validation.py
+++ b/webapp/camera_survey/validation.py
@@ -1,0 +1,113 @@
+"""Shared validation helpers for survey API endpoints."""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from poc_homography.camera_config import get_camera_by_id
+
+from .ptz import create_ptz_camera
+
+logger = logging.getLogger(__name__)
+
+
+def parse_optional_float(data: dict, field: str) -> tuple[float | None, str | None]:
+    """Parse an optional float field from request data.
+
+    Returns:
+        (value, error_message). error_message is None on success.
+    """
+    if field not in data or data[field] is None:
+        return None, None
+    try:
+        value = float(data[field])
+    except (ValueError, TypeError):
+        return None, f"{field} must be numeric"
+    if not math.isfinite(value):
+        return None, f"{field} must be a finite number"
+    return value, None
+
+
+def parse_fixed_axis_values(
+    data: dict,
+) -> tuple[float | None, float | None, float | None, str | None]:
+    """Parse optional fixed axis values from request data.
+
+    Returns:
+        (fixed_pan, fixed_tilt, fixed_zoom, error_message).
+        error_message is None on success.
+    """
+    fixed_pan, err = parse_optional_float(data, "fixed_pan")
+    if err:
+        return None, None, None, err
+
+    fixed_tilt, err = parse_optional_float(data, "fixed_tilt")
+    if err:
+        return None, None, None, err
+
+    fixed_zoom, err = parse_optional_float(data, "fixed_zoom")
+    if err:
+        return None, None, None, err
+
+    return fixed_pan, fixed_tilt, fixed_zoom, None
+
+
+def validate_fixed_axis_ranges(
+    fixed_pan: float | None,
+    fixed_tilt: float | None,
+    fixed_zoom: float | None,
+    camera_id: str,
+    tenant_id: str,
+) -> str | None:
+    """Validate fixed axis values against camera capabilities.
+
+    Returns error message if validation fails, None if all values are in range.
+    """
+    if fixed_pan is None and fixed_tilt is None and fixed_zoom is None:
+        return None
+
+    camera = get_camera_by_id(camera_id)
+    if not camera:
+        return f"Camera not found: {camera_id}"
+
+    camera_ip = camera.get("ip")
+    if not camera_ip:
+        return f"Camera {camera_id} has no IP address"
+
+    try:
+        ptz_camera = create_ptz_camera(
+            camera_ip=camera_ip,
+            camera_name=camera.get("name", camera_id),
+            camera_model=camera.get("model"),
+            tenant_id=tenant_id,
+        )
+        capabilities = ptz_camera.get_capabilities()
+    except ValueError as e:
+        return str(e)
+    except Exception as e:
+        logger.exception(f"Failed to get camera capabilities for {camera_id}")
+        return f"Failed to get camera capabilities: {e}"
+
+    if fixed_pan is not None:
+        if not (capabilities.pan_min <= fixed_pan <= capabilities.pan_max):
+            return (
+                f"Fixed pan value {fixed_pan} is outside valid range "
+                f"[{capabilities.pan_min}, {capabilities.pan_max}]"
+            )
+
+    if fixed_tilt is not None:
+        if not (capabilities.tilt_min <= fixed_tilt <= capabilities.tilt_max):
+            return (
+                f"Fixed tilt value {fixed_tilt} is outside valid range "
+                f"[{capabilities.tilt_min}, {capabilities.tilt_max}]"
+            )
+
+    if fixed_zoom is not None:
+        if not (capabilities.zoom_min <= fixed_zoom <= capabilities.zoom_max):
+            return (
+                f"Fixed zoom value {fixed_zoom} is outside valid range "
+                f"[{capabilities.zoom_min}, {capabilities.zoom_max}]"
+            )
+
+    return None

--- a/webapp/camera_survey/views.py
+++ b/webapp/camera_survey/views.py
@@ -19,10 +19,10 @@ from poc_homography.camera_config import (
     get_tenants,
 )
 
-from .ptz import create_ptz_camera
-
 from .models import SurveyAxis, SurveyConfig
+from .ptz import create_ptz_camera
 from .services import CameraSurveyService, get_survey_presets
+from .validation import parse_fixed_axis_values, validate_fixed_axis_ranges
 
 logger = logging.getLogger(__name__)
 
@@ -161,77 +161,16 @@ def api_start_survey(request: HttpRequest) -> JsonResponse:
     if step <= 0:
         return _error_response("step must be greater than 0")
 
-    # Parse optional fixed axis values
-    fixed_pan: float | None = None
-    fixed_tilt: float | None = None
-    fixed_zoom: float | None = None
+    # Parse and validate optional fixed axis values
+    fixed_pan, fixed_tilt, fixed_zoom, parse_err = parse_fixed_axis_values(data)
+    if parse_err:
+        return _error_response(parse_err)
 
-    if "fixed_pan" in data and data["fixed_pan"] is not None:
-        try:
-            fixed_pan = float(data["fixed_pan"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_pan must be numeric")
-
-    if "fixed_tilt" in data and data["fixed_tilt"] is not None:
-        try:
-            fixed_tilt = float(data["fixed_tilt"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_tilt must be numeric")
-
-    if "fixed_zoom" in data and data["fixed_zoom"] is not None:
-        try:
-            fixed_zoom = float(data["fixed_zoom"])
-        except (ValueError, TypeError):
-            return _error_response("fixed_zoom must be numeric")
-
-    # Validate fixed axis values against camera capabilities
-    if fixed_pan is not None or fixed_tilt is not None or fixed_zoom is not None:
-        # Get camera to create PTZ instance for capabilities
-        camera = get_camera_by_id(data["camera_id"])
-        if not camera:
-            return _error_response(f"Camera not found: {data['camera_id']}")
-
-        camera_ip = camera.get("ip")
-        if not camera_ip:
-            return _error_response(f"Camera {data['camera_id']} has no IP address")
-
-        try:
-            ptz_camera = create_ptz_camera(
-                camera_ip=camera_ip,
-                camera_name=camera.get("name", data["camera_id"]),
-                camera_model=camera.get("model"),
-                tenant_id=data["tenant_id"],
-            )
-            capabilities = ptz_camera.get_capabilities()
-        except ValueError as e:
-            return _error_response(str(e))
-        except Exception as e:
-            logger.exception(f"Failed to get camera capabilities for {data['camera_id']}")
-            return _error_response(f"Failed to get camera capabilities: {e}", 500)
-
-        # Validate fixed pan against camera limits
-        if fixed_pan is not None:
-            if not (capabilities.pan_min <= fixed_pan <= capabilities.pan_max):
-                return _error_response(
-                    f"Fixed pan value {fixed_pan} is outside valid range "
-                    f"[{capabilities.pan_min}, {capabilities.pan_max}]"
-                )
-
-        # Validate fixed tilt against camera limits
-        if fixed_tilt is not None:
-            if not (capabilities.tilt_min <= fixed_tilt <= capabilities.tilt_max):
-                return _error_response(
-                    f"Fixed tilt value {fixed_tilt} is outside valid range "
-                    f"[{capabilities.tilt_min}, {capabilities.tilt_max}]"
-                )
-
-        # Validate fixed zoom against camera limits
-        if fixed_zoom is not None:
-            if not (capabilities.zoom_min <= fixed_zoom <= capabilities.zoom_max):
-                return _error_response(
-                    f"Fixed zoom value {fixed_zoom} is outside valid range "
-                    f"[{capabilities.zoom_min}, {capabilities.zoom_max}]"
-                )
+    range_err = validate_fixed_axis_ranges(
+        fixed_pan, fixed_tilt, fixed_zoom, data["camera_id"], data["tenant_id"]
+    )
+    if range_err:
+        return _error_response(range_err)
 
     # Parse session tags
     session_tags = data.get("session_tags", [])
@@ -261,10 +200,12 @@ def api_start_survey(request: HttpRequest) -> JsonResponse:
     if error:
         return _error_response(error, 500)
 
-    return _success_response({
-        "session_id": session_id,
-        "message": "Survey started successfully",
-    })
+    return _success_response(
+        {
+            "session_id": session_id,
+            "message": "Survey started successfully",
+        }
+    )
 
 
 @require_GET
@@ -283,14 +224,16 @@ def api_survey_status(request: HttpRequest, session_id: str) -> JsonResponse:
         # Check if it's a completed session
         session = _survey_service.get_session(session_id)
         if session:
-            return _success_response({
-                "session_id": session_id,
-                "status": session.status.value,
-                "step_count": len(session.captures),
-                "total_steps": len(session.captures),
-                "current_ptz": session.final_ptz.to_dict() if session.final_ptz else None,
-                "last_capture_path": None,
-            })
+            return _success_response(
+                {
+                    "session_id": session_id,
+                    "status": session.status.value,
+                    "step_count": len(session.captures),
+                    "total_steps": len(session.captures),
+                    "current_ptz": session.final_ptz.to_dict() if session.final_ptz else None,
+                    "last_capture_path": None,
+                }
+            )
         return _error_response("Survey not found", 404)
 
     return _success_response(progress.to_dict())
@@ -311,10 +254,12 @@ def api_abort_survey(request: HttpRequest, session_id: str) -> JsonResponse:
     if not success:
         return _error_response(error or "Failed to abort survey", 400)
 
-    return _success_response({
-        "session_id": session_id,
-        "message": "Survey abort requested",
-    })
+    return _success_response(
+        {
+            "session_id": session_id,
+            "message": "Survey abort requested",
+        }
+    )
 
 
 @require_GET
@@ -336,12 +281,14 @@ def api_sessions_list(request: HttpRequest) -> JsonResponse:
 
     sessions, total = _survey_service.list_sessions(limit=limit, offset=offset)
 
-    return _success_response({
-        "sessions": sessions,
-        "total": total,
-        "limit": limit,
-        "offset": offset,
-    })
+    return _success_response(
+        {
+            "sessions": sessions,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+    )
 
 
 @require_GET
@@ -416,9 +363,11 @@ def api_presets(request: HttpRequest) -> JsonResponse:
     """
     presets = get_survey_presets()
 
-    return _success_response({
-        "presets": [p.to_dict() for p in presets],
-    })
+    return _success_response(
+        {
+            "presets": [p.to_dict() for p in presets],
+        }
+    )
 
 
 @require_POST
@@ -436,10 +385,12 @@ def api_delete_session(request: HttpRequest, session_id: str) -> JsonResponse:
     if not success:
         return _error_response(error or "Failed to delete session", 400)
 
-    return _success_response({
-        "session_id": session_id,
-        "message": "Session deleted successfully",
-    })
+    return _success_response(
+        {
+            "session_id": session_id,
+            "message": "Session deleted successfully",
+        }
+    )
 
 
 @require_GET
@@ -474,7 +425,9 @@ def api_ptz_status(request: HttpRequest) -> JsonResponse:
 
     try:
         # Create PTZ camera instance
-        ptz_camera = create_ptz_camera(camera_ip=camera_ip, camera_name=camera_name, tenant_id=tenant_id)
+        ptz_camera = create_ptz_camera(
+            camera_ip=camera_ip, camera_name=camera_name, tenant_id=tenant_id
+        )
 
         # Get current position
         position = ptz_camera.get_status()
@@ -482,13 +435,15 @@ def api_ptz_status(request: HttpRequest) -> JsonResponse:
         if position is None:
             return _error_response("Failed to get camera position", 500)
 
-        return _success_response({
-            "ptz": {
-                "pan": position.pan,
-                "tilt": position.tilt,
-                "zoom": position.zoom,
+        return _success_response(
+            {
+                "ptz": {
+                    "pan": position.pan,
+                    "tilt": position.tilt,
+                    "zoom": position.zoom,
+                }
             }
-        })
+        )
 
     except ValueError as e:
         # Raised by create_ptz_camera if credentials not set


### PR DESCRIPTION
## Summary

- Add fixed axis input controls (pan, tilt, zoom) to camera_evaluation UI, restoring feature parity with camera_survey
- Update camera_evaluation backend (`api_survey_start()`) to pass `fixed_pan`, `fixed_tilt`, `fixed_zoom` to `SurveyConfig`
- Extract shared survey configuration HTML into a reusable Django template partial (`survey_config_fields.html`) to prevent future template drift

## Changes

### Frontend (`camera_evaluation/index.html`)
- Add fixed axis input fields (pan, tilt, zoom) with show/hide logic based on selected survey axis
- Add `updateFixedAxisVisibility()` and `fetchAndPopulateFixedAxisPosition()` JavaScript functions
- Auto-populate fixed axis defaults from camera's current position on camera selection
- Include `fixed_pan`, `fixed_tilt`, `fixed_zoom` in survey start API request body

### Backend (`camera_evaluation/views.py`)
- Extract `fixed_pan`, `fixed_tilt`, `fixed_zoom` from request body and pass to `SurveyConfig` constructor

### Template Consolidation
- Create `camera_survey/includes/survey_config_fields.html` shared partial with parameterized IDs
- Update both `camera_survey/index.html` and `camera_evaluation/index.html` to use the shared partial
- Parameterize via Django context: `id_prefix`, `axis_radio_name`, `show_helpers`, `show_current_position`

## Test plan

- [ ] Verify camera_evaluation shows fixed axis inputs when axis is selected (pan survey shows tilt+zoom fixed inputs)
- [ ] Verify fixed axis inputs auto-populate from camera's current position
- [ ] Verify survey start API includes fixed axis values in request body
- [ ] Verify survey manifest YAML records fixed axis values under `survey_parameters`
- [ ] Verify camera_survey still works identically after template refactor
- [ ] Verify both tools display identical fixed axis UI behavior

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)