### PR TITLE
fix(calibration): unify calibration repo plumbing

### DIFF
--- a/data/lens_calibrations/valte_cam01.yaml
+++ b/data/lens_calibrations/valte_cam01.yaml
@@ -1,0 +1,19 @@
+id: valte_cam01
+entries:
+- zoom_factor: 1.0
+  distortion:
+    k1: -0.142578473376
+    k2: -0.075324877083
+    p1: -0.002494896402
+    p2: -0.008090950449
+    k3: 0.231109795821
+  calibration_date: '2026-02-02T18:33:50.096780'
+  source_images: []
+  validation_rmse: 160.3262
+  num_lines_used: 43
+  fx: 1670.796460176991
+  fy: 1670.796460176991
+  cx: 960.0
+  cy: 540.0
+created_date: '2026-04-20T11:35:35.779222'
+last_modified: '2026-04-20T11:35:35.779222'

--- a/poc_homography/calibration/lens_distortion/calibration_table.py
+++ b/poc_homography/calibration/lens_distortion/calibration_table.py
@@ -519,7 +519,8 @@ def load_calibration_for_camera(
 ) -> CameraCalibrationTable | None:
     """Load calibration table for a camera from standard location.
 
-    Looks for file named '{camera_id}_calibration.yaml' in calibration_dir.
+    Checks for both legacy (``{camera_id}_calibration.yaml``) and DDD repo
+    (``{camera_id}.yaml``) file naming conventions.
 
     Args:
         camera_id: Camera identifier.
@@ -529,13 +530,45 @@ def load_calibration_for_camera(
         CameraCalibrationTable if found, None otherwise.
     """
     calibration_dir = Path(calibration_dir)
-    calibration_file = calibration_dir / f"{camera_id}_calibration.yaml"
 
-    if calibration_file.exists():
-        return CameraCalibrationTable.load(calibration_file)
+    # Legacy format: {camera_id}_calibration.yaml
+    legacy_file = calibration_dir / f"{camera_id}_calibration.yaml"
+    if legacy_file.exists():
+        return CameraCalibrationTable.load(legacy_file)
+
+    # DDD repo format: {camera_id}.yaml (entries have nested 'distortion' dict)
+    ddd_file = calibration_dir / f"{camera_id}.yaml"
+    if ddd_file.exists():
+        return _load_from_ddd_format(ddd_file)
 
     logger.debug(f"No calibration file found for camera {camera_id}")
     return None
+
+
+def _load_from_ddd_format(path: Path) -> CameraCalibrationTable:
+    """Load a CameraCalibrationTable from a DDD-repo YAML file.
+
+    DDD files use ``id`` instead of ``camera_id`` and nest distortion
+    coefficients under an ``entries[].distortion`` dict.
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    if data is None:
+        raise ValueError(f"Calibration file is empty: {path}")
+
+    # Normalize DDD schema → legacy schema
+    data.setdefault("camera_id", data.pop("id", path.stem))
+    for entry in data.get("entries", []):
+        distortion = entry.pop("distortion", None)
+        if distortion and "k1" not in entry:
+            entry["k1"] = distortion.get("k1", 0.0)
+            entry["k2"] = distortion.get("k2", 0.0)
+            entry["k3"] = distortion.get("k3", 0.0)
+            entry["p1"] = distortion.get("p1", 0.0)
+            entry["p2"] = distortion.get("p2", 0.0)
+
+    return CameraCalibrationTable.from_dict(data)
 
 
 def load_lens_distortion_as_table(

--- a/poc_homography/calibration/lens_distortion/calibration_table.py
+++ b/poc_homography/calibration/lens_distortion/calibration_table.py
@@ -589,15 +589,9 @@ def load_lens_distortion_as_table(
         Dictionary mapping zoom_factor to ``{k1, k2, k3, p1, p2}`` dicts,
         or ``None`` if no calibration file exists.
     """
-    calibration_dir = Path(calibration_dir)
-    calibration_file = calibration_dir / f"{camera_id}_calibration.yaml"
-
-    if not calibration_file.exists():
-        return None
-
     try:
-        table = CameraCalibrationTable.load(calibration_file)
-        if not table.entries:
+        table = load_calibration_for_camera(camera_id, calibration_dir)
+        if table is None or not table.entries:
             return None
 
         result: dict[float, dict[str, float]] = {}

--- a/poc_homography/calibration/lens_distortion/cli.py
+++ b/poc_homography/calibration/lens_distortion/cli.py
@@ -331,28 +331,29 @@ def cmd_calibrate(args: argparse.Namespace) -> int:
         if len(result.line_errors) > 10:
             print(f"  ... and {len(result.line_errors) - 10} more")
 
-    # Persist results
-    camera_id = args.camera_id or "unknown_camera"
-    zoom = args.zoom or 1.0
+    # Persist results only on successful calibration
+    if result.success and result.is_improved():
+        camera_id = args.camera_id or "unknown_camera"
+        zoom = args.zoom or 1.0
 
-    table = CameraCalibrationTable(camera_id=camera_id)
-    entry = ZoomCalibrationEntry.from_solver_result(
-        zoom_factor=zoom,
-        distortion=result.distortion,
-        validation_rmse=result.overall_rmse,
-        source_images=[str(p) for p in images[:10]],
-        num_lines_used=len(all_lines),
-    )
-    table.add_entry(entry)
-    try:
-        sync_to_ddd_repo(table)
-    except Exception:
-        logger.warning("Failed to sync to DDD repo", exc_info=True)
+        table = CameraCalibrationTable(camera_id=camera_id)
+        entry = ZoomCalibrationEntry.from_solver_result(
+            zoom_factor=zoom,
+            distortion=result.distortion,
+            validation_rmse=result.overall_rmse,
+            source_images=[str(p) for p in images[:10]],
+            num_lines_used=len(all_lines),
+        )
+        table.add_entry(entry)
+        try:
+            sync_to_ddd_repo(table)
+        except Exception:
+            logger.warning("Failed to sync to DDD repo", exc_info=True)
 
-    if args.output:
-        output_path = Path(args.output)
-        table.save(output_path)
-        logger.info(f"Saved calibration to {output_path}")
+        if args.output:
+            output_path = Path(args.output)
+            table.save(output_path)
+            logger.info(f"Saved calibration to {output_path}")
 
     # Also output JSON for programmatic use
     if args.json:

--- a/poc_homography/calibration/lens_distortion/cli.py
+++ b/poc_homography/calibration/lens_distortion/cli.py
@@ -331,23 +331,27 @@ def cmd_calibrate(args: argparse.Namespace) -> int:
         if len(result.line_errors) > 10:
             print(f"  ... and {len(result.line_errors) - 10} more")
 
-    # Save results if requested
+    # Persist results
+    camera_id = args.camera_id or "unknown_camera"
+    zoom = args.zoom or 1.0
+
+    table = CameraCalibrationTable(camera_id=camera_id)
+    entry = ZoomCalibrationEntry.from_solver_result(
+        zoom_factor=zoom,
+        distortion=result.distortion,
+        validation_rmse=result.overall_rmse,
+        source_images=[str(p) for p in images[:10]],
+        num_lines_used=len(all_lines),
+    )
+    table.add_entry(entry)
+    try:
+        sync_to_ddd_repo(table)
+    except Exception:
+        logger.warning("Failed to sync to DDD repo", exc_info=True)
+
     if args.output:
         output_path = Path(args.output)
-        camera_id = args.camera_id or "unknown_camera"
-        zoom = args.zoom or 1.0
-
-        table = CameraCalibrationTable(camera_id=camera_id)
-        entry = ZoomCalibrationEntry.from_solver_result(
-            zoom_factor=zoom,
-            distortion=result.distortion,
-            validation_rmse=result.overall_rmse,
-            source_images=[str(p) for p in images[:10]],  # First 10 as reference
-            num_lines_used=len(all_lines),
-        )
-        table.add_entry(entry)
         table.save(output_path)
-        sync_to_ddd_repo(table)
         logger.info(f"Saved calibration to {output_path}")
 
     # Also output JSON for programmatic use
@@ -566,7 +570,10 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
         return 1
 
     # Save results (including partial success)
-    sync_to_ddd_repo(table)
+    try:
+        sync_to_ddd_repo(table)
+    except Exception:
+        logger.warning("Failed to sync to DDD repo", exc_info=True)
     if args.output:
         output_path = Path(args.output)
         table.save(output_path)

--- a/poc_homography/calibration/lens_distortion/cli.py
+++ b/poc_homography/calibration/lens_distortion/cli.py
@@ -33,6 +33,7 @@ from poc_homography.calibration.lens_distortion.calibration_table import (
     CameraCalibrationTable,
     ZoomCalibrationEntry,
 )
+from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo
 from poc_homography.calibration.lens_distortion.distortion_solver import (
     DistortionSolver,
     SolverConfig,
@@ -346,6 +347,7 @@ def cmd_calibrate(args: argparse.Namespace) -> int:
         )
         table.add_entry(entry)
         table.save(output_path)
+        sync_to_ddd_repo(table)
         logger.info(f"Saved calibration to {output_path}")
 
     # Also output JSON for programmatic use
@@ -564,6 +566,7 @@ def cmd_calibrate_batch(args: argparse.Namespace) -> int:
         return 1
 
     # Save results (including partial success)
+    sync_to_ddd_repo(table)
     if args.output:
         output_path = Path(args.output)
         table.save(output_path)

--- a/poc_homography/calibration/lens_distortion/ddd_sync.py
+++ b/poc_homography/calibration/lens_distortion/ddd_sync.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 def _find_project_root() -> Path:
     """Walk up from this file to find the project root (contains pyproject.toml)."""
     current = Path(__file__).resolve().parent

--- a/poc_homography/calibration/lens_distortion/ddd_sync.py
+++ b/poc_homography/calibration/lens_distortion/ddd_sync.py
@@ -14,7 +14,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DATA_DIR = Path(__file__).resolve().parents[3] / "data" / "lens_calibrations"
+def _find_project_root() -> Path:
+    """Walk up from this file to find the project root (contains pyproject.toml)."""
+    current = Path(__file__).resolve().parent
+    for parent in (current, *current.parents):
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return current.parents[2]  # fallback: assume standard layout
+
+
+DEFAULT_DATA_DIR = _find_project_root() / "data" / "lens_calibrations"
 
 
 def sync_to_ddd_repo(

--- a/poc_homography/calibration/lens_distortion/ddd_sync.py
+++ b/poc_homography/calibration/lens_distortion/ddd_sync.py
@@ -1,0 +1,80 @@
+"""Sync legacy CameraCalibrationTable to the DDD LensCalibrationTable repo."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from poc_homography.calibration.lens_distortion.calibration_table import (
+        CameraCalibrationTable,
+    )
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATA_DIR = Path(__file__).resolve().parents[3] / "data" / "lens_calibrations"
+
+
+def sync_to_ddd_repo(
+    table: CameraCalibrationTable,
+    data_dir: Path | None = None,
+) -> None:
+    """Persist a legacy CameraCalibrationTable into the DDD YAML repo.
+
+    Merges with any existing entries for the same camera_id so that
+    multi-zoom calibration accumulates over time.
+    """
+    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+    from poc_homography.domain.vo.lens_distortion import LensDistortion
+    from poc_homography.domain.vo.zoom_calibration_entry import (
+        ZoomCalibrationEntry as DddEntry,
+    )
+    from poc_homography.infrastructure.repositories.repo_yaml_lens_calibration_table import (
+        RepoYamlLensCalibrationTable,
+    )
+    from poc_homography.types import PixelsFloat, Unitless
+
+    if data_dir is None:
+        data_dir = DEFAULT_DATA_DIR
+
+    repo = RepoYamlLensCalibrationTable(data_dir)
+
+    existing = repo.get(table.camera_id)
+    existing_by_zoom: dict[float, DddEntry] = {}
+    if existing:
+        for e in existing.entries:
+            existing_by_zoom[float(e.zoom_factor)] = e
+
+    for legacy_entry in table.entries.values():
+        ddd_entry = DddEntry(
+            zoom_factor=Unitless(legacy_entry.zoom_factor),
+            distortion=LensDistortion(
+                k1=Unitless(legacy_entry.k1),
+                k2=Unitless(legacy_entry.k2),
+                p1=Unitless(legacy_entry.p1),
+                p2=Unitless(legacy_entry.p2),
+                k3=Unitless(legacy_entry.k3),
+            ),
+            calibration_date=legacy_entry.calibration_date,
+            source_images=tuple(legacy_entry.source_images),
+            validation_rmse=legacy_entry.validation_rmse,
+            num_lines_used=legacy_entry.num_lines_used,
+            fx=PixelsFloat(legacy_entry.fx),
+            fy=PixelsFloat(legacy_entry.fy),
+            cx=PixelsFloat(legacy_entry.cx),
+            cy=PixelsFloat(legacy_entry.cy),
+            reprojection_error_px=legacy_entry.reprojection_error_px,
+        )
+        existing_by_zoom[float(legacy_entry.zoom_factor)] = ddd_entry
+
+    now = datetime.now().isoformat()
+    entity = LensCalibrationTable(
+        id=table.camera_id,
+        entries=tuple(existing_by_zoom[z] for z in sorted(existing_by_zoom)),
+        created_date=existing.created_date if existing else now,
+        last_modified=now,
+    )
+    repo.save(entity)
+    logger.info(f"Synced calibration to DDD repo: {data_dir / f'{table.camera_id}.yaml'}")

--- a/webapp/homography_web/calibration_utils.py
+++ b/webapp/homography_web/calibration_utils.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from django.http import HttpRequest, JsonResponse
@@ -147,55 +146,9 @@ def serialize_calibration_entry(entry: ZoomCalibrationEntry) -> dict[str, Any]:
 
 def save_calibration_to_repo(table: Any, data_dir: Path) -> None:
     """Convert a legacy ``CameraCalibrationTable`` to ``LensCalibrationTable`` and persist."""
-    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
-    from poc_homography.domain.vo.lens_distortion import LensDistortion
-    from poc_homography.domain.vo.zoom_calibration_entry import (
-        ZoomCalibrationEntry as DddEntry,
-    )
-    from poc_homography.infrastructure.repositories.repo_yaml_lens_calibration_table import (
-        RepoYamlLensCalibrationTable,
-    )
-    from poc_homography.types import PixelsFloat, Unitless
+    from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo
 
-    repo = RepoYamlLensCalibrationTable(data_dir)
-
-    # Merge with any existing entries already persisted for this camera
-    existing = repo.get(table.camera_id)
-    existing_by_zoom: dict[float, DddEntry] = {}
-    if existing:
-        for e in existing.entries:
-            existing_by_zoom[float(e.zoom_factor)] = e
-
-    for legacy_entry in table.entries.values():
-        ddd_entry = DddEntry(
-            zoom_factor=Unitless(legacy_entry.zoom_factor),
-            distortion=LensDistortion(
-                k1=Unitless(legacy_entry.k1),
-                k2=Unitless(legacy_entry.k2),
-                p1=Unitless(legacy_entry.p1),
-                p2=Unitless(legacy_entry.p2),
-                k3=Unitless(legacy_entry.k3),
-            ),
-            calibration_date=legacy_entry.calibration_date,
-            source_images=tuple(legacy_entry.source_images),
-            validation_rmse=legacy_entry.validation_rmse,
-            num_lines_used=legacy_entry.num_lines_used,
-            fx=PixelsFloat(legacy_entry.fx),
-            fy=PixelsFloat(legacy_entry.fy),
-            cx=PixelsFloat(legacy_entry.cx),
-            cy=PixelsFloat(legacy_entry.cy),
-            reprojection_error_px=legacy_entry.reprojection_error_px,
-        )
-        existing_by_zoom[float(legacy_entry.zoom_factor)] = ddd_entry
-
-    now = datetime.now().isoformat()
-    entity = LensCalibrationTable(
-        id=table.camera_id,
-        entries=tuple(existing_by_zoom[z] for z in sorted(existing_by_zoom)),
-        created_date=existing.created_date if existing else now,
-        last_modified=now,
-    )
-    repo.save(entity)
+    sync_to_ddd_repo(table, data_dir)
 
 
 def load_calibration_from_repo(camera_id: str, data_dir: Path) -> LensCalibrationTable | None:


### PR DESCRIPTION
## Summary
- CLI and webapp calibration tools now write to the same DDD repo (`data/lens_calibrations/`)
- `load_calibration_for_camera()` reads both legacy (`{id}_calibration.yaml`) and DDD (`{id}.yaml`) formats
- Deduplicates the legacy→DDD conversion into a shared `ddd_sync` module
- Seeds the existing `valte_cam01` calibration into the DDD repo

## Context
After #241 wired lens undistortion into `MapPointHomography`, the precision tool couldn't actually load calibration data because:
1. The CLI saved to `calibration_results/` (not the DDD repo path)
2. The loader only checked `{id}_calibration.yaml` (not the DDD filename `{id}.yaml`)

## Results (homography_precision API)
| Pan angle | RMSE without | RMSE with | Improvement |
|-----------|-------------|-----------|-------------|
| 30° | 3.68 px | 1.26 px | -66% |
| 45° | 7.10 px | 1.14 px | -84% |
| 60° | 8.34 px | 1.63 px | -80% |
| 75° | 5.66 px | 3.40 px | -40% |
| 90° | 2.83 px | 1.09 px | -61% |

## Test plan
- [ ] `uv run pytest tests/` passes
- [ ] `uv run pyright` passes
- [ ] Precision API returns improved metrics with calibration loaded