### PR TITLE
feat(point-picker): auto-save GCP mutations to YAML repo (#234)

### DIFF
--- a/tests/test_point_picker.py
+++ b/tests/test_point_picker.py
@@ -18,13 +18,13 @@ if str(WEBAPP_DIR) not in sys.path:
     sys.path.insert(0, str(WEBAPP_DIR))
 
 # Import from the new Django app location
+from homography_web.frame_utils import normalize_array
 from point_picker.state import (
     ABBREVIATION_TO_TAG,
     TAG_ABBREVIATIONS,
     PointPickerState,
     get_tag_from_id,
 )
-from homography_web.frame_utils import normalize_array
 
 
 class TestTagAbbreviations:
@@ -247,27 +247,22 @@ class TestPointPickerState:
         with pytest.raises(KeyError):
             mock_state.delete_point("PS999")
 
-    def test_save_and_load_repo(self, mock_state: PointPickerState, tmp_path: Path) -> None:
-        """Save and load via GCP repo preserves points."""
-        mock_state.add_point("parking_spot", 100, 200)
-        mock_state.add_point("arrows", 300, 400)
+    def test_save_and_delete_gcp_via_repo_helpers(
+        self, mock_state: PointPickerState, tmp_path: Path
+    ) -> None:
+        """save_gcp_to_repo writes YAML; delete_gcp_from_repo removes it."""
+        from point_picker.state import delete_gcp_from_repo, save_gcp_to_repo
 
         gcps_dir = tmp_path / "gcps"
         gcps_dir.mkdir()
-        mock_state.save_to_repo(gcps_dir)
 
-        # Load into a new state
-        with patch("point_picker.state.tifffile.TiffFile") as mock_tif:
-            mock_tif.return_value = MockTiffFile()
-            geotiff_path = tmp_path / "test2.tif"
-            geotiff_path.touch()
-            new_state = PointPickerState(geotiff_path)
+        save_gcp_to_repo("PS1", 100.0, 200.0, mock_state.map_id, gcps_dir)
+        yaml_files = list(gcps_dir.glob("*.yaml"))
+        assert len(yaml_files) == 1
 
-        new_state.load_from_repo(gcps_dir, mock_state.map_id)
-
-        assert len(new_state.registry.points) == 2
-        assert "PS1" in new_state.registry.points
-        assert "AR1" in new_state.registry.points
+        delete_gcp_from_repo("PS1", mock_state.map_id, gcps_dir)
+        yaml_files = list(gcps_dir.glob("*.yaml"))
+        assert len(yaml_files) == 0
 
 
 class TestPointPickerStateGeoCoords:
@@ -364,8 +359,12 @@ class TestPointPickerAPI:
 
         # Inject state for the test tenant, clean up after test
         pp_state._states[self.TENANT_ID] = state
-        # Bypass tenant repo validation (test tenant doesn't exist in YAML repo)
-        with patch("point_picker.views.get_tenant_id", return_value=self.TENANT_ID):
+        # Bypass tenant repo validation and YAML persistence (test tenant has no repo dir)
+        with (
+            patch("point_picker.views.get_tenant_id", return_value=self.TENANT_ID),
+            patch("point_picker.views.save_gcp_to_repo"),
+            patch("point_picker.views.delete_gcp_from_repo"),
+        ):
             yield Client()
         pp_state._states.pop(self.TENANT_ID, None)
 
@@ -567,79 +566,28 @@ class TestPointPickerAPI:
         assert data["easting"] is None
         assert data["northing"] is None
 
-    def test_export_points(self, test_client, tmp_path: Path) -> None:
-        """POST /point-picker/api/export/ saves points to YAML file."""
-        # Add some points
-        test_client.post(
-            self._url("/point-picker/api/points/"),
-            data=json.dumps({"tag": "parking_spot", "pixel_x": 100, "pixel_y": 200}),
-            content_type="application/json",
-        )
-        test_client.post(
-            self._url("/point-picker/api/points/"),
-            data=json.dumps({"tag": "arrows", "pixel_x": 300, "pixel_y": 400}),
-            content_type="application/json",
-        )
-
-        # Export (saves to repository)
+    def test_export_endpoint_removed(self, test_client) -> None:
+        """POST /point-picker/api/export/ returns 404 (endpoint removed)."""
         resp = test_client.post(
             self._url("/point-picker/api/export/"),
             data=json.dumps({}),
             content_type="application/json",
         )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["count"] == 2
-        assert data["saved"] is True
+        assert resp.status_code == 404
 
-    def test_import_points(self, test_client, tmp_path: Path) -> None:
-        """POST /point-picker/api/import/ loads points from GCP repository."""
-        import point_picker.views as pp_views
-        from unittest.mock import MagicMock
-
-        # Create GCP YAML files in repo format
-        gcps_dir = tmp_path / "gcps"
-        gcps_dir.mkdir()
-        (gcps_dir / "test__PS1.yaml").write_text(
-            "id: test/PS1\nname: PS1\nmap_point:\n  map_id: test\n  pixel_point:\n    x: 100.0\n    y: 200.0\n"
-        )
-        (gcps_dir / "test__AR1.yaml").write_text(
-            "id: test/AR1\nname: AR1\nmap_point:\n  map_id: test\n  pixel_point:\n    x: 300.0\n    y: 400.0\n"
-        )
-
-        # Monkeypatch GCPS_DIR to use tmp directory
-        original = pp_views.GCPS_DIR
-        pp_views.GCPS_DIR = gcps_dir
-
-        # Mock map entity for tenant validation in api_import
-        mock_map = MagicMock()
-        mock_map.id = "test"
-
-        try:
-            with patch("point_picker.views.get_map_from_tenant_id", return_value=mock_map):
-                resp = test_client.post(
-                    self._url("/point-picker/api/import/"),
-                    data=json.dumps({"map_id": "test"}),
-                    content_type="application/json",
-                )
-                assert resp.status_code == 200
-                data = resp.json()
-                assert data["count"] == 2
-
-                # Verify points were imported
-                resp = test_client.get(self._url("/point-picker/api/points/"))
-                assert len(resp.json()["points"]) == 2
-        finally:
-            pp_views.GCPS_DIR = original
-
-    def test_import_missing_map_id_returns_422(self, test_client) -> None:
-        """POST /point-picker/api/import/ without map_id returns 422."""
+    def test_import_endpoint_removed(self, test_client) -> None:
+        """POST /point-picker/api/import/ returns 404 (endpoint removed)."""
         resp = test_client.post(
             self._url("/point-picker/api/import/"),
-            data=json.dumps({}),
+            data=json.dumps({"map_id": "test"}),
             content_type="application/json",
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 404
+
+    def test_registries_endpoint_removed(self, test_client) -> None:
+        """GET /point-picker/api/registries/ returns 404 (endpoint removed)."""
+        resp = test_client.get(self._url("/point-picker/api/registries/"))
+        assert resp.status_code == 404
 
     def test_full_point_lifecycle(self, test_client) -> None:
         """Test complete point lifecycle: create -> read -> update -> delete."""

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -14,6 +14,7 @@ from homography_web.frame_utils import (
 from PIL import Image
 
 from poc_homography.domain.vo.geotiff import GeoTiff
+from poc_homography.infrastructure.repositories import RepoYamlGroundControlPoint
 from poc_homography.map_points.gcp_registry import GCPRegistry
 from poc_homography.map_points.map_point import MapPoint
 
@@ -162,28 +163,6 @@ class PointPickerState:
         del new_points[point_id]
         self.registry = GCPRegistry(map_id=self.map_id, points=new_points)
 
-    def load_from_repo(self, data_dir: Path, map_id: str) -> None:
-        """Load points from the DDD GCP repository.
-
-        Args:
-            data_dir: Directory containing per-GCP YAML files.
-            map_id: Map identifier to load.
-        """
-        from poc_homography.map_points.gcp_registry import from_gcp_repo
-
-        self.registry = from_gcp_repo(data_dir, map_id)
-        self.map_id = self.registry.map_id
-
-    def save_to_repo(self, data_dir: Path) -> None:
-        """Save points to the DDD GCP repository.
-
-        Args:
-            data_dir: Directory for per-GCP YAML files.
-        """
-        from poc_homography.map_points.gcp_registry import save_to_gcp_repo
-
-        save_to_gcp_repo(self.registry, data_dir)
-
     def get_geo_coords(self, pixel_x: float, pixel_y: float) -> tuple[float, float] | None:
         """Convert pixel coordinates to geographic coordinates.
 
@@ -228,7 +207,10 @@ def get_state(tenant_id: str) -> PointPickerState:
 
     # Load GCPs for this tenant's map only
     if GCPS_DIR.exists():
-        state.load_from_repo(GCPS_DIR, map_entity.id)
+        from poc_homography.map_points.gcp_registry import from_gcp_repo
+
+        state.registry = from_gcp_repo(GCPS_DIR, map_entity.id)
+        state.map_id = state.registry.map_id
 
     _states[tenant_id] = state
     return state
@@ -249,4 +231,67 @@ def get_tag_from_id(point_id: str) -> str:
     return "extra"
 
 
+# ---------------------------------------------------------------------------
+# Repository adapter functions (bridge legacy MapPoint <-> DDD repos)
+# ---------------------------------------------------------------------------
+
+_gcp_repo_cache: dict[str, RepoYamlGroundControlPoint] = {}
+
+
+def _get_gcp_repo(data_dir: Path) -> RepoYamlGroundControlPoint:
+    """Return a cached RepoYamlGroundControlPoint for *data_dir*."""
+    key = str(data_dir)
+    if key not in _gcp_repo_cache:
+        _gcp_repo_cache[key] = RepoYamlGroundControlPoint(data_dir)
+    return _gcp_repo_cache[key]
+
+
+def save_gcp_to_repo(
+    point_id: str,
+    pixel_x: float,
+    pixel_y: float,
+    map_id: str,
+    data_dir: Path,
+) -> None:
+    """Persist a single GCP to the DDD ``RepoYamlGroundControlPoint`` repository.
+
+    Accepts raw coordinates so callers can write to disk *before* mutating
+    in-memory state, keeping the two in sync even when the write fails.
+
+    Args:
+        point_id: Point identifier (e.g. "PS1").
+        pixel_x: X pixel coordinate.
+        pixel_y: Y pixel coordinate.
+        map_id: Map identifier for the GCP.
+        data_dir: Directory for per-GCP YAML files.
+    """
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+    from poc_homography.domain.vo.map_point import MapPoint as DomainMapPoint
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+
+    repo = _get_gcp_repo(data_dir)
+    gcp = GroundControlPoint(
+        name=point_id,
+        map_point=DomainMapPoint(
+            map_id=map_id,
+            pixel_point=PixelPoint.create(pixel_x, pixel_y),
+        ),
+    )
+    repo.save(gcp)
+
+
+def delete_gcp_from_repo(point_id: str, map_id: str, data_dir: Path) -> None:
+    """Delete a GCP from the DDD ``RepoYamlGroundControlPoint`` repository.
+
+    Args:
+        point_id: Point identifier (e.g. "PS1").
+        map_id: Map identifier for constructing the entity ID.
+        data_dir: Directory for per-GCP YAML files.
+    """
+    repo = _get_gcp_repo(data_dir)
+    # Entity ID format is {map_id}/{point_id} per GroundControlPoint.id
+    repo.delete(f"{map_id}/{point_id}")
+
+
 register_invalidation_callback(_states.clear)
+register_invalidation_callback(_gcp_repo_cache.clear)

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -288,9 +288,17 @@ def delete_gcp_from_repo(point_id: str, map_id: str, data_dir: Path) -> None:
         map_id: Map identifier for constructing the entity ID.
         data_dir: Directory for per-GCP YAML files.
     """
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+    from poc_homography.domain.vo.map_point import MapPoint as DomainMapPoint
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+
     repo = _get_gcp_repo(data_dir)
-    # Entity ID format is {map_id}/{point_id} per GroundControlPoint.id
-    repo.delete(f"{map_id}/{point_id}")
+    # Use GroundControlPoint.id to derive the entity ID rather than duplicating the format.
+    _zero = PixelPoint.create(0, 0)
+    entity_id = GroundControlPoint(
+        name=point_id, map_point=DomainMapPoint(map_id=map_id, pixel_point=_zero)
+    ).id
+    repo.delete(entity_id)
 
 
 register_invalidation_callback(_states.clear)

--- a/webapp/point_picker/templates/point_picker/index.html
+++ b/webapp/point_picker/templates/point_picker/index.html
@@ -96,22 +96,6 @@
         .marker.selected::before { border-color: #ffeb3b; box-shadow: 0 0 8px #ffeb3b; }
         .marker.selected::after { background: #ffeb3b; }
         #filename { font-size: 12px; color: #888; word-break: break-all; }
-        .modal {
-            display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-            background: rgba(0,0,0,0.5); align-items: center; justify-content: center;
-            z-index: 1000;
-        }
-        .modal.active { display: flex; }
-        .modal-content {
-            background: white; padding: 24px; border-radius: 12px;
-            min-width: 300px; max-width: 400px;
-        }
-        .modal-title { font-size: 18px; margin-bottom: 16px; }
-        .modal input {
-            width: 100%; padding: 10px; border: 1px solid #ddd;
-            border-radius: 6px; margin-bottom: 16px; font-size: 14px;
-        }
-        .modal-buttons { display: flex; gap: 8px; justify-content: flex-end; }
     </style>
 </head>
 <body>
@@ -137,27 +121,8 @@
             <div class="section-title">Points</div>
             <div id="point-list"></div>
         </div>
-        <div class="section">
-            <div class="btn-group">
-                <button class="btn btn-primary" id="export-btn">Save to Repo</button>
-                <button class="btn btn-secondary" id="import-btn">Load from Repo</button>
-            </div>
-        </div>
     </div>
     <div id="viewer"></div>
-
-    <div id="import-modal" class="modal">
-        <div class="modal-content">
-            <div class="modal-title">Load from Repository</div>
-            <select id="import-map-id" style="width:100%;padding:10px;border:1px solid #ddd;border-radius:6px;margin-bottom:16px;font-size:14px;">
-                <option value="">Loading...</option>
-            </select>
-            <div class="modal-buttons">
-                <button class="btn btn-secondary" onclick="closeModal('import-modal')">Cancel</button>
-                <button class="btn btn-primary" onclick="doImport()">Load</button>
-            </div>
-        </div>
-    </div>
 
     <script src="{% static 'js/tenant.js' %}"></script>
     <script>
@@ -258,13 +223,6 @@
                 // Setup tag buttons
                 document.querySelectorAll('.tag-btn').forEach(btn => {
                     btn.addEventListener('click', () => selectTag(btn.dataset.tag));
-                });
-
-                // Setup export/import
-                document.getElementById('export-btn').addEventListener('click', () => doExport());
-                document.getElementById('import-btn').addEventListener('click', () => {
-                    populateRegistryDropdown();
-                    openModal('import-modal');
                 });
 
                 // Initial setup
@@ -539,74 +497,6 @@
                 updateNextId();
             } catch (e) {
                 showError(`Failed to delete point: ${e.message}`);
-            }
-        }
-
-        function openModal(id) {
-            document.getElementById(id).classList.add('active');
-        }
-
-        function closeModal(id) {
-            document.getElementById(id).classList.remove('active');
-        }
-
-        async function populateRegistryDropdown() {
-            const select = document.getElementById('import-map-id');
-            try {
-                const resp = await fetch(`${API_BASE}/api/registries/`);
-                if (!resp.ok) return;
-                const data = await resp.json();
-                select.innerHTML = '';
-                (data.map_ids || []).forEach(id => {
-                    const opt = document.createElement('option');
-                    opt.value = id;
-                    opt.textContent = id;
-                    select.appendChild(opt);
-                });
-            } catch (e) {
-                select.innerHTML = '<option value="">Error loading</option>';
-            }
-        }
-
-        async function doExport() {
-            try {
-                const resp = await fetch(`${API_BASE}/api/export/`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: '{}'
-                });
-                if (!resp.ok) {
-                    const err = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-                    showError(`Save failed: ${err.error || err.detail || 'Unknown error'}`);
-                    return;
-                }
-                const result = await resp.json();
-                alert(`Saved ${result.count} points to repository`);
-            } catch (e) {
-                showError(`Save failed: ${e.message}`);
-            }
-        }
-
-        async function doImport() {
-            const mapId = document.getElementById('import-map-id').value;
-            if (!mapId) return;
-            try {
-                const resp = await fetch(`${API_BASE}/api/import/`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ map_id: mapId })
-                });
-                if (!resp.ok) {
-                    const err = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
-                    showError(`Load failed: ${err.error || err.detail || 'Unknown error'}`);
-                    return;
-                }
-                const result = await resp.json();
-                alert(`Loaded ${result.count} points for map "${result.map_id}"`);
-                closeModal('import-modal');
-                await loadPoints();
-            } catch (e) {
-                showError(`Load failed: ${e.message}`);
             }
         }
 

--- a/webapp/point_picker/urls.py
+++ b/webapp/point_picker/urls.py
@@ -19,9 +19,4 @@ urlpatterns = [
     path("api/points/<str:point_id>/", views.api_point_detail, name="api_point_detail"),
     # Coordinate API
     path("api/geo-coords/", views.api_geo_coords, name="api_geo_coords"),
-    # Import/Export API
-    path("api/export/", views.api_export, name="api_export"),
-    path("api/import/", views.api_import, name="api_import"),
-    # Repository API
-    path("api/registries/", views.api_registries, name="api_registries"),
 ]

--- a/webapp/point_picker/views.py
+++ b/webapp/point_picker/views.py
@@ -12,10 +12,10 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
-from homography_web.frame_utils import GCPS_DIR, get_map_from_tenant_id, get_tenant_id, normalize_array
+from homography_web.frame_utils import GCPS_DIR, get_tenant_id, normalize_array
 from PIL import Image
 
-from .state import get_state, get_tag_from_id
+from .state import delete_gcp_from_repo, get_state, get_tag_from_id, save_gcp_to_repo
 from .validation import (
     validate_add_point_request,
     validate_update_point_request,
@@ -230,7 +230,11 @@ def api_points(request: HttpRequest) -> JsonResponse:
     pixel_y = float(data["pixel_y"])
     point_id = data.get("id")
 
-    point_id = state.add_point(tag, pixel_x, pixel_y, point_id=point_id)
+    # Persist to YAML repo before mutating in-memory state so a failed
+    # write never leaves state and disk out of sync.
+    resolved_id = point_id if point_id is not None else state.get_next_id(tag)
+    save_gcp_to_repo(resolved_id, pixel_x, pixel_y, state.map_id, GCPS_DIR)
+    point_id = state.add_point(tag, pixel_x, pixel_y, point_id=resolved_id)
     point = state.registry.points[point_id]
 
     return JsonResponse(
@@ -251,6 +255,9 @@ def api_point_detail(request: HttpRequest, point_id: str) -> JsonResponse:
 
     if request.method == "DELETE":
         try:
+            # Delete from YAML repo before mutating in-memory state so a failed
+            # write never leaves state and disk out of sync.
+            delete_gcp_from_repo(point_id, state.map_id, GCPS_DIR)
             state.delete_point(point_id)
             return JsonResponse({"deleted": point_id})
         except KeyError:
@@ -267,6 +274,11 @@ def api_point_detail(request: HttpRequest, point_id: str) -> JsonResponse:
         return JsonResponse({"error": error}, status=422)
 
     try:
+        # Persist to YAML repo before mutating in-memory state so a failed
+        # write never leaves state and disk out of sync.
+        save_gcp_to_repo(
+            point_id, float(data["pixel_x"]), float(data["pixel_y"]), state.map_id, GCPS_DIR
+        )
         state.update_point(point_id, float(data["pixel_x"]), float(data["pixel_y"]))
         point = state.registry.points[point_id]
         return JsonResponse(
@@ -326,55 +338,3 @@ def api_geo_coords(request: HttpRequest) -> JsonResponse:
             "crs": None,
         }
     )
-
-
-@csrf_exempt
-@require_http_methods(["POST"])
-def api_export(request: HttpRequest) -> JsonResponse:
-    """Save points to the GCP repository."""
-    state = get_state(get_tenant_id(request))
-    state.save_to_repo(GCPS_DIR)
-    return JsonResponse({"saved": True, "count": len(state.registry.points)})
-
-
-@csrf_exempt
-@require_http_methods(["POST"])
-def api_import(request: HttpRequest) -> JsonResponse:
-    """Import points from the GCP repository by map_id."""
-    try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return JsonResponse({"error": "Invalid JSON"}, status=400)
-
-    map_id = data.get("map_id")
-    if not map_id or not isinstance(map_id, str):
-        return JsonResponse({"error": "Missing or invalid field: map_id"}, status=422)
-
-    tenant_id = get_tenant_id(request)
-    # Validate map_id belongs to this tenant
-    map_entity = get_map_from_tenant_id(tenant_id)
-    if map_entity is None or map_entity.id != map_id:
-        return JsonResponse({"error": f"map_id {map_id!r} does not belong to this tenant"}, status=403)
-
-    state = get_state(tenant_id)
-    state.load_from_repo(GCPS_DIR, map_id)
-    return JsonResponse(
-        {
-            "map_id": state.registry.map_id,
-            "count": len(state.registry.points),
-        }
-    )
-
-
-@require_GET
-def api_registries(request: HttpRequest) -> JsonResponse:
-    """Return available map IDs from the GCP repository, filtered by tenant."""
-    from poc_homography.map_points.gcp_registry import list_map_ids
-
-    if not GCPS_DIR.exists():
-        return JsonResponse({"map_ids": []})
-    tenant_id = get_tenant_id(request)
-    map_entity = get_map_from_tenant_id(tenant_id)
-    tenant_map_ids = {map_entity.id} if map_entity else set()
-    all_ids = list_map_ids(GCPS_DIR)
-    return JsonResponse({"map_ids": [mid for mid in all_ids if mid in tenant_map_ids]})

--- a/webapp/point_picker/views.py
+++ b/webapp/point_picker/views.py
@@ -254,14 +254,13 @@ def api_point_detail(request: HttpRequest, point_id: str) -> JsonResponse:
     state = get_state(get_tenant_id(request))
 
     if request.method == "DELETE":
-        try:
-            # Delete from YAML repo before mutating in-memory state so a failed
-            # write never leaves state and disk out of sync.
-            delete_gcp_from_repo(point_id, state.map_id, GCPS_DIR)
-            state.delete_point(point_id)
-            return JsonResponse({"deleted": point_id})
-        except KeyError:
+        if point_id not in state.registry.points:
             return JsonResponse({"error": f"Point not found: {point_id}"}, status=404)
+        # Delete from YAML repo before mutating in-memory state so a failed
+        # write never leaves state and disk out of sync.
+        delete_gcp_from_repo(point_id, state.map_id, GCPS_DIR)
+        state.delete_point(point_id)
+        return JsonResponse({"deleted": point_id})
 
     # PUT - update point coordinates
     try:
@@ -273,13 +272,14 @@ def api_point_detail(request: HttpRequest, point_id: str) -> JsonResponse:
     if error:
         return JsonResponse({"error": error}, status=422)
 
+    px = float(data["pixel_x"])
+    py = float(data["pixel_y"])
+
     try:
         # Persist to YAML repo before mutating in-memory state so a failed
         # write never leaves state and disk out of sync.
-        save_gcp_to_repo(
-            point_id, float(data["pixel_x"]), float(data["pixel_y"]), state.map_id, GCPS_DIR
-        )
-        state.update_point(point_id, float(data["pixel_x"]), float(data["pixel_y"]))
+        save_gcp_to_repo(point_id, px, py, state.map_id, GCPS_DIR)
+        state.update_point(point_id, px, py)
         point = state.registry.points[point_id]
         return JsonResponse(
             {


### PR DESCRIPTION
## Summary

- Auto-persist every GCP mutation (add, update, delete) directly to `RepoYamlGroundControlPoint` at mutation time, following the pattern from the line picker (#231)
- Add `save_gcp_to_repo` and `delete_gcp_from_repo` helper functions with repo caching
- Remove `api_export`, `api_import`, `api_registries` endpoints and URL routes
- Remove `save_to_repo` and `load_from_repo` methods from `PointPickerState`
- Remove frontend Save/Load buttons, import modal, and related JS functions

Closes #234

## Test plan

- [ ] Add a GCP via the point picker UI and verify a YAML file appears in `GCPS_DIR`
- [ ] Drag-move a GCP and verify the YAML file is updated
- [ ] Delete a GCP and verify the YAML file is removed
- [ ] Restart the server and verify GCPs load from YAML files on init
- [ ] Verify `GET/POST api/export/`, `GET/POST api/import/`, `GET api/registries/` all return 404
- [ ] Verify the sidebar no longer shows Save/Load buttons or import modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)