### PR TITLE
feat(api): migrate frame_utils.py from RepoYaml to RepoPostgres

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import bcrypt
@@ -12,19 +11,12 @@ from sqlalchemy.orm import Session
 
 from poc_homography.infrastructure.database import get_sessionmaker
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.infrastructure.repositories import RepoYamlMap, RepoYamlTenant
+from poc_homography.infrastructure.repositories import RepoPostgresMap, RepoPostgresTenant
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     from poc_homography.domain.entities.map import Map
-
-# ---------------------------------------------------------------------------
-# Data directories (mirrors webapp/homography_web/frame_utils.py layout)
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-_DATA_DIR = _PROJECT_ROOT / "data"
 
 # ---------------------------------------------------------------------------
 # DB session
@@ -76,17 +68,23 @@ def get_current_user(
 # ---------------------------------------------------------------------------
 
 
-def get_tenant_id(tenant_id: str = Query(...)) -> str:
+def get_tenant_id(
+    tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
+) -> str:
     """Extract and validate the ``tenant_id`` query parameter."""
-    repo = RepoYamlTenant(_DATA_DIR / "tenants")
+    repo = RepoPostgresTenant(session)
     if not repo.exists(tenant_id):
         raise HTTPException(status_code=400, detail=f"Unknown tenant_id: {tenant_id}")
     return tenant_id
 
 
-def get_map_for_tenant(tenant_id: str = Depends(get_tenant_id)) -> Map:
+def get_map_for_tenant(
+    tenant_id: str = Depends(get_tenant_id),
+    session: Session = Depends(get_db_session),
+) -> Map:
     """Resolve the :class:`Map` entity associated with *tenant_id*."""
-    repo = RepoYamlMap(_DATA_DIR / "maps")
+    repo = RepoPostgresMap(session)
     maps = repo.get_by_tenant(tenant_id)
     if not maps:
         raise HTTPException(status_code=404, detail=f"No map found for tenant: {tenant_id}")

--- a/api/deps.py
+++ b/api/deps.py
@@ -26,10 +26,14 @@ _http_basic = HTTPBasic()
 
 
 def get_db_session() -> Generator[Session, None, None]:
-    """Yield a read-only SQLAlchemy session for authentication queries."""
+    """Yield an SQLAlchemy session, committing on success or rolling back on error."""
     session = get_sessionmaker()()
     try:
         yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
     finally:
         session.close()
 

--- a/api/routers/camera_annotator.py
+++ b/api/routers/camera_annotator.py
@@ -18,18 +18,17 @@ from api.schemas.camera_annotator import (
     SwitchImageResponse,
 )
 from api.utils.frame_helpers import (
-    FRAMES_DIR,
     get_frame_image_path,
     get_map_for_tenant,
     image_filename_to_frame,
     list_image_filenames,
     load_annotations_for_frame,
+    save_annotations_for_frame,
     validate_image_filename,
 )
 from poc_homography.domain.entities.annotation import Annotation
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.infrastructure.repositories import RepoPostgresCapturedFrame
 from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
 # ---------------------------------------------------------------------------
@@ -160,9 +159,7 @@ def save_annotations(
         for ann in body.annotations
     ]
 
-    RepoPostgresCapturedFrame(session, frames_dir=FRAMES_DIR).save_annotations(
-        frame.id, ann_entities
-    )
+    save_annotations_for_frame(frame.id, ann_entities, session)
 
     return SaveAnnotationsResponse(success=True, saved=len(ann_entities))
 

--- a/api/routers/camera_annotator.py
+++ b/api/routers/camera_annotator.py
@@ -6,8 +6,9 @@ import mimetypes
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
 from homography_web.frame_utils import (
-    GCPS_DIR,
     get_available_images,
     get_frame_image_path,
     get_frame_repo,
@@ -18,7 +19,7 @@ from homography_web.frame_utils import (
     validate_image_filename,
 )
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.camera_annotator import (
     AnnotationOut,
     GcpOut,
@@ -30,7 +31,7 @@ from api.schemas.camera_annotator import (
 from poc_homography.domain.entities.annotation import Annotation
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.map_points.gcp_registry import from_gcp_repo
+from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
 # ---------------------------------------------------------------------------
 # Router
@@ -60,13 +61,14 @@ def _resolve_map_id(tenant_id: str) -> str:
 def list_gcps(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> list[GcpOut]:
     """List GCPs for a tenant."""
     map_entity = get_map_from_tenant_id(tenant_id)
     if map_entity is None:
         return []
     try:
-        registry = from_gcp_repo(GCPS_DIR, map_entity.id)
+        registry = from_gcp_repo_pg(session, map_entity.id)
     except (KeyError, ValueError, OSError):
         return []
 

--- a/api/routers/camera_annotator.py
+++ b/api/routers/camera_annotator.py
@@ -8,17 +8,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from homography_web.frame_utils import (
-    get_available_images,
-    get_frame_image_path,
-    get_frame_repo,
-    get_map_from_tenant_id,
-    image_filename_to_frame,
-    invalidate_cache,
-    load_annotations_for_frame,
-    validate_image_filename,
-)
-
 from api.deps import get_current_user, get_db_session
 from api.schemas.camera_annotator import (
     AnnotationOut,
@@ -28,9 +17,19 @@ from api.schemas.camera_annotator import (
     SwitchImageRequest,
     SwitchImageResponse,
 )
+from api.utils.frame_helpers import (
+    FRAMES_DIR,
+    get_frame_image_path,
+    get_map_for_tenant,
+    image_filename_to_frame,
+    list_image_filenames,
+    load_annotations_for_frame,
+    validate_image_filename,
+)
 from poc_homography.domain.entities.annotation import Annotation
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.repositories import RepoPostgresCapturedFrame
 from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
 # ---------------------------------------------------------------------------
@@ -44,9 +43,9 @@ router = APIRouter(prefix="/camera-annotator", tags=["camera-annotator"])
 # ---------------------------------------------------------------------------
 
 
-def _resolve_map_id(tenant_id: str) -> str:
+def _resolve_map_id(tenant_id: str, session: Session) -> str:
     """Return the map_id for *tenant_id*, raising 404 when missing."""
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         raise HTTPException(status_code=404, detail=f"No map found for tenant: {tenant_id}")
     return map_entity.id
@@ -64,7 +63,7 @@ def list_gcps(
     session: Session = Depends(get_db_session),
 ) -> list[GcpOut]:
     """List GCPs for a tenant."""
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         return []
     try:
@@ -83,12 +82,13 @@ def get_annotations(
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> list[AnnotationOut]:
     """Get annotations for a specific image."""
-    frame = image_filename_to_frame(image_filename)
+    frame = image_filename_to_frame(image_filename, session)
     if frame is None:
         return []
-    annotations = load_annotations_for_frame(frame.id)
+    annotations = load_annotations_for_frame(frame.id, session)
     return [AnnotationOut(**ann) for ann in annotations]
 
 
@@ -96,10 +96,11 @@ def get_annotations(
 def list_images(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> list[str]:
     """List available images for a tenant."""
-    map_id = _resolve_map_id(tenant_id)
-    return get_available_images(map_id)
+    map_id = _resolve_map_id(tenant_id, session)
+    return list_image_filenames(session, map_id)
 
 
 @router.post("/api/switch-image/", response_model=SwitchImageResponse)
@@ -107,21 +108,22 @@ def switch_image(
     body: SwitchImageRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> SwitchImageResponse:
     """Validate an image and return its annotations (stateless)."""
     if not validate_image_filename(body.filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    frame = image_filename_to_frame(body.filename)
+    frame = image_filename_to_frame(body.filename, session)
     if frame is None:
         raise HTTPException(status_code=404, detail=f"Image not found: {body.filename}")
 
     # Ensure the frame belongs to the tenant's map
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity and frame.map_id != map_entity.id:
         raise HTTPException(status_code=404, detail=f"Image not found: {body.filename}")
 
-    annotations = load_annotations_for_frame(frame.id)
+    annotations = load_annotations_for_frame(frame.id, session)
     return SwitchImageResponse(
         success=True,
         filename=body.filename,
@@ -134,9 +136,10 @@ def save_annotations(
     body: SaveAnnotationsRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> SaveAnnotationsResponse:
     """Save annotations for an image."""
-    frame = image_filename_to_frame(body.image_filename)
+    frame = image_filename_to_frame(body.image_filename, session)
     if frame is None:
         raise HTTPException(status_code=400, detail="No image selected")
 
@@ -157,8 +160,9 @@ def save_annotations(
         for ann in body.annotations
     ]
 
-    get_frame_repo().save_annotations(frame.id, ann_entities)
-    invalidate_cache()
+    RepoPostgresCapturedFrame(session, frames_dir=FRAMES_DIR).save_annotations(
+        frame.id, ann_entities
+    )
 
     return SaveAnnotationsResponse(success=True, saved=len(ann_entities))
 
@@ -168,12 +172,13 @@ def serve_image(
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> FileResponse:
     """Serve a camera image file from disk."""
     if not validate_image_filename(image_filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    frame = image_filename_to_frame(image_filename)
+    frame = image_filename_to_frame(image_filename, session)
     if frame is None:
         raise HTTPException(status_code=404, detail="Image not found")
 

--- a/api/routers/camera_diagnostic.py
+++ b/api/routers/camera_diagnostic.py
@@ -53,8 +53,9 @@ from camera_survey.ptz import create_ptz_camera
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from ptz_discovery_and_control.hikvision.hikvision_ptz_discovery import HikvisionPTZ
+from sqlalchemy.orm import Session
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.camera_diagnostic import (
     CameraOut,
     CameraResultIn,
@@ -386,12 +387,13 @@ def _run_ptz_test(
 @router.get("/api/tenants/")
 def api_tenants(
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> JSONResponse:
     """List all tenants."""
     try:
-        from homography_web.frame_utils import get_tenant_repo
+        from poc_homography.infrastructure.repositories import RepoPostgresTenant
 
-        tenant_entities = get_tenant_repo().get_all()
+        tenant_entities = RepoPostgresTenant(session).get_all()
         tenant_list = [
             TenantOut(id=t.id, name=t.name, description=t.description).model_dump()
             for t in tenant_entities

--- a/api/routers/camera_line_annotator.py
+++ b/api/routers/camera_line_annotator.py
@@ -7,20 +7,10 @@ import re
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from homography_web.frame_utils import (
-    LINES_DIR,
-    get_available_images_fresh,
-    get_frame_image_path,
-    get_line_annotation_repo,
-    get_map_from_tenant_id,
-    image_filename_to_frame,
-    invalidate_cache,
-    load_line_annotations_for_frame,
-    validate_image_filename,
-)
-from line_picker.state import from_line_repo
+from line_picker.state import from_line_repo_pg
+from sqlalchemy.orm import Session
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.camera_line_annotator import (
     CameraStatusOut,
     CreateAnnotationRequest,
@@ -33,9 +23,18 @@ from api.schemas.camera_line_annotator import (
     UpdateAnnotationRequest,
     UpdateAnnotationResponse,
 )
+from api.utils.frame_helpers import (
+    get_frame_image_path,
+    get_map_for_tenant,
+    image_filename_to_frame,
+    list_image_filenames,
+    load_line_annotations_for_frame,
+    validate_image_filename,
+)
 from poc_homography.domain.entities.line_annotation import LineAnnotation
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.repositories import RepoPostgresLineAnnotation
 
 # ---------------------------------------------------------------------------
 # Router
@@ -54,9 +53,9 @@ _LINE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
 # ---------------------------------------------------------------------------
 
 
-def _resolve_map_id(tenant_id: str) -> str:
+def _resolve_map_id(tenant_id: str, session: Session) -> str:
     """Return the map_id for *tenant_id*, raising 404 when missing."""
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         raise HTTPException(status_code=404, detail=f"No map found for tenant: {tenant_id}")
     return map_entity.id
@@ -68,12 +67,12 @@ def _validate_line_id(line_id: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid line_id format")
 
 
-def _validate_and_get_frame(image_filename: str):
+def _validate_and_get_frame(image_filename: str, session: Session):
     """Validate *image_filename* and return the CapturedFrame, or raise."""
     if not validate_image_filename(image_filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    frame = image_filename_to_frame(image_filename)
+    frame = image_filename_to_frame(image_filename, session)
     if frame is None:
         raise HTTPException(status_code=404, detail=f"Image not found: {image_filename}")
     return frame
@@ -99,28 +98,30 @@ def _annotation_dict_to_out(ann: dict) -> LineAnnotationOut:
 @router.get("/api/images/", response_model=list[str])
 def list_images(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> list[str]:
     """List available images for a tenant."""
-    map_id = _resolve_map_id(tenant_id)
-    return get_available_images_fresh(map_id)
+    map_id = _resolve_map_id(tenant_id, session)
+    return list_image_filenames(session, map_id)
 
 
 @router.post("/api/switch-image/", response_model=SwitchImageResponse)
 def switch_image(
     body: SwitchImageRequest,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> SwitchImageResponse:
     """Validate an image and return its line annotations and camera status (stateless)."""
-    frame = _validate_and_get_frame(body.filename)
+    frame = _validate_and_get_frame(body.filename, session)
 
     # Ensure the frame belongs to the tenant's map
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity and frame.map_id != map_entity.id:
         raise HTTPException(status_code=404, detail=f"Image not found: {body.filename}")
 
-    annotations = load_line_annotations_for_frame(frame.id)
+    annotations = load_line_annotations_for_frame(frame.id, session)
 
     camera_status = CameraStatusOut(
         pan=float(frame.ptz_state.pan_raw),
@@ -140,10 +141,11 @@ def switch_image(
 def serve_image(
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> FileResponse:
     """Serve a camera image file from disk."""
-    frame = _validate_and_get_frame(image_filename)
+    frame = _validate_and_get_frame(image_filename, session)
 
     resolved_path = get_frame_image_path(frame)
     if not resolved_path.exists():
@@ -167,17 +169,15 @@ def serve_image(
 @router.get("/api/line-ids/", response_model=LineIdsResponse)
 def list_line_ids(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineIdsResponse:
     """Get available line IDs from the lines registry."""
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         raise HTTPException(status_code=404, detail=f"No map found for tenant: {tenant_id}")
 
-    try:
-        repo_lines = from_line_repo(LINES_DIR, map_entity.id)
-    except OSError:
-        repo_lines = []
+    repo_lines = from_line_repo_pg(session, map_entity.id)
 
     line_ids = [line.line_id for line in repo_lines if line.line_id]
     return LineIdsResponse(map_id=map_entity.id, line_ids=line_ids)
@@ -187,11 +187,12 @@ def list_line_ids(
 def get_annotations(
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> list[LineAnnotationOut]:
     """Get line annotations for a specific image."""
-    frame = _validate_and_get_frame(image_filename)
-    annotations = load_line_annotations_for_frame(frame.id)
+    frame = _validate_and_get_frame(image_filename, session)
+    annotations = load_line_annotations_for_frame(frame.id, session)
     return [_annotation_dict_to_out(ann) for ann in annotations]
 
 
@@ -199,14 +200,15 @@ def get_annotations(
 def create_annotation(
     body: CreateAnnotationRequest,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> CreateAnnotationResponse:
     """Create a new line annotation."""
     _validate_line_id(body.line_id)
 
-    frame = _validate_and_get_frame(body.image_filename)
+    frame = _validate_and_get_frame(body.image_filename, session)
 
-    repo = get_line_annotation_repo()
+    repo = RepoPostgresLineAnnotation(session)
 
     points_tuple: tuple[PixelPoint, ...] | None = None
     if body.points and len(body.points) >= 2:
@@ -221,7 +223,6 @@ def create_annotation(
         points=points_tuple,
     )
     repo.save(line_ann)
-    invalidate_cache()
 
     annotation_out = LineAnnotationOut(
         line_id=body.line_id,
@@ -240,14 +241,15 @@ def update_annotation(
     line_id: str,
     body: UpdateAnnotationRequest,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> UpdateAnnotationResponse:
     """Update an existing line annotation."""
     _validate_line_id(line_id)
 
-    frame = _validate_and_get_frame(body.image_filename)
+    frame = _validate_and_get_frame(body.image_filename, session)
 
-    repo = get_line_annotation_repo()
+    repo = RepoPostgresLineAnnotation(session)
     entity_id = f"{frame.id}/{line_id}"
 
     if not repo.exists(entity_id):
@@ -266,7 +268,6 @@ def update_annotation(
         points=points_tuple,
     )
     repo.save(line_ann)
-    invalidate_cache()
 
     annotation_out = LineAnnotationOut(
         line_id=line_id,
@@ -285,21 +286,20 @@ def delete_annotation(
     line_id: str,
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> DeleteAnnotationResponse:
     """Delete a line annotation."""
     _validate_line_id(line_id)
 
-    frame = _validate_and_get_frame(image_filename)
+    frame = _validate_and_get_frame(image_filename, session)
 
-    repo = get_line_annotation_repo()
+    repo = RepoPostgresLineAnnotation(session)
     entity_id = f"{frame.id}/{line_id}"
 
     deleted = repo.delete(entity_id)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Annotation not found: {line_id}")
-
-    invalidate_cache()
 
     return DeleteAnnotationResponse(success=True, deleted_line_id=line_id)
 
@@ -308,10 +308,11 @@ def delete_annotation(
 def camera_status(
     tenant_id: str = Query(...),
     image_filename: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> CameraStatusOut:
     """Get camera PTZ status for a specific image."""
-    frame = _validate_and_get_frame(image_filename)
+    frame = _validate_and_get_frame(image_filename, session)
 
     return CameraStatusOut(
         pan=float(frame.ptz_state.pan_raw),

--- a/api/routers/distortion_validator.py
+++ b/api/routers/distortion_validator.py
@@ -44,6 +44,7 @@ from api.utils.frame_helpers import (
     validate_image_filename,
 )
 from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
 
 logger = logging.getLogger(__name__)
 
@@ -133,8 +134,6 @@ def calibration_files(
     user: UserModel = Depends(get_current_user),
 ) -> CalibrationFilesResponse:
     """List available camera_ids in the calibration repo."""
-    from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
-
     try:
         repo = RepoPostgresLensCalibrationTable(session)
         camera_ids = sorted(entity.id for entity in repo.get_all())
@@ -151,8 +150,6 @@ def load_calibration(
     user: UserModel = Depends(get_current_user),
 ) -> LoadCalibrationResponse:
     """Load a calibration by camera_id from the DDD repo."""
-    from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
-
     if not body.camera_id:
         raise HTTPException(status_code=400, detail="Missing camera_id")
 

--- a/api/routers/distortion_validator.py
+++ b/api/routers/distortion_validator.py
@@ -17,22 +17,10 @@ import cv2
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from homography_web.calibration_utils import (
-    list_calibration_ids,
-    load_calibration_from_repo,
-    serialize_calibration_entry,
-)
-from homography_web.frame_utils import (
-    CALIBRATIONS_DIR,
-    WEBAPP_DIR,
-    get_frame_image_path,
-    get_map_from_tenant_id,
-    image_filename_to_frame,
-    list_image_filenames,
-    validate_image_filename,
-)
+from homography_web.calibration_utils import serialize_calibration_entry
+from sqlalchemy.orm import Session
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.distortion_validator import (
     CalibrationFilesResponse,
     ComputeIntrinsicsRequest,
@@ -46,6 +34,14 @@ from api.schemas.distortion_validator import (
     TransformPointsResponse,
     UndistortRequest,
     UndistortResponse,
+)
+from api.utils.frame_helpers import (
+    WEBAPP_DIR,
+    get_frame_image_path,
+    get_map_for_tenant,
+    image_filename_to_frame,
+    list_image_filenames,
+    validate_image_filename,
 )
 from poc_homography.infrastructure.models.user import UserModel
 
@@ -71,10 +67,10 @@ router = APIRouter(prefix="/distortion-validator", tags=["distortion-validator"]
 MAX_POINTS = 10_000  # Prevent DoS via excessive input
 
 
-def _resolve_image_path(image_path: str) -> Path | None:
+def _resolve_image_path(image_path: str, session: Session) -> Path | None:
     """Resolve an image path safely against known directories."""
     # Try as filename in the CapturedFrame repo
-    frame = image_filename_to_frame(image_path)
+    frame = image_filename_to_frame(image_path, session)
     if frame is not None:
         fp = get_frame_image_path(frame)
         if fp.exists():
@@ -133,11 +129,15 @@ def _encode_image(img: np.ndarray) -> str:
 
 @router.get("/api/calibration-files/", response_model=CalibrationFilesResponse)
 def calibration_files(
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> CalibrationFilesResponse:
     """List available camera_ids in the calibration repo."""
+    from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
+
     try:
-        camera_ids = list_calibration_ids(CALIBRATIONS_DIR)
+        repo = RepoPostgresLensCalibrationTable(session)
+        camera_ids = sorted(entity.id for entity in repo.get_all())
         return CalibrationFilesResponse(camera_ids=camera_ids)
     except Exception:
         logger.exception("Failed to list calibrations")
@@ -147,14 +147,18 @@ def calibration_files(
 @router.post("/api/load-calibration/", response_model=LoadCalibrationResponse)
 def load_calibration(
     body: LoadCalibrationRequest,
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LoadCalibrationResponse:
     """Load a calibration by camera_id from the DDD repo."""
+    from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
+
     if not body.camera_id:
         raise HTTPException(status_code=400, detail="Missing camera_id")
 
     try:
-        entity = load_calibration_from_repo(body.camera_id, CALIBRATIONS_DIR)
+        repo = RepoPostgresLensCalibrationTable(session)
+        entity = repo.get(body.camera_id)
         if entity is None:
             raise HTTPException(
                 status_code=404,
@@ -175,6 +179,7 @@ def load_calibration(
 def images(
     tenant_id: str = Query(None),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> ImagesResponse:
     """List available test images."""
     try:
@@ -184,12 +189,12 @@ def images(
         map_id: str | None = None
         if tenant_id:
             try:
-                map_entity = get_map_from_tenant_id(tenant_id)
+                map_entity = get_map_for_tenant(tenant_id, session)
                 map_id = map_entity.id if map_entity else None
             except ValueError:
                 map_id = None
 
-        for filename in list_image_filenames(map_id):
+        for filename in list_image_filenames(session, map_id):
             result.append(ImageItem(name=filename, source="captured_frame"))
 
         # Survey images
@@ -219,6 +224,7 @@ def images(
 def undistort(
     body: UndistortRequest,
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> UndistortResponse:
     """Undistort an image using provided coefficients.
 
@@ -228,7 +234,7 @@ def undistort(
     if not body.image_path:
         raise HTTPException(status_code=400, detail="Missing image_path")
 
-    img_path = _resolve_image_path(body.image_path)
+    img_path = _resolve_image_path(body.image_path, session)
     if img_path is None:
         raise HTTPException(status_code=404, detail="Image not found")
 

--- a/api/routers/gcp.py
+++ b/api/routers/gcp.py
@@ -2,27 +2,21 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.gcp import (
     MapIdsResponse,
     MapListResponse,
     TenantListResponse,
 )
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.infrastructure.repositories import RepoYamlMap, RepoYamlTenant
-from poc_homography.map_points.gcp_registry import list_map_ids
-
-# ---------------------------------------------------------------------------
-# Data directories
-# ---------------------------------------------------------------------------
-
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_DATA_DIR = _PROJECT_ROOT / "data"
-_GCPS_DIR = _DATA_DIR / "gcps"
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresGroundControlPoint,
+    RepoPostgresMap,
+    RepoPostgresTenant,
+)
 
 # ---------------------------------------------------------------------------
 # Router
@@ -33,10 +27,11 @@ router = APIRouter(prefix="/gcp", tags=["gcp"])
 
 @router.get("/api/tenants/", response_model=TenantListResponse)
 def get_tenants(
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> TenantListResponse:
     """List all tenants."""
-    repo = RepoYamlTenant(_DATA_DIR / "tenants")
+    repo = RepoPostgresTenant(session)
     tenants = repo.get_all()
     return TenantListResponse(tenants=[t.to_dict() for t in tenants])
 
@@ -44,10 +39,11 @@ def get_tenants(
 @router.get("/api/tenants/{tenant_id}/maps/", response_model=MapListResponse)
 def get_tenant_maps(
     tenant_id: str,
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> MapListResponse:
     """List maps for a tenant."""
-    repo = RepoYamlMap(_DATA_DIR / "maps")
+    repo = RepoPostgresMap(session)
     maps = repo.get_by_tenant(tenant_id)
     return MapListResponse(maps=[m.to_dict() for m in maps.values()])
 
@@ -55,13 +51,13 @@ def get_tenant_maps(
 @router.get("/api/map-ids/", response_model=MapIdsResponse)
 def get_map_ids(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> MapIdsResponse:
     """List map IDs filtered by tenant, intersected with available GCPs."""
-    if not _GCPS_DIR.exists():
-        return MapIdsResponse(map_ids=[])
-
-    tenant_maps = RepoYamlMap(_DATA_DIR / "maps").get_by_tenant(tenant_id)
+    tenant_maps = RepoPostgresMap(session).get_by_tenant(tenant_id)
     tenant_map_ids = set(tenant_maps)
-    all_ids = list_map_ids(_GCPS_DIR)
-    return MapIdsResponse(map_ids=[mid for mid in all_ids if mid in tenant_map_ids])
+
+    gcp_repo = RepoPostgresGroundControlPoint(session)
+    all_gcp_map_ids = sorted({gcp.map_id for gcp in gcp_repo.get_all()})
+    return MapIdsResponse(map_ids=[mid for mid in all_gcp_map_ids if mid in tenant_map_ids])

--- a/api/routers/homography_precision.py
+++ b/api/routers/homography_precision.py
@@ -196,7 +196,7 @@ def _load_line_test_case_by_name(name: str, map_id: str | None, session: Session
     We strip the ``_lines`` suffix to find the frame, then load line
     annotations from the LineAnnotation repo.
     """
-    stem = name.removesuffix("_lines") if name.endswith("_lines") else name
+    stem = name.removesuffix("_lines")
 
     for frame in list_frames(session, map_id):
         if frame.image_path.stem != stem:
@@ -566,12 +566,13 @@ def api_line_registry(
     session: Session = Depends(get_db_session),
 ) -> LineRegistryResponse:
     """Get the line registry for the tenant's map."""
-    lines = _load_line_registry(tenant_id, session)
+    map_id = _require_map_id(tenant_id, session)
+    lines = from_line_repo_pg(session, map_id) if map_id else []
     if not lines:
         raise HTTPException(status_code=404, detail="No lines found in line registry")
 
     return LineRegistryResponse(
-        map_id=_require_map_id(tenant_id, session),
+        map_id=map_id,
         lines=[
             LineOut(
                 line_id=line.line_id,
@@ -746,11 +747,10 @@ def api_compute_line_errors(
                 detail=f"Need at least 4 point annotations, got {len(annotations)}",
             )
 
-        map_id_for_gcps = _require_map_id(tenant_id, session)
-        if map_id_for_gcps is None:
+        if map_id is None:
             return _no_map_error()
         try:
-            gcp_registry = from_gcp_repo_pg(session, map_id_for_gcps)
+            gcp_registry = from_gcp_repo_pg(session, map_id)
         except (KeyError, ValueError, OSError) as e:
             raise HTTPException(
                 status_code=500, detail=f"Failed to load GCP registry: {e}"
@@ -940,7 +940,7 @@ def api_map_info(
     if info is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Map GeoTIFF not found: {_get_map_geotiff_file(tenant_id, session)}",
+            detail="Map GeoTIFF not found for tenant",
         )
 
     return MapInfoResponse(

--- a/api/routers/homography_precision.py
+++ b/api/routers/homography_precision.py
@@ -13,29 +13,11 @@ import numpy as np
 import tifffile
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import JSONResponse
+from line_picker.state import Line, from_line_repo_pg
+from PIL import Image
 from sqlalchemy.orm import Session
 
-from homography_web.frame_utils import (
-    CALIBRATIONS_DIR,
-    DATA_MAPS_DIR,
-    LINES_DIR,
-    extract_geotiff,
-    get_frame_image_path,
-    get_map_from_tenant_id,
-    image_filename_to_frame,
-    list_frames,
-    load_annotations_for_frame,
-    load_line_annotations_for_frame,
-    register_invalidation_callback,
-)
-from homography_web.frame_utils import (
-    get_frame_repo as _get_frame_repo,
-)
-from line_picker.state import Line, from_line_repo
-from PIL import Image
-
 from api.deps import get_current_user, get_db_session
-from api.utils.tiles import render_tile
 from api.schemas.homography_precision import (
     CameraInfoResponse,
     ComputeHomographyFromLinesRequest,
@@ -61,6 +43,18 @@ from api.schemas.homography_precision import (
     TestCaseListResponse,
     TestCaseSummary,
 )
+from api.utils.frame_helpers import (
+    CALIBRATIONS_DIR,
+    DATA_MAPS_DIR,
+    extract_geotiff,
+    get_frame_image_path,
+    get_map_for_tenant,
+    image_filename_to_frame,
+    list_frames,
+    load_annotations_for_frame,
+    load_line_annotations_for_frame,
+)
+from api.utils.tiles import render_tile
 from poc_homography.calibration.lens_distortion.calibration_table import load_calibration_for_camera
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.homography.map_points import MapPointHomography
@@ -93,9 +87,6 @@ class ImageInfoCache(TypedDict):
 _line_registry_cache: dict[str, list[Line]] = {}
 _image_info_cache: dict[str, ImageInfoCache] = {}
 
-register_invalidation_callback(_line_registry_cache.clear)
-register_invalidation_callback(_image_info_cache.clear)
-
 # ---------------------------------------------------------------------------
 # Helper functions
 # ---------------------------------------------------------------------------
@@ -112,13 +103,13 @@ def _no_map_error() -> JSONResponse:
     )
 
 
-def _require_map_id(tenant_id: str) -> str | None:
+def _require_map_id(tenant_id: str, session: Session) -> str | None:
     """Return the map ID for a tenant, or None if no map is configured."""
-    entity = get_map_from_tenant_id(tenant_id)
+    entity = get_map_for_tenant(tenant_id, session)
     return entity.id if entity else None
 
 
-def _distortion_kwargs(test_case: dict) -> dict[str, float]:
+def _distortion_kwargs(test_case: dict, session: Session) -> dict[str, float]:
     """Build distortion kwargs for MapPointHomography from a test case.
 
     Extracts camera_name and zoom from the test case, loads the calibration
@@ -129,7 +120,7 @@ def _distortion_kwargs(test_case: dict) -> dict[str, float]:
     image_filename = test_case.get("image")
     if not image_filename:
         return {}
-    frame = image_filename_to_frame(image_filename)
+    frame = image_filename_to_frame(image_filename, session)
     if frame is None:
         return {}
     zoom = test_case.get("camera_status", {}).get("zoom")
@@ -157,9 +148,9 @@ def _distortion_kwargs(test_case: dict) -> dict[str, float]:
         return {}
 
 
-def _get_map_geotiff_file(tenant_id: str) -> Path | None:
+def _get_map_geotiff_file(tenant_id: str, session: Session) -> Path | None:
     """Return path to the GeoTIFF file for the tenant's map, or None."""
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         return None
     resolved = DATA_MAPS_DIR / map_entity.photo.path
@@ -168,27 +159,27 @@ def _get_map_geotiff_file(tenant_id: str) -> Path | None:
     return resolved
 
 
-def _load_line_registry(tenant_id: str) -> list[Line]:
+def _load_line_registry(tenant_id: str, session: Session) -> list[Line]:
     """Load and cache line registry from DDD repo."""
     if tenant_id in _line_registry_cache:
         return _line_registry_cache[tenant_id]
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         return []
-    lines = from_line_repo(LINES_DIR, map_entity.id)
+    lines = from_line_repo_pg(session, map_entity.id)
     _line_registry_cache[tenant_id] = lines
     return lines
 
 
-def _load_test_case_by_name(name: str, map_id: str | None = None) -> dict | None:
+def _load_test_case_by_name(name: str, map_id: str | None, session: Session) -> dict | None:
     """Load a test case by name from the CapturedFrame repo.
 
     Matches ``name`` against each frame's image stem (filename without extension).
     """
-    for frame in list_frames(map_id):
+    for frame in list_frames(session, map_id):
         if frame.image_path.stem != name:
             continue
-        annotations = load_annotations_for_frame(frame.id)
+        annotations = load_annotations_for_frame(frame.id, session)
         if not annotations:
             continue
         tc: dict = {
@@ -205,7 +196,7 @@ def _load_test_case_by_name(name: str, map_id: str | None = None) -> dict | None
     return None
 
 
-def _load_line_test_case_by_name(name: str, map_id: str | None = None) -> dict | None:
+def _load_line_test_case_by_name(name: str, map_id: str | None, session: Session) -> dict | None:
     """Load a line test case by name from the DDD repos.
 
     For line test cases the ``name`` convention is ``{image_stem}_lines``.
@@ -214,13 +205,13 @@ def _load_line_test_case_by_name(name: str, map_id: str | None = None) -> dict |
     """
     stem = name.removesuffix("_lines") if name.endswith("_lines") else name
 
-    for frame in list_frames(map_id):
+    for frame in list_frames(session, map_id):
         if frame.image_path.stem != stem:
             continue
-        line_anns = load_line_annotations_for_frame(frame.id)
+        line_anns = load_line_annotations_for_frame(frame.id, session)
         if not line_anns:
             continue
-        point_anns = load_annotations_for_frame(frame.id)
+        point_anns = load_annotations_for_frame(frame.id, session)
         point_annotations_ref = frame.image_path.stem if point_anns else ""
         return {
             "name": name,
@@ -236,9 +227,9 @@ def _load_line_test_case_by_name(name: str, map_id: str | None = None) -> dict |
     return None
 
 
-def _get_camera_image_path(test_case_name: str, map_id: str | None = None) -> Path | None:
+def _get_camera_image_path(test_case_name: str, map_id: str | None, session: Session) -> Path | None:
     """Get the path to the camera image for a test case."""
-    test_case = _load_test_case_by_name(test_case_name, map_id)
+    test_case = _load_test_case_by_name(test_case_name, map_id, session)
     if test_case is None:
         return None
 
@@ -246,19 +237,19 @@ def _get_camera_image_path(test_case_name: str, map_id: str | None = None) -> Pa
     if not image_filename:
         return None
 
-    frame = image_filename_to_frame(image_filename)
+    frame = image_filename_to_frame(image_filename, session)
     if frame is None:
         return None
     return get_frame_image_path(frame)
 
 
-def _get_camera_info(test_case_name: str, map_id: str | None = None) -> ImageInfoCache | None:
+def _get_camera_info(test_case_name: str, map_id: str | None, session: Session) -> ImageInfoCache | None:
     """Get cached camera image info, loading if necessary."""
     cache_key = f"camera:{test_case_name}"
     if cache_key in _image_info_cache:
         return _image_info_cache[cache_key]
 
-    image_path = _get_camera_image_path(test_case_name, map_id)
+    image_path = _get_camera_image_path(test_case_name, map_id, session)
     if image_path is None or not image_path.exists():
         return None
 
@@ -275,13 +266,13 @@ def _get_camera_info(test_case_name: str, map_id: str | None = None) -> ImageInf
     return info
 
 
-def _get_map_info(tenant_id: str) -> ImageInfoCache | None:
+def _get_map_info(tenant_id: str, session: Session) -> ImageInfoCache | None:
     """Get cached map GeoTIFF info, loading if necessary."""
     cache_key = f"map:geotiff:{tenant_id}"
     if cache_key in _image_info_cache:
         return _image_info_cache[cache_key]
 
-    geotiff_path = _get_map_geotiff_file(tenant_id)
+    geotiff_path = _get_map_geotiff_file(tenant_id, session)
     if geotiff_path is None or not geotiff_path.exists():
         return None
 
@@ -328,18 +319,18 @@ def _perpendicular_distance(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> floa
 def api_test_cases(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> TestCaseListResponse:
     """List all available test cases with annotation counts."""
-    repo = _get_frame_repo()
-    map_entity = get_map_from_tenant_id(tenant_id)
+    map_entity = get_map_for_tenant(tenant_id, session)
     map_id = map_entity.id if map_entity else None
-    frames = list_frames(map_id)
+    frames = list_frames(session, map_id)
     if not frames:
         raise HTTPException(status_code=404, detail="No captured frames found")
 
     test_cases: list[TestCaseSummary] = []
     for frame in frames:
-        annotations = repo.get_annotations(frame.id)
+        annotations = load_annotations_for_frame(frame.id, session)
         if not annotations:
             continue
         test_cases.append(
@@ -358,10 +349,11 @@ def api_test_case_detail(
     name: str,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> TestCaseDetailResponse:
     """Get a specific test case by name."""
-    map_id = _require_map_id(tenant_id)
-    tc = _load_test_case_by_name(name, map_id)
+    map_id = _require_map_id(tenant_id, session)
+    tc = _load_test_case_by_name(name, map_id, session)
     if tc is None:
         raise HTTPException(status_code=404, detail=f"Test case not found: {name}")
 
@@ -383,17 +375,17 @@ def api_compute_homography(
     test_case_name = body.test_case_name
 
     # Load GCP registry from repository
-    map_id = _require_map_id(tenant_id)
+    map_id = _require_map_id(tenant_id, session)
 
     # Load test case
-    test_case = _load_test_case_by_name(test_case_name, map_id)
+    test_case = _load_test_case_by_name(test_case_name, map_id, session)
     if test_case is None:
         raise HTTPException(
             status_code=404, detail=f"Test case not found: {test_case_name}"
         )
 
     annotations = test_case.get("annotations", [])
-    if len(annotations) < 4:  # noqa: PLR2004
+    if len(annotations) < 4:
         raise HTTPException(
             status_code=400,
             detail=f"Need at least 4 annotations, got {len(annotations)}",
@@ -409,7 +401,7 @@ def api_compute_homography(
 
     # Compute homography
     try:
-        homography = MapPointHomography(map_id=registry.map_id, **_distortion_kwargs(test_case))
+        homography = MapPointHomography(map_id=registry.map_id, **_distortion_kwargs(test_case, session))
         result = homography.compute_from_gcps(
             gcps=annotations,
             map_registry=registry,
@@ -524,7 +516,7 @@ def api_gcp_registry(
     session: Session = Depends(get_db_session),
 ) -> GCPRegistryResponse | JSONResponse:
     """Get the GCP registry for the tenant's map."""
-    map_id = _require_map_id(tenant_id)
+    map_id = _require_map_id(tenant_id, session)
     if map_id is None:
         return _no_map_error()
     try:
@@ -544,12 +536,13 @@ def api_gcp_registry(
 def api_line_test_cases(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> LineTestCaseListResponse:
     """List all available line test cases."""
-    map_id = _require_map_id(tenant_id)
+    map_id = _require_map_id(tenant_id, session)
     test_cases: list[LineTestCaseSummary] = []
-    for frame in list_frames(map_id):
-        line_anns = load_line_annotations_for_frame(frame.id)
+    for frame in list_frames(session, map_id):
+        line_anns = load_line_annotations_for_frame(frame.id, session)
         if not line_anns:
             continue
         test_cases.append(
@@ -571,10 +564,11 @@ def api_line_test_case_detail(
     name: str,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> LineTestCaseDetailResponse:
     """Get a specific line test case by name."""
-    map_id = _require_map_id(tenant_id)
-    tc = _load_line_test_case_by_name(name, map_id)
+    map_id = _require_map_id(tenant_id, session)
+    tc = _load_line_test_case_by_name(name, map_id, session)
     if tc is None:
         raise HTTPException(status_code=404, detail=f"Line test case not found: {name}")
 
@@ -590,14 +584,15 @@ def api_line_test_case_detail(
 def api_line_registry(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> LineRegistryResponse:
     """Get the line registry for the tenant's map."""
-    lines = _load_line_registry(tenant_id)
+    lines = _load_line_registry(tenant_id, session)
     if not lines:
         raise HTTPException(status_code=404, detail="No lines found in line registry")
 
     return LineRegistryResponse(
-        map_id=_require_map_id(tenant_id),
+        map_id=_require_map_id(tenant_id, session),
         lines=[
             LineOut(
                 line_id=line.line_id,
@@ -619,16 +614,17 @@ def api_compute_homography_from_lines(
     body: ComputeHomographyFromLinesRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> ComputeHomographyFromLinesResponse | JSONResponse:
     """Compute line-based homography from line correspondences."""
     test_case_name = body.test_case_name
     line_annotations = body.line_annotations
 
-    map_id = _require_map_id(tenant_id)
+    map_id = _require_map_id(tenant_id, session)
 
     line_test_case: dict | None = None
     if test_case_name:
-        line_test_case = _load_line_test_case_by_name(test_case_name, map_id)
+        line_test_case = _load_line_test_case_by_name(test_case_name, map_id, session)
         if line_test_case is None:
             raise HTTPException(
                 status_code=404,
@@ -641,13 +637,13 @@ def api_compute_homography_from_lines(
             detail="Missing required field: test_case_name or line_annotations",
         )
 
-    if len(line_annotations) < 2:  # noqa: PLR2004
+    if len(line_annotations) < 2:
         raise HTTPException(
             status_code=400,
             detail=f"Need at least 2 line annotations, got {len(line_annotations)}",
         )
 
-    lines = _load_line_registry(tenant_id)
+    lines = _load_line_registry(tenant_id, session)
     if not lines:
         raise HTTPException(status_code=500, detail="No lines found in line registry")
 
@@ -656,7 +652,7 @@ def api_compute_homography_from_lines(
     if map_id is None:
         return _no_map_error()
     try:
-        dist_kw = _distortion_kwargs(line_test_case) if test_case_name and line_test_case else {}
+        dist_kw = _distortion_kwargs(line_test_case, session) if test_case_name and line_test_case else {}
         homography = MapPointHomography(map_id=map_id, **dist_kw)
         result = homography.compute_from_lines(
             line_annotations=line_annotations,
@@ -701,8 +697,8 @@ def api_compute_line_errors(
     use_line_homography = body.use_line_homography
 
     # Load line test case
-    map_id = _require_map_id(tenant_id)
-    line_test_case = _load_line_test_case_by_name(test_case_name, map_id)
+    map_id = _require_map_id(tenant_id, session)
+    line_test_case = _load_line_test_case_by_name(test_case_name, map_id, session)
     if line_test_case is None:
         raise HTTPException(
             status_code=404, detail=f"Line test case not found: {test_case_name}"
@@ -715,7 +711,7 @@ def api_compute_line_errors(
         )
 
     # Load line registry (needed for both approaches)
-    lines = _load_line_registry(tenant_id)
+    lines = _load_line_registry(tenant_id, session)
     if not lines:
         raise HTTPException(
             status_code=500, detail="No lines found in line registry"
@@ -725,7 +721,7 @@ def api_compute_line_errors(
 
     # Compute homography - either from lines or from referenced point annotations
     if use_line_homography:
-        if len(line_annotations) < 2:  # noqa: PLR2004
+        if len(line_annotations) < 2:
             raise HTTPException(
                 status_code=400,
                 detail=f"Need at least 2 line annotations for line-based homography, got {len(line_annotations)}",
@@ -735,7 +731,7 @@ def api_compute_line_errors(
             return _no_map_error()
         try:
             homography = MapPointHomography(
-                map_id=map_id, **_distortion_kwargs(line_test_case)
+                map_id=map_id, **_distortion_kwargs(line_test_case, session)
             )
             homography.compute_from_lines(
                 line_annotations=line_annotations,
@@ -757,7 +753,7 @@ def api_compute_line_errors(
                 detail="No point_annotations_ref found in line test case. Use use_line_homography=true for line-based homography.",
             )
 
-        point_test_case = _load_test_case_by_name(point_annotations_ref, map_id)
+        point_test_case = _load_test_case_by_name(point_annotations_ref, map_id, session)
         if point_test_case is None:
             raise HTTPException(
                 status_code=404,
@@ -765,13 +761,13 @@ def api_compute_line_errors(
             )
 
         annotations = point_test_case.get("annotations", [])
-        if len(annotations) < 4:  # noqa: PLR2004
+        if len(annotations) < 4:
             raise HTTPException(
                 status_code=400,
                 detail=f"Need at least 4 point annotations, got {len(annotations)}",
             )
 
-        map_id_for_gcps = _require_map_id(tenant_id)
+        map_id_for_gcps = _require_map_id(tenant_id, session)
         if map_id_for_gcps is None:
             return _no_map_error()
         try:
@@ -783,7 +779,7 @@ def api_compute_line_errors(
 
         try:
             homography = MapPointHomography(
-                map_id=gcp_registry.map_id, **_distortion_kwargs(line_test_case)
+                map_id=gcp_registry.map_id, **_distortion_kwargs(line_test_case, session)
             )
             homography.compute_from_gcps(
                 gcps=annotations,
@@ -936,10 +932,11 @@ def api_camera_info(
     case: str = Query(...),
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> CameraInfoResponse:
     """Get camera image metadata (width, height, filename)."""
-    map_id = _require_map_id(tenant_id)
-    info = _get_camera_info(case, map_id)
+    map_id = _require_map_id(tenant_id, session)
+    info = _get_camera_info(case, map_id, session)
     if info is None:
         raise HTTPException(
             status_code=404,
@@ -957,13 +954,14 @@ def api_camera_info(
 def api_map_info(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> MapInfoResponse:
     """Get map GeoTIFF metadata (width, height, filename, geotransform, CRS)."""
-    info = _get_map_info(tenant_id)
+    info = _get_map_info(tenant_id, session)
     if info is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Map GeoTIFF not found: {_get_map_geotiff_file(tenant_id)}",
+            detail=f"Map GeoTIFF not found: {_get_map_geotiff_file(tenant_id, session)}",
         )
 
     return MapInfoResponse(
@@ -984,21 +982,22 @@ def api_camera_tile(
     size: int = Query(256, ge=1, le=4096),
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> Response:
     """Get a camera image tile at specified coordinates and zoom level.
 
     OpenSeadragon uses a pyramid where level 0 is most zoomed out and
     the max level is full resolution.
     """
-    map_id = _require_map_id(tenant_id)
-    info = _get_camera_info(case, map_id)
+    map_id = _require_map_id(tenant_id, session)
+    info = _get_camera_info(case, map_id, session)
     if info is None:
         raise HTTPException(
             status_code=404,
             detail=f"Test case not found or image missing: {case}",
         )
 
-    image_path = _get_camera_image_path(case, map_id)
+    image_path = _get_camera_image_path(case, map_id, session)
     if image_path is None or not image_path.exists():
         raise HTTPException(
             status_code=404,
@@ -1022,6 +1021,7 @@ def api_map_tile(
     size: int = Query(256, ge=1, le=4096),
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> Response:
     """Get a map GeoTIFF tile at specified coordinates and zoom level.
 
@@ -1030,14 +1030,14 @@ def api_map_tile(
     """
     # Resolve the file path once to avoid TOCTOU race between info lookup
     # and the actual tile read.
-    geotiff_path = _get_map_geotiff_file(tenant_id)
+    geotiff_path = _get_map_geotiff_file(tenant_id, session)
     if geotiff_path is None:
         raise HTTPException(
             status_code=404,
             detail="Map GeoTIFF not found for tenant",
         )
 
-    info = _get_map_info(tenant_id)
+    info = _get_map_info(tenant_id, session)
     if info is None:
         raise HTTPException(
             status_code=404,

--- a/api/routers/homography_precision.py
+++ b/api/routers/homography_precision.py
@@ -70,12 +70,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/homography-precision", tags=["homography-precision"])
 
 # ---------------------------------------------------------------------------
-# Caches
+# Types
 # ---------------------------------------------------------------------------
 
 
-class ImageInfoCache(TypedDict):
-    """Cache entry for image information."""
+class ImageInfo(TypedDict):
+    """Image metadata returned by info helpers."""
 
     width: int
     height: int
@@ -83,9 +83,6 @@ class ImageInfoCache(TypedDict):
     geotransform: list[float] | None
     crs: str | None
 
-
-_line_registry_cache: dict[str, list[Line]] = {}
-_image_info_cache: dict[str, ImageInfoCache] = {}
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -160,15 +157,11 @@ def _get_map_geotiff_file(tenant_id: str, session: Session) -> Path | None:
 
 
 def _load_line_registry(tenant_id: str, session: Session) -> list[Line]:
-    """Load and cache line registry from DDD repo."""
-    if tenant_id in _line_registry_cache:
-        return _line_registry_cache[tenant_id]
+    """Load line registry from the PG repo."""
     map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         return []
-    lines = from_line_repo_pg(session, map_entity.id)
-    _line_registry_cache[tenant_id] = lines
-    return lines
+    return from_line_repo_pg(session, map_entity.id)
 
 
 def _load_test_case_by_name(name: str, map_id: str | None, session: Session) -> dict | None:
@@ -243,18 +236,14 @@ def _get_camera_image_path(test_case_name: str, map_id: str | None, session: Ses
     return get_frame_image_path(frame)
 
 
-def _get_camera_info(test_case_name: str, map_id: str | None, session: Session) -> ImageInfoCache | None:
-    """Get cached camera image info, loading if necessary."""
-    cache_key = f"camera:{test_case_name}"
-    if cache_key in _image_info_cache:
-        return _image_info_cache[cache_key]
-
+def _get_camera_info(test_case_name: str, map_id: str | None, session: Session) -> ImageInfo | None:
+    """Get camera image metadata."""
     image_path = _get_camera_image_path(test_case_name, map_id, session)
     if image_path is None or not image_path.exists():
         return None
 
     with Image.open(image_path) as img:
-        info: ImageInfoCache = {
+        return {
             "width": img.width,
             "height": img.height,
             "filename": image_path.name,
@@ -262,16 +251,9 @@ def _get_camera_info(test_case_name: str, map_id: str | None, session: Session) 
             "crs": None,
         }
 
-    _image_info_cache[cache_key] = info
-    return info
 
-
-def _get_map_info(tenant_id: str, session: Session) -> ImageInfoCache | None:
-    """Get cached map GeoTIFF info, loading if necessary."""
-    cache_key = f"map:geotiff:{tenant_id}"
-    if cache_key in _image_info_cache:
-        return _image_info_cache[cache_key]
-
+def _get_map_info(tenant_id: str, session: Session) -> ImageInfo | None:
+    """Get map GeoTIFF metadata."""
     geotiff_path = _get_map_geotiff_file(tenant_id, session)
     if geotiff_path is None or not geotiff_path.exists():
         return None
@@ -282,16 +264,13 @@ def _get_map_info(tenant_id: str, session: Session) -> ImageInfoCache | None:
         height: int = page.imagelength  # type: ignore[union-attr]
         geotiff = extract_geotiff(tif)
 
-        info: ImageInfoCache = {
+        return {
             "width": width,
             "height": height,
             "filename": geotiff_path.name,
             "geotransform": geotiff.geotransform.to_list() if geotiff else None,
             "crs": geotiff.crs if geotiff else None,
         }
-
-    _image_info_cache[cache_key] = info
-    return info
 
 
 def _perpendicular_distance(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> float:

--- a/api/routers/homography_precision.py
+++ b/api/routers/homography_precision.py
@@ -13,10 +13,11 @@ import numpy as np
 import tifffile
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
 from homography_web.frame_utils import (
     CALIBRATIONS_DIR,
     DATA_MAPS_DIR,
-    GCPS_DIR,
     LINES_DIR,
     extract_geotiff,
     get_frame_image_path,
@@ -33,7 +34,7 @@ from homography_web.frame_utils import (
 from line_picker.state import Line, from_line_repo
 from PIL import Image
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.utils.tiles import render_tile
 from api.schemas.homography_precision import (
     CameraInfoResponse,
@@ -64,7 +65,7 @@ from poc_homography.calibration.lens_distortion.calibration_table import load_ca
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.homography.map_points import MapPointHomography
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.map_points.gcp_registry import from_gcp_repo
+from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
 logger = logging.getLogger(__name__)
 
@@ -376,6 +377,7 @@ def api_compute_homography(
     body: ComputeHomographyRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> ComputeHomographyResponse | JSONResponse:
     """Compute point-based homography with metrics, per-point errors, and overlays."""
     test_case_name = body.test_case_name
@@ -399,7 +401,7 @@ def api_compute_homography(
     if map_id is None:
         return _no_map_error()
     try:
-        registry = from_gcp_repo(GCPS_DIR, map_id)
+        registry = from_gcp_repo_pg(session, map_id)
     except (KeyError, ValueError, OSError) as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to load GCP registry: {e}"
@@ -519,13 +521,14 @@ def api_compute_homography(
 def api_gcp_registry(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> GCPRegistryResponse | JSONResponse:
     """Get the GCP registry for the tenant's map."""
     map_id = _require_map_id(tenant_id)
     if map_id is None:
         return _no_map_error()
     try:
-        registry = from_gcp_repo(GCPS_DIR, map_id)
+        registry = from_gcp_repo_pg(session, map_id)
     except (KeyError, ValueError, OSError) as e:
         raise HTTPException(status_code=500, detail=f"Failed to load GCP registry: {e}")
 
@@ -687,6 +690,7 @@ def api_compute_line_errors(
     body: ComputeLineErrorsRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> ComputeLineErrorsResponse | JSONResponse:
     """Compute line errors from a line test case.
 
@@ -771,7 +775,7 @@ def api_compute_line_errors(
         if map_id_for_gcps is None:
             return _no_map_error()
         try:
-            gcp_registry = from_gcp_repo(GCPS_DIR, map_id_for_gcps)
+            gcp_registry = from_gcp_repo_pg(session, map_id_for_gcps)
         except (KeyError, ValueError, OSError) as e:
             raise HTTPException(
                 status_code=500, detail=f"Failed to load GCP registry: {e}"

--- a/api/routers/lens_calibration.py
+++ b/api/routers/lens_calibration.py
@@ -11,18 +11,7 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from homography_web.calibration_utils import (
-    list_calibration_ids,
-    load_calibration_from_repo,
-    save_calibration_to_repo,
-    serialize_calibration_entry,
-)
-from homography_web.frame_utils import (
-    CALIBRATIONS_DIR,
-    get_line_annotation_repo,
-    get_map_from_tenant_id,
-)
-
+from homography_web.calibration_utils import serialize_calibration_entry
 from sqlalchemy.orm import Session
 
 from api.deps import get_current_user, get_db_session
@@ -41,8 +30,13 @@ from api.schemas.lens_calibration import (
     ValidateRequest,
     ValidateResponse,
 )
+from api.utils.frame_helpers import get_map_for_tenant
 from poc_homography.infrastructure.models.user import UserModel
-from poc_homography.infrastructure.repositories import RepoPostgresCalibrationLineTraceSet
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresCalibrationLineTraceSet,
+    RepoPostgresLensCalibrationTable,
+    RepoPostgresLineAnnotation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -296,6 +290,7 @@ def validate_calibration(
 @router.post("/api/save/", response_model=SaveCalibrationResponse)
 def save_calibration(
     body: SaveCalibrationRequest,
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> SaveCalibrationResponse:
     """Save calibration results via the DDD repo."""
@@ -304,6 +299,7 @@ def save_calibration(
             CameraCalibrationTable,
             ZoomCalibrationEntry,
         )
+        from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo_pg
         from poc_homography.domain.vo import LensDistortion
         from poc_homography.types import Unitless
 
@@ -330,7 +326,7 @@ def save_calibration(
         )
         table.add_entry(entry)
 
-        save_calibration_to_repo(table, CALIBRATIONS_DIR)
+        sync_to_ddd_repo_pg(table, session)
 
         return SaveCalibrationResponse(success=True, camera_id=body.camera_id)
 
@@ -347,6 +343,7 @@ def save_calibration(
 @router.post("/api/load/", response_model=LoadCalibrationResponse)
 def load_calibration(
     body: LoadCalibrationRequest,
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LoadCalibrationResponse:
     """Load calibration from DDD repo by camera_id."""
@@ -354,7 +351,8 @@ def load_calibration(
         raise HTTPException(status_code=400, detail="Missing camera_id")
 
     try:
-        entity = load_calibration_from_repo(body.camera_id, CALIBRATIONS_DIR)
+        repo = RepoPostgresLensCalibrationTable(session)
+        entity = repo.get(body.camera_id)
         if entity is None:
             raise HTTPException(
                 status_code=404,
@@ -365,9 +363,6 @@ def load_calibration(
 
         return LoadCalibrationResponse(camera_id=entity.id, entries=entries)
 
-    except ImportError:
-        logger.exception("Calibration module not available")
-        raise HTTPException(status_code=500, detail="Calibration module not available")
     except HTTPException:
         raise
     except Exception:
@@ -377,11 +372,13 @@ def load_calibration(
 
 @router.get("/api/calibration-ids/", response_model=CalibrationIdsResponse)
 def calibration_ids(
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> CalibrationIdsResponse:
     """List available camera_ids in the calibration repo."""
     try:
-        camera_ids = list_calibration_ids(CALIBRATIONS_DIR)
+        repo = RepoPostgresLensCalibrationTable(session)
+        camera_ids = sorted(entity.id for entity in repo.get_all())
         return CalibrationIdsResponse(camera_ids=camera_ids)
     except Exception:
         logger.exception("Failed to list calibration IDs")
@@ -463,9 +460,10 @@ def line_trace_sets(
         entities = repo.get_all()
         names = sorted(e.name for e in entities)
 
-        map_entity = get_map_from_tenant_id(tenant_id)
+        map_entity = get_map_for_tenant(tenant_id, session)
         map_id = map_entity.id if map_entity else None
-        all_frame_ids = {ann.frame_id for ann in get_line_annotation_repo().get_all()}
+        line_ann_repo = RepoPostgresLineAnnotation(session)
+        all_frame_ids = {ann.frame_id for ann in line_ann_repo.get_all()}
         if map_id:
             all_frame_ids = {fid for fid in all_frame_ids if fid.startswith(map_id + "/")}
         frame_ids = sorted(all_frame_ids)
@@ -499,11 +497,12 @@ def line_trace_set_detail(
             )
 
         # Fall back to LineAnnotation entities matching this frame_id (tenant-scoped)
-        map_entity = get_map_from_tenant_id(tenant_id)
+        map_entity = get_map_for_tenant(tenant_id, session)
         map_id = map_entity.id if map_entity else None
+        line_ann_repo = RepoPostgresLineAnnotation(session)
         frame_anns = [
             ann
-            for ann in get_line_annotation_repo().get_all()
+            for ann in line_ann_repo.get_all()
             if ann.frame_id == name and (not map_id or name.startswith(map_id + "/"))
         ]
         if frame_anns:

--- a/api/routers/lens_calibration.py
+++ b/api/routers/lens_calibration.py
@@ -18,13 +18,14 @@ from homography_web.calibration_utils import (
     serialize_calibration_entry,
 )
 from homography_web.frame_utils import (
-    CALIBRATION_LINE_TRACES_DIR,
     CALIBRATIONS_DIR,
     get_line_annotation_repo,
     get_map_from_tenant_id,
 )
 
-from api.deps import get_current_user
+from sqlalchemy.orm import Session
+
+from api.deps import get_current_user, get_db_session
 from api.schemas.lens_calibration import (
     CalibrateAnnotatedLinesRequest,
     CalibrateAnnotatedLinesResponse,
@@ -41,26 +42,9 @@ from api.schemas.lens_calibration import (
     ValidateResponse,
 )
 from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.repositories import RepoPostgresCalibrationLineTraceSet
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Cached repo
-# ---------------------------------------------------------------------------
-
-_line_trace_set_repo = None
-
-
-def _get_line_trace_set_repo():
-    """Return a cached ``RepoYamlCalibrationLineTraceSet`` instance."""
-    global _line_trace_set_repo
-    if _line_trace_set_repo is None:
-        from poc_homography.infrastructure.repositories import (
-            RepoYamlCalibrationLineTraceSet,
-        )
-
-        _line_trace_set_repo = RepoYamlCalibrationLineTraceSet(CALIBRATION_LINE_TRACES_DIR)
-    return _line_trace_set_repo
 
 
 # ---------------------------------------------------------------------------
@@ -466,6 +450,7 @@ def compute_intrinsics(
 @router.get("/api/line-trace-sets/", response_model=LineTraceSetsResponse)
 def line_trace_sets(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineTraceSetsResponse:
     """List available line trace sources.
@@ -474,7 +459,7 @@ def line_trace_sets(
     groups so that annotations created via camera_line_annotator also appear.
     """
     try:
-        repo = _get_line_trace_set_repo()
+        repo = RepoPostgresCalibrationLineTraceSet(session)
         entities = repo.get_all()
         names = sorted(e.name for e in entities)
 
@@ -495,6 +480,7 @@ def line_trace_sets(
 def line_trace_set_detail(
     name: str = Query(...),
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineTraceSetDetailResponse:
     """Load line traces by name.
@@ -504,7 +490,7 @@ def line_trace_set_detail(
     """
     try:
         # Try CalibrationLineTraceSet first
-        repo = _get_line_trace_set_repo()
+        repo = RepoPostgresCalibrationLineTraceSet(session)
         entity = repo.get(name)
         if entity is not None:
             return LineTraceSetDetailResponse(

--- a/api/routers/line_picker.py
+++ b/api/routers/line_picker.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from homography_web.frame_utils import LINES_DIR
+from sqlalchemy.orm import Session
 from webapp.line_picker.state import (
-    delete_line_from_repo,
+    delete_line_from_repo_pg,
     get_state,
-    save_line_to_repo,
+    save_line_to_repo_pg,
 )
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.line_picker import (
     AddLineRequest,
     DeleteLineResponse,
@@ -38,10 +38,11 @@ router = APIRouter(prefix="/line-picker", tags=["line-picker"])
 @router.get("/api/image/info/", response_model=ImageInfoResponse)
 def image_info(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> ImageInfoResponse:
     """Return image metadata (dimensions, geotransform, CRS, filename)."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     return ImageInfoResponse(
         width=state.width,
         height=state.height,
@@ -58,13 +59,14 @@ def image_tile(
     y: int = Query(0),
     z: int = Query(0),
     size: int = Query(256, ge=1, le=4096),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Return an OpenSeadragon tile as a PNG image.
 
     At level *z* the image appears at resolution ``original / 2^(max_level - z)``.
     """
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     png_bytes = render_tile(
         image_path=state.geotiff_path,
         width=state.width,
@@ -78,10 +80,11 @@ def image_tile(
 def image_full(
     tenant_id: str = Query(...),
     max_size: int = Query(2048, ge=1, le=8192),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> Response:
     """Return the full image scaled to *max_size* as a PNG."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     png_bytes = render_full_image(image_path=state.geotiff_path, max_size=max_size)
     return Response(content=png_bytes, media_type="image/png")
 
@@ -94,10 +97,11 @@ def image_full(
 @router.get("/api/lines/", response_model=LineListResponse)
 def list_lines(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineListResponse:
     """List all lines for the tenant's map."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     return LineListResponse(
         map_id=state.map_id,
         lines=[
@@ -117,23 +121,24 @@ def list_lines(
 def add_line(
     body: AddLineRequest,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineOut:
     """Add a new line.
 
-    Persists to the YAML repo before mutating in-memory state so a failed
-    write never leaves state and disk out of sync.
+    Persists to the database before mutating in-memory state so a failed
+    write never leaves state and DB out of sync.
     """
     start_x = float(body.start_x)
     start_y = float(body.start_y)
     end_x = float(body.end_x)
     end_y = float(body.end_y)
 
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     try:
         resolved_id = body.line_id if body.line_id is not None else state.get_next_id()
-        save_line_to_repo(resolved_id, start_x, start_y, end_x, end_y, state.map_id, LINES_DIR)
+        save_line_to_repo_pg(resolved_id, start_x, start_y, end_x, end_y, state.map_id, session)
         state.add_line(start_x, start_y, end_x, end_y, line_id=resolved_id)
 
         return LineOut(
@@ -152,13 +157,14 @@ def update_line(
     line_id: str,
     body: UpdateLineRequest,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> LineOut:
     """Update the coordinate endpoints of an existing line.
 
     Supports partial updates -- only provided fields are changed.
     """
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     line = state.get_line(line_id)
     if line is None:
@@ -174,8 +180,8 @@ def update_line(
     if new_start_x == new_end_x and new_start_y == new_end_y:
         raise HTTPException(status_code=422, detail="Start and end points must be different")
 
-    # Persist to YAML repo before mutating in-memory state
-    save_line_to_repo(line_id, new_start_x, new_start_y, new_end_x, new_end_y, state.map_id, LINES_DIR)
+    # Persist to DB before mutating in-memory state
+    save_line_to_repo_pg(line_id, new_start_x, new_start_y, new_end_x, new_end_y, state.map_id, session)
     line.start_x = new_start_x
     line.start_y = new_start_y
     line.end_x = new_end_x
@@ -194,14 +200,15 @@ def update_line(
 def delete_line(
     line_id: str,
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> DeleteLineResponse:
     """Delete a line."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     try:
-        # Persist to YAML repo before mutating in-memory state
-        delete_line_from_repo(line_id, state.map_id, LINES_DIR)
+        # Persist to DB before mutating in-memory state
+        delete_line_from_repo_pg(line_id, state.map_id, session)
         state.delete_line(line_id)
         return DeleteLineResponse(deleted=line_id)
     except KeyError:
@@ -216,10 +223,11 @@ def delete_line(
 @router.get("/api/lines/next-id/", response_model=NextLineIdResponse)
 def next_line_id(
     tenant_id: str = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> NextLineIdResponse:
     """Return the next auto-incremented line ID."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     return NextLineIdResponse(next_id=state.get_next_id())
 
 
@@ -228,10 +236,11 @@ def geo_coords(
     tenant_id: str = Query(...),
     pixel_x: float = Query(...),
     pixel_y: float = Query(...),
+    session: Session = Depends(get_db_session),
     user: UserModel = Depends(get_current_user),
 ) -> GeoCoordsResponse:
     """Convert pixel coordinates to geographic coordinates."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     if state.geotiff is None:
         return GeoCoordsResponse(easting=None, northing=None, crs=None)

--- a/api/routers/point_picker.py
+++ b/api/routers/point_picker.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from homography_web.frame_utils import GCPS_DIR
+from sqlalchemy.orm import Session
 
-from api.deps import get_current_user
+from api.deps import get_current_user, get_db_session
 from api.schemas.point_picker import (
     AddPointRequest,
     DeletePointResponse,
@@ -19,10 +19,10 @@ from api.schemas.point_picker import (
 from api.utils.tiles import render_full_image, render_tile
 from poc_homography.infrastructure.models.user import UserModel
 from webapp.point_picker.state import (
-    delete_gcp_from_repo,
+    delete_gcp_from_repo_pg,
     get_state,
     get_tag_from_id,
-    save_gcp_to_repo,
+    save_gcp_to_repo_pg,
 )
 from webapp.point_picker.validation import (
     validate_add_point_request,
@@ -44,9 +44,10 @@ router = APIRouter(prefix="/point-picker", tags=["point-picker"])
 def image_info(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> ImageInfoResponse:
     """Return image metadata (dimensions, geotransform, CRS, filename)."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     return ImageInfoResponse(
         width=state.width,
         height=state.height,
@@ -64,12 +65,13 @@ def image_tile(
     z: int = Query(0),
     size: int = Query(256, ge=1, le=4096),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> Response:
     """Return an OpenSeadragon tile as a PNG image.
 
     At level *z* the image appears at resolution ``original / 2^(max_level - z)``.
     """
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     png_bytes = render_tile(
         image_path=state.geotiff_path,
         width=state.width,
@@ -84,9 +86,10 @@ def image_full(
     tenant_id: str = Query(...),
     max_size: int = Query(2048, ge=1, le=8192),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> Response:
     """Return the full image scaled to *max_size* as a PNG."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     png_bytes = render_full_image(image_path=state.geotiff_path, max_size=max_size)
     return Response(content=png_bytes, media_type="image/png")
 
@@ -100,9 +103,10 @@ def image_full(
 def list_points(
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> PointListResponse:
     """List all GCPs for the tenant's map."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     return PointListResponse(
         map_id=state.registry.map_id,
         points=[
@@ -122,18 +126,19 @@ def add_point(
     body: AddPointRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> PointOut:
     """Add a new GCP.
 
-    Persists to the YAML repo before mutating in-memory state so a failed
-    write never leaves state and disk out of sync.
+    Persists to the database before mutating in-memory state so a failed
+    write never leaves state and DB out of sync.
     """
     data = body.model_dump()
     error = validate_add_point_request(data)
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     tag = data.get("tag", "extra")
     pixel_x = float(data["pixel_x"])
@@ -141,7 +146,7 @@ def add_point(
     point_id = data.get("id")
 
     resolved_id = point_id if point_id is not None else state.get_next_id(tag)
-    save_gcp_to_repo(resolved_id, pixel_x, pixel_y, state.map_id, GCPS_DIR)
+    save_gcp_to_repo_pg(resolved_id, pixel_x, pixel_y, state.map_id, session)
     point_id = state.add_point(tag, pixel_x, pixel_y, point_id=resolved_id)
     point = state.registry.points[point_id]
 
@@ -159,6 +164,7 @@ def update_point(
     body: UpdatePointRequest,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> PointOut:
     """Update the pixel coordinates of an existing GCP."""
     data = body.model_dump()
@@ -166,13 +172,13 @@ def update_point(
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     px = float(data["pixel_x"])
     py = float(data["pixel_y"])
 
     try:
-        save_gcp_to_repo(point_id, px, py, state.map_id, GCPS_DIR)
+        save_gcp_to_repo_pg(point_id, px, py, state.map_id, session)
         state.update_point(point_id, px, py)
         point = state.registry.points[point_id]
         return PointOut(
@@ -190,14 +196,15 @@ def delete_point(
     point_id: str,
     tenant_id: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> DeletePointResponse:
     """Delete a GCP."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
 
     if point_id not in state.registry.points:
         raise HTTPException(status_code=404, detail=f"Point not found: {point_id}")
 
-    delete_gcp_from_repo(point_id, state.map_id, GCPS_DIR)
+    delete_gcp_from_repo_pg(point_id, state.map_id, session)
     state.delete_point(point_id)
     return DeletePointResponse(deleted=point_id)
 
@@ -212,9 +219,10 @@ def next_id(
     tenant_id: str = Query(...),
     tag: str = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> NextIdResponse:
     """Return the next auto-incremented ID for a tag category."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     try:
         nid = state.get_next_id(tag)
         return NextIdResponse(tag=tag, next_id=nid)
@@ -228,9 +236,10 @@ def geo_coords(
     pixel_x: float = Query(...),
     pixel_y: float = Query(...),
     user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
 ) -> GeoCoordsResponse:
     """Convert pixel coordinates to geographic coordinates."""
-    state = get_state(tenant_id)
+    state = get_state(tenant_id, session)
     coords = state.get_geo_coords(pixel_x, pixel_y)
     if coords:
         return GeoCoordsResponse(

--- a/api/utils/frame_helpers.py
+++ b/api/utils/frame_helpers.py
@@ -11,11 +11,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homography_web.frame_utils import (
-    CALIBRATION_LINE_TRACES_DIR,
     CALIBRATIONS_DIR,
     DATA_MAPS_DIR,
     FRAMES_DIR,
-    LINES_DIR,
     WEBAPP_DIR,
     extract_geotiff,
     normalize_array,
@@ -31,15 +29,14 @@ from poc_homography.infrastructure.repositories import (
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from poc_homography.domain.entities.annotation import Annotation
     from poc_homography.domain.entities.captured_frame import CapturedFrame
     from poc_homography.domain.entities.map import Map
 
 __all__ = [
     "CALIBRATIONS_DIR",
-    "CALIBRATION_LINE_TRACES_DIR",
     "DATA_MAPS_DIR",
     "FRAMES_DIR",
-    "LINES_DIR",
     "WEBAPP_DIR",
     "extract_geotiff",
     "get_frame_image_path",
@@ -51,6 +48,7 @@ __all__ = [
     "load_line_annotations_for_frame",
     "normalize_array",
     "resolve_map_for_tenant",
+    "save_annotations_for_frame",
     "validate_image_filename",
 ]
 
@@ -128,6 +126,13 @@ def load_annotations_for_frame(frame_id: str, session: Session) -> list[dict]:
         }
         for ann in annotations
     ]
+
+
+def save_annotations_for_frame(
+    frame_id: str, annotations: list[Annotation], session: Session
+) -> None:
+    """Persist point annotations for *frame_id*."""
+    _frame_repo(session).save_annotations(frame_id, annotations)
 
 
 def load_line_annotations_for_frame(frame_id: str, session: Session) -> list[dict]:

--- a/api/utils/frame_helpers.py
+++ b/api/utils/frame_helpers.py
@@ -1,0 +1,148 @@
+"""Session-aware frame, annotation, and line-annotation helpers for the API layer.
+
+Replaces the repo-backed functions in ``homography_web.frame_utils`` so that
+API routers never instantiate ``RepoYaml*`` classes.  Pure utilities and path
+constants are re-exported from ``frame_utils`` for convenience.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homography_web.frame_utils import (
+    CALIBRATION_LINE_TRACES_DIR,
+    CALIBRATIONS_DIR,
+    DATA_MAPS_DIR,
+    FRAMES_DIR,
+    LINES_DIR,
+    WEBAPP_DIR,
+    extract_geotiff,
+    normalize_array,
+    validate_image_filename,
+)
+
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresCapturedFrame,
+    RepoPostgresLineAnnotation,
+    RepoPostgresMap,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.domain.entities.captured_frame import CapturedFrame
+    from poc_homography.domain.entities.map import Map
+
+__all__ = [
+    "CALIBRATIONS_DIR",
+    "CALIBRATION_LINE_TRACES_DIR",
+    "DATA_MAPS_DIR",
+    "FRAMES_DIR",
+    "LINES_DIR",
+    "WEBAPP_DIR",
+    "extract_geotiff",
+    "get_frame_image_path",
+    "get_map_for_tenant",
+    "image_filename_to_frame",
+    "list_frames",
+    "list_image_filenames",
+    "load_annotations_for_frame",
+    "load_line_annotations_for_frame",
+    "normalize_array",
+    "resolve_map_for_tenant",
+    "validate_image_filename",
+]
+
+
+def get_map_for_tenant(tenant_id: str, session: Session) -> Map | None:
+    """Return the ``Map`` for *tenant_id*, or ``None``."""
+    repo = RepoPostgresMap(session)
+    maps = repo.get_by_tenant(tenant_id)
+    if maps:
+        return next(iter(maps.values()))
+    return None
+
+
+def resolve_map_for_tenant(tenant_id: str, session: Session) -> tuple[Map, Path]:
+    """Resolve the ``Map`` and its image file for *tenant_id*.
+
+    Raises:
+        RuntimeError: If no map is configured or the file is missing.
+    """
+    map_entity = get_map_for_tenant(tenant_id, session)
+    if map_entity is None:
+        raise RuntimeError(f"No map configured for tenant: {tenant_id}")
+
+    map_file = DATA_MAPS_DIR / map_entity.photo.path
+    if not map_file.exists():
+        raise RuntimeError(f"Map file not found: {map_file}")
+
+    return map_entity, map_file
+
+
+def _frame_repo(session: Session) -> RepoPostgresCapturedFrame:
+    return RepoPostgresCapturedFrame(session, frames_dir=FRAMES_DIR)
+
+
+def list_frames(session: Session, map_id: str | None = None) -> list[CapturedFrame]:
+    """Return captured frames, optionally filtered by *map_id*."""
+    repo = _frame_repo(session)
+    if map_id is not None:
+        return repo.get_by_map(map_id)
+    return repo.get_all()
+
+
+def image_filename_to_frame(
+    filename: str, session: Session, *, map_id: str | None = None
+) -> CapturedFrame | None:
+    """Look up a ``CapturedFrame`` by its image filename."""
+    for frame in list_frames(session, map_id):
+        if frame.image_path.name == filename:
+            return frame
+    return None
+
+
+def get_frame_image_path(frame: CapturedFrame) -> Path:
+    """Return the absolute path to a frame's image file."""
+    return FRAMES_DIR / frame.map_id / frame.camera_name / str(frame.image_path)
+
+
+def list_image_filenames(session: Session, map_id: str | None = None) -> list[str]:
+    """Return sorted image filenames from the captured-frame repo."""
+    return sorted(f.image_path.name for f in list_frames(session, map_id))
+
+
+def load_annotations_for_frame(frame_id: str, session: Session) -> list[dict]:
+    """Load point annotations for a frame in legacy dict format.
+
+    Returns list of ``{gcp_id, pixel_x, pixel_y}`` dicts.
+    """
+    repo = _frame_repo(session)
+    annotations = repo.get_annotations(frame_id)
+    return [
+        {
+            "gcp_id": ann.gcp_id,
+            "pixel_x": round(float(ann.pixel.x), 1),
+            "pixel_y": round(float(ann.pixel.y), 1),
+        }
+        for ann in annotations
+    ]
+
+
+def load_line_annotations_for_frame(frame_id: str, session: Session) -> list[dict]:
+    """Load line annotations for a frame in legacy dict format."""
+    repo = RepoPostgresLineAnnotation(session)
+    results: list[dict] = []
+    for ann in repo.get_by_frame_id(frame_id):
+        entry: dict = {
+            "line_id": ann.line_id,
+            "start_pixel_x": float(ann.start_pixel.x),
+            "start_pixel_y": float(ann.start_pixel.y),
+            "end_pixel_x": float(ann.end_pixel.x),
+            "end_pixel_y": float(ann.end_pixel.y),
+        }
+        if ann.points is not None:
+            entry["points"] = [[float(p.x), float(p.y)] for p in ann.points]
+        results.append(entry)
+    return results

--- a/api/utils/tiles.py
+++ b/api/utils/tiles.py
@@ -13,8 +13,9 @@ from pathlib import Path
 
 import numpy as np
 import tifffile
-from homography_web.frame_utils import normalize_array
 from PIL import Image
+
+from api.utils.frame_helpers import normalize_array
 
 
 def _read_tiff_as_rgb(image_path: Path, region: tuple[int, int, int, int] | None = None) -> Image.Image:
@@ -35,19 +36,19 @@ def _read_tiff_as_rgb(image_path: Path, region: tuple[int, int, int, int] | None
         # Apply region crop first (operates on the numpy array).
         if region is not None:
             x0, y0, x1, y1 = region
-            if data.ndim <= 3:  # noqa: PLR2004
+            if data.ndim <= 3:
                 # (H, W) or (H, W, C) -- spatial dims are the first two
                 data = data[y0:y1, x0:x1]
             else:
                 # Channel-first layout (C, H, W)
                 data = data[:, y0:y1, x0:x1]
 
-        if data.ndim == 2:  # noqa: PLR2004
+        if data.ndim == 2:
             img = Image.fromarray(normalize_array(data), mode="L")
             return img.convert("RGB")
 
-        if data.ndim == 3:  # noqa: PLR2004
-            if data.shape[2] >= 3:  # noqa: PLR2004
+        if data.ndim == 3:
+            if data.shape[2] >= 3:
                 return Image.fromarray(normalize_array(data[:, :, :3]), mode="RGB")
             img = Image.fromarray(normalize_array(data[:, :, 0]), mode="L")
             return img.convert("RGB")

--- a/poc_homography/calibration/lens_distortion/ddd_sync.py
+++ b/poc_homography/calibration/lens_distortion/ddd_sync.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from poc_homography.calibration.lens_distortion.calibration_table import (
         CameraCalibrationTable,
     )
@@ -88,3 +90,61 @@ def sync_to_ddd_repo(
     )
     repo.save(entity)
     logger.info(f"Synced calibration to DDD repo: {data_dir / f'{table.camera_id}.yaml'}")
+
+
+def sync_to_ddd_repo_pg(
+    table: CameraCalibrationTable,
+    session: Session,
+) -> None:
+    """Persist a legacy CameraCalibrationTable into the DDD PostgreSQL repo.
+
+    Merges with any existing entries for the same camera_id so that
+    multi-zoom calibration accumulates over time.
+    """
+    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+    from poc_homography.domain.vo.lens_distortion import LensDistortion
+    from poc_homography.domain.vo.zoom_calibration_entry import (
+        ZoomCalibrationEntry as DddEntry,
+    )
+    from poc_homography.infrastructure.repositories import RepoPostgresLensCalibrationTable
+    from poc_homography.types import PixelsFloat, Unitless
+
+    repo = RepoPostgresLensCalibrationTable(session)
+
+    existing = repo.get(table.camera_id)
+    existing_by_zoom: dict[float, DddEntry] = {}
+    if existing:
+        for e in existing.entries:
+            existing_by_zoom[float(e.zoom_factor)] = e
+
+    for legacy_entry in table.entries.values():
+        ddd_entry = DddEntry(
+            zoom_factor=Unitless(legacy_entry.zoom_factor),
+            distortion=LensDistortion(
+                k1=Unitless(legacy_entry.k1),
+                k2=Unitless(legacy_entry.k2),
+                p1=Unitless(legacy_entry.p1),
+                p2=Unitless(legacy_entry.p2),
+                k3=Unitless(legacy_entry.k3),
+            ),
+            calibration_date=legacy_entry.calibration_date,
+            source_images=tuple(legacy_entry.source_images),
+            validation_rmse=legacy_entry.validation_rmse,
+            num_lines_used=legacy_entry.num_lines_used,
+            fx=PixelsFloat(legacy_entry.fx),
+            fy=PixelsFloat(legacy_entry.fy),
+            cx=PixelsFloat(legacy_entry.cx),
+            cy=PixelsFloat(legacy_entry.cy),
+            reprojection_error_px=legacy_entry.reprojection_error_px,
+        )
+        existing_by_zoom[float(legacy_entry.zoom_factor)] = ddd_entry
+
+    now = datetime.now().isoformat()
+    entity = LensCalibrationTable(
+        id=table.camera_id,
+        entries=tuple(existing_by_zoom[z] for z in sorted(existing_by_zoom)),
+        created_date=existing.created_date if existing else now,
+        last_modified=now,
+    )
+    repo.save(entity)
+    logger.info("Synced calibration to PostgreSQL repo for camera: %s", table.camera_id)

--- a/poc_homography/camera_config.py
+++ b/poc_homography/camera_config.py
@@ -12,6 +12,12 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.infrastructure.repositories import RepoPostgresTenant
 
 # Legacy global credentials - kept for backwards compatibility
 # Prefer tenant-specific credentials defined in per-tenant env vars
@@ -30,6 +36,18 @@ def _get_tenant_repo():
     from poc_homography.infrastructure.repositories import RepoYamlTenant
 
     return RepoYamlTenant(_project_root() / "data" / "tenants")
+
+
+def _get_tenant_repo_pg(session: Session) -> RepoPostgresTenant:
+    """Create a PostgreSQL-backed tenant repository for the given session.
+
+    Unlike the YAML variant this is *not* cached because the repository is
+    bound to a specific SQLAlchemy session whose lifetime is managed by the
+    caller.
+    """
+    from poc_homography.infrastructure.repositories import RepoPostgresTenant as _Cls
+
+    return _Cls(session)
 
 
 # =============================================================================
@@ -423,6 +441,48 @@ def get_tenant_by_name(tenant_name: str) -> dict | None:
         Tenant configuration dict or None if not found
     """
     for tenant in _get_tenant_repo().get_all():
+        if tenant.name == tenant_name:
+            return _tenant_to_dict(tenant)
+    return None
+
+
+def get_tenants_pg(session: Session) -> list:
+    """Get list of all tenant configurations (PostgreSQL-backed).
+
+    Args:
+        session: SQLAlchemy session.
+
+    Returns:
+        List of tenant configuration dicts.
+    """
+    return [_tenant_to_dict(t) for t in _get_tenant_repo_pg(session).get_all()]
+
+
+def get_tenant_by_id_pg(session: Session, tenant_id: str) -> dict | None:
+    """Find tenant configuration by ID (PostgreSQL-backed).
+
+    Args:
+        session: SQLAlchemy session.
+        tenant_id: ID of the tenant (e.g., "valte", "setram").
+
+    Returns:
+        Tenant configuration dict or None if not found.
+    """
+    tenant = _get_tenant_repo_pg(session).get(tenant_id)
+    return _tenant_to_dict(tenant) if tenant else None
+
+
+def get_tenant_by_name_pg(session: Session, tenant_name: str) -> dict | None:
+    """Find tenant configuration by name (PostgreSQL-backed).
+
+    Args:
+        session: SQLAlchemy session.
+        tenant_name: Name of the tenant (e.g., "Valte", "Setram").
+
+    Returns:
+        Tenant configuration dict or None if not found.
+    """
+    for tenant in _get_tenant_repo_pg(session).get_all():
         if tenant.name == tenant_name:
             return _tenant_to_dict(tenant)
     return None

--- a/poc_homography/infrastructure/repositories/repo_postgres_line_annotation.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_line_annotation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
+
 from poc_homography.domain.entities.line_annotation import LineAnnotation
 from poc_homography.infrastructure.models.line_annotation import LineAnnotationModel
 from poc_homography.infrastructure.repositories.base import RepoPostgres
@@ -37,3 +39,9 @@ class RepoPostgresLineAnnotation(RepoPostgres[LineAnnotation]):
                 else None
             ),
         }
+
+    def get_by_frame_id(self, frame_id: str) -> list[LineAnnotation]:
+        """Return all line annotations belonging to *frame_id*."""
+        stmt = select(self._model_cls).where(LineAnnotationModel.frame_id == frame_id)
+        rows = self._session.execute(stmt).scalars().all()
+        return [self._row_to_entity(row) for row in rows]

--- a/poc_homography/map_points/gcp_registry.py
+++ b/poc_homography/map_points/gcp_registry.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+
 import yaml
 
 from poc_homography.map_points.map_point import MapPoint
@@ -259,8 +261,6 @@ def from_gcp_repo_pg(session: Session, map_id: str) -> GCPRegistry:
         GCPRegistry populated with the legacy MapPoint representation.
     """
     from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
-
-    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
 
     repo = RepoPostgresGroundControlPoint(session)
     gcps_by_id: dict[str, GroundControlPoint] = repo.get_by_map(map_id)  # type: ignore[assignment]

--- a/poc_homography/map_points/gcp_registry.py
+++ b/poc_homography/map_points/gcp_registry.py
@@ -260,8 +260,10 @@ def from_gcp_repo_pg(session: Session, map_id: str) -> GCPRegistry:
     """
     from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
 
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+
     repo = RepoPostgresGroundControlPoint(session)
-    gcps_by_id = repo.get_by_map(map_id)
+    gcps_by_id: dict[str, GroundControlPoint] = repo.get_by_map(map_id)  # type: ignore[assignment]
 
     points: dict[str, MapPoint] = {}
     for gcp in gcps_by_id.values():

--- a/poc_homography/map_points/gcp_registry.py
+++ b/poc_homography/map_points/gcp_registry.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 import yaml
 
@@ -236,5 +239,79 @@ def list_map_ids(data_dir: Path) -> list[str]:
     from poc_homography.infrastructure.repositories import RepoYamlGroundControlPoint
 
     repo = RepoYamlGroundControlPoint(data_dir)
+    all_gcps = repo.get_all()
+    return sorted({gcp.map_id for gcp in all_gcps})
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL-backed adapter functions
+# ---------------------------------------------------------------------------
+
+
+def from_gcp_repo_pg(session: Session, map_id: str) -> GCPRegistry:
+    """Load a GCPRegistry from the ``RepoPostgresGroundControlPoint`` repository.
+
+    Args:
+        session: SQLAlchemy session.
+        map_id: Map identifier to filter GCPs by.
+
+    Returns:
+        GCPRegistry populated with the legacy MapPoint representation.
+    """
+    from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
+
+    repo = RepoPostgresGroundControlPoint(session)
+    gcps_by_id = repo.get_by_map(map_id)
+
+    points: dict[str, MapPoint] = {}
+    for gcp in gcps_by_id.values():
+        mp = gcp.map_point
+        points[gcp.name] = MapPoint(
+            pixel_x=float(mp.pixel_point.x),
+            pixel_y=float(mp.pixel_point.y),
+        )
+
+    return GCPRegistry(map_id=map_id, points=points)
+
+
+def save_to_gcp_repo_pg(registry: GCPRegistry, session: Session) -> None:
+    """Save a GCPRegistry to the ``RepoPostgresGroundControlPoint`` repository.
+
+    Each point in the registry is converted to a ``GroundControlPoint`` entity
+    and persisted via the PostgreSQL repository.
+
+    Args:
+        registry: The legacy registry to persist.
+        session: SQLAlchemy session.
+    """
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+    from poc_homography.domain.vo.map_point import MapPoint as DomainMapPoint
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+    from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
+
+    repo = RepoPostgresGroundControlPoint(session)
+    for name, point in registry.points.items():
+        gcp = GroundControlPoint(
+            name=name,
+            map_point=DomainMapPoint(
+                map_id=registry.map_id,
+                pixel_point=PixelPoint.create(point.pixel_x, point.pixel_y),
+            ),
+        )
+        repo.save(gcp)
+
+
+def list_map_ids_pg(session: Session) -> list[str]:
+    """Return sorted unique map IDs found in the PostgreSQL GCP repository.
+
+    Args:
+        session: SQLAlchemy session.
+
+    Returns:
+        Sorted list of unique map_id strings.
+    """
+    from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
+
+    repo = RepoPostgresGroundControlPoint(session)
     all_gcps = repo.get_all()
     return sorted({gcp.map_id for gcp in all_gcps})

--- a/scripts/test-spa.sh
+++ b/scripts/test-spa.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── SPA Testing Session Bootstrap ────────────────────────────────────
+# Starts the FastAPI backend + Vite dev server and ensures a test user
+# exists in the database. Opens the browser when ready.
+#
+# Usage:
+#   ./scripts/test-spa.sh              # default: user=admin pass=admin
+#   ./scripts/test-spa.sh myuser mypass
+#
+# Prerequisites:
+#   - DATABASE_URL env var set (or .env file with it)
+#   - uv installed
+#   - node/npm installed
+#   - spa/node_modules installed (script runs npm install if missing)
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPA_DIR="$PROJECT_ROOT/spa"
+TEST_USER="${1:-admin}"
+TEST_PASS="${2:-admin}"
+
+API_PORT=8000
+SPA_PORT=5173
+
+cleanup() {
+    echo ""
+    echo "Shutting down..."
+    [ -n "${API_PID:-}" ] && kill "$API_PID" 2>/dev/null || true
+    [ -n "${SPA_PID:-}" ] && kill "$SPA_PID" 2>/dev/null || true
+    wait 2>/dev/null
+    echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+# ── 1. Check prerequisites ───────────────────────────────────────────
+
+if ! command -v uv &>/dev/null; then
+    echo "Error: uv not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
+if ! command -v node &>/dev/null; then
+    echo "Error: node not found. Install Node.js >= 18."
+    exit 1
+fi
+
+if [ ! -f "$SPA_DIR/package.json" ]; then
+    echo "Error: spa/package.json not found. Is the SPA scaffolded?"
+    exit 1
+fi
+
+# ── 2. Check DATABASE_URL ────────────────────────────────────────────
+
+if [ -z "${DATABASE_URL:-}" ]; then
+    if [ -f "$PROJECT_ROOT/.env" ]; then
+        # shellcheck disable=SC2046
+        export $(grep -v '^\s*#' "$PROJECT_ROOT/.env" | grep 'DATABASE_URL' | xargs)
+    fi
+fi
+
+if [ -z "${DATABASE_URL:-}" ]; then
+    echo "Error: DATABASE_URL is not set."
+    echo "Set it in your environment or add it to .env"
+    exit 1
+fi
+
+echo "DATABASE_URL is set."
+
+# ── 3. Run Alembic migrations ────────────────────────────────────────
+
+echo "Running database migrations..."
+cd "$PROJECT_ROOT"
+uv run alembic upgrade head
+
+# ── 4. Seed test user (idempotent) ───────────────────────────────────
+
+echo "Ensuring test user '$TEST_USER' exists..."
+cd "$PROJECT_ROOT"
+uv run python -c "
+import uuid, bcrypt, sys
+from poc_homography.infrastructure.database import get_sessionmaker
+from poc_homography.infrastructure.models.user import UserModel
+
+session = get_sessionmaker()()
+try:
+    existing = session.query(UserModel).filter(UserModel.username == '$TEST_USER').first()
+    if existing:
+        print(f'User \"$TEST_USER\" already exists (id={existing.id}).')
+    else:
+        pw_hash = bcrypt.hashpw(b'$TEST_PASS', bcrypt.gensalt()).decode()
+        # Pick the first tenant from the database
+        from poc_homography.infrastructure.repositories import RepoPostgresTenant
+        tenants = RepoPostgresTenant(session).get_all()
+        if not tenants:
+            print('Warning: no tenants found in the database.', file=sys.stderr)
+            sys.exit(1)
+        tenant_id = tenants[0].id
+        user = UserModel(
+            id=str(uuid.uuid4()),
+            username='$TEST_USER',
+            hashed_password=pw_hash,
+            tenant_id=tenant_id,
+            is_active=True,
+        )
+        session.add(user)
+        session.commit()
+        print(f'Created user \"$TEST_USER\" (tenant={tenant_id}).')
+finally:
+    session.close()
+"
+
+# ── 5. Install SPA dependencies (if needed) ─────────────────────────
+
+if [ ! -d "$SPA_DIR/node_modules" ]; then
+    echo "Installing SPA dependencies..."
+    cd "$SPA_DIR"
+    npm install --legacy-peer-deps
+fi
+
+# ── 6. Kill any existing processes on our ports ──────────────────────
+
+for port in $API_PORT $SPA_PORT; do
+    pid=$(lsof -ti :"$port" 2>/dev/null || true)
+    if [ -n "$pid" ]; then
+        echo "Port $port in use (pid $pid), stopping it..."
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+done
+
+# ── 7. Start FastAPI backend ─────────────────────────────────────────
+
+echo "Starting FastAPI backend on port $API_PORT..."
+cd "$PROJECT_ROOT"
+uv run uvicorn api.main:app --reload --port "$API_PORT" &
+API_PID=$!
+
+# ── 8. Start Vite dev server ─────────────────────────────────────────
+
+echo "Starting Vite dev server on port $SPA_PORT..."
+cd "$SPA_DIR"
+npm run dev -- --port "$SPA_PORT" &
+SPA_PID=$!
+
+# ── 9. Wait for both servers to be ready ─────────────────────────────
+
+echo "Waiting for servers..."
+
+for i in $(seq 1 30); do
+    if curl -sf "http://localhost:$API_PORT/health" >/dev/null 2>&1; then
+        echo "  FastAPI ready."
+        break
+    fi
+    sleep 1
+done
+
+for i in $(seq 1 20); do
+    if curl -sf "http://localhost:$SPA_PORT/" >/dev/null 2>&1; then
+        echo "  Vite ready."
+        break
+    fi
+    sleep 1
+done
+
+# ── 10. Open browser ─────────────────────────────────────────────────
+
+URL="http://localhost:$SPA_PORT"
+echo ""
+echo "=========================================="
+echo "  SPA ready at: $URL"
+echo "  Login with:   $TEST_USER / $TEST_PASS"
+echo "=========================================="
+echo ""
+
+if command -v open &>/dev/null; then
+    open "$URL"
+elif command -v xdg-open &>/dev/null; then
+    xdg-open "$URL"
+fi
+
+echo "Press Ctrl+C to stop both servers."
+wait

--- a/spa/src/pages/DashboardPage.tsx
+++ b/spa/src/pages/DashboardPage.tsx
@@ -109,35 +109,13 @@ export default function DashboardPage() {
       {!loading && !hasMaps && selectedTenantId && (
         <div className={styles.noMapWarning}>
           <strong>
-            No map configured for tenant &ldquo;{selectedTenantId}&rdquo;
+            No map data available for tenant &ldquo;{selectedTenantId}&rdquo;
           </strong>
-          Map-dependent tools are disabled. To set up a map for this tenant:
-          <ol>
-            <li>
-              Place a GeoTIFF file in the project root (e.g.{' '}
-              <code>my_map.tif</code>)
-            </li>
-            <li>
-              Create a map YAML file at <code>data/maps/&lt;name&gt;.yaml</code>{' '}
-              with:
-              <pre>{`id: my_map          # must match the .tif filename (without extension)
-tenant_id: ${selectedTenantId}
-photo:
-  path: my_map.png
-  width: ...         # image width in pixels
-  height: ...        # image height in pixels
-geotiff:
-  geotransform:
-    origin_easting: ...
-    pixel_width: ...
-    row_rotation: 0.0
-    origin_northing: ...
-    col_rotation: 0.0
-    pixel_height: ...
-  crs: EPSG:25830`}</pre>
-            </li>
-            <li>Restart the server</li>
-          </ol>
+          <p>
+            Map-dependent tools require GCP data to be configured for this
+            tenant&apos;s map. Contact an administrator to set up map and GCP
+            data.
+          </p>
         </div>
       )}
 

--- a/tests/test_api/test_gcp.py
+++ b/tests/test_api/test_gcp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from poc_homography.domain.entities.map import Map
 from poc_homography.domain.entities.tenant import Tenant
@@ -46,7 +46,7 @@ def _make_map(mid: str = "acme-map", tenant_id: str = "acme") -> Map:
 class TestGetTenants:
     """Tests for ``GET /gcp/api/tenants/``."""
 
-    @patch("api.routers.gcp.RepoYamlTenant")
+    @patch("api.routers.gcp.RepoPostgresTenant")
     def test_returns_tenant_list(
         self, mock_repo_cls: object, client: TestClient
     ) -> None:
@@ -64,7 +64,7 @@ class TestGetTenants:
         assert data["tenants"][0]["id"] == "t1"
         assert data["tenants"][1]["name"] == "Tenant Two"
 
-    @patch("api.routers.gcp.RepoYamlTenant")
+    @patch("api.routers.gcp.RepoPostgresTenant")
     def test_returns_empty_list(
         self, mock_repo_cls: object, client: TestClient
     ) -> None:
@@ -85,7 +85,7 @@ class TestGetTenants:
 class TestGetTenantMaps:
     """Tests for ``GET /gcp/api/tenants/{tenant_id}/maps/``."""
 
-    @patch("api.routers.gcp.RepoYamlMap")
+    @patch("api.routers.gcp.RepoPostgresMap")
     def test_returns_maps_for_tenant(
         self, mock_repo_cls: object, client: TestClient
     ) -> None:
@@ -101,7 +101,7 @@ class TestGetTenantMaps:
         assert data["maps"][0]["id"] == "map-1"
         assert data["maps"][0]["tenant_id"] == "acme"
 
-    @patch("api.routers.gcp.RepoYamlMap")
+    @patch("api.routers.gcp.RepoPostgresMap")
     def test_returns_empty_when_no_maps(
         self, mock_repo_cls: object, client: TestClient
     ) -> None:
@@ -122,20 +122,27 @@ class TestGetTenantMaps:
 class TestGetMapIds:
     """Tests for ``GET /gcp/api/map-ids/?tenant_id=…``."""
 
-    @patch("api.routers.gcp.list_map_ids")
-    @patch("api.routers.gcp.RepoYamlMap")
+    @patch("api.routers.gcp.RepoPostgresGroundControlPoint")
+    @patch("api.routers.gcp.RepoPostgresMap")
     def test_returns_filtered_map_ids(
         self,
-        mock_repo_cls: object,
-        mock_list_ids: object,
+        mock_map_cls: object,
+        mock_gcp_cls: object,
         client: TestClient,
     ) -> None:
-        mock_instance = mock_repo_cls.return_value  # type: ignore[union-attr]
-        mock_instance.get_by_tenant.return_value = {
+        mock_map_instance = mock_map_cls.return_value  # type: ignore[union-attr]
+        mock_map_instance.get_by_tenant.return_value = {
             "map-a": _make_map("map-a"),
             "map-b": _make_map("map-b"),
         }
-        mock_list_ids.return_value = ["map-a", "map-c"]  # type: ignore[union-attr]
+
+        # Mock GCPs: map-a and map-c have GCPs; map-b does not.
+        gcp_a = MagicMock()
+        gcp_a.map_id = "map-a"
+        gcp_c = MagicMock()
+        gcp_c.map_id = "map-c"
+        mock_gcp_instance = mock_gcp_cls.return_value  # type: ignore[union-attr]
+        mock_gcp_instance.get_all.return_value = [gcp_a, gcp_c]
 
         resp = client.get("/gcp/api/map-ids/", params={"tenant_id": "acme"})
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -220,6 +220,18 @@ save_to_gcp_repo  # unused function (poc_homography/map_points/gcp_registry.py:2
 list_map_ids  # unused function (poc_homography/map_points/gcp_registry.py:227) - legacy bridge
 error_px  # unused variable (poc_homography/validation/camera_model.py:65) - NamedTuple field
 
+# -- PostgreSQL _pg adapter functions (called from api/ routers, not scanned by vulture) --
+sync_to_ddd_repo_pg  # unused function (poc_homography/calibration/lens_distortion/ddd_sync.py) - used by api/routers/lens_calibration.py
+get_tenants_pg  # unused function (poc_homography/camera_config.py) - used by api/routers
+get_tenant_by_id_pg  # unused function (poc_homography/camera_config.py) - used by api/routers
+get_tenant_by_name_pg  # unused function (poc_homography/camera_config.py) - used by api/routers
+save_to_gcp_repo_pg  # unused function (poc_homography/map_points/gcp_registry.py) - used by api/routers/point_picker.py
+list_map_ids_pg  # unused function (poc_homography/map_points/gcp_registry.py) - used by api/routers/point_picker.py
+save_line_to_repo_pg  # unused function (webapp/line_picker/state.py) - used by api/routers/line_picker.py
+delete_line_from_repo_pg  # unused function (webapp/line_picker/state.py) - used by api/routers/line_picker.py
+save_gcp_to_repo_pg  # unused function (webapp/point_picker/state.py) - used by api/routers/point_picker.py
+delete_gcp_from_repo_pg  # unused function (webapp/point_picker/state.py) - used by api/routers/point_picker.py
+
 # -- PostgreSQL session repository base class (abstract hooks called by base CRUD) --
 _.get_session_dir  # unused method (infrastructure/repositories/repo_postgres_survey_session.py) - YAML compat API
 

--- a/webapp/line_picker/state.py
+++ b/webapp/line_picker/state.py
@@ -17,6 +17,8 @@ from PIL import Image
 from poc_homography.infrastructure.repositories import RepoYamlLine
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from poc_homography.domain.vo.geotiff import GeoTiff
 
 
@@ -209,11 +211,13 @@ class LinePickerState:
 _states: dict[str, LinePickerState] = {}
 
 
-def get_state(tenant_id: str) -> LinePickerState:
+def get_state(tenant_id: str, session: Session | None = None) -> LinePickerState:
     """Get or lazily initialize state for a tenant.
 
     Args:
         tenant_id: Tenant identifier.
+        session: Optional SQLAlchemy session. When provided, lines and map
+            resolution use PostgreSQL instead of YAML files.
 
     Returns:
         LinePickerState for the given tenant.
@@ -224,7 +228,12 @@ def get_state(tenant_id: str) -> LinePickerState:
     if tenant_id in _states:
         return _states[tenant_id]
 
-    map_entity, map_file = resolve_map_for_tenant(tenant_id)
+    if session is not None:
+        from api.utils.frame_helpers import resolve_map_for_tenant as resolve_pg
+
+        map_entity, map_file = resolve_pg(tenant_id, session)
+    else:
+        map_entity, map_file = resolve_map_for_tenant(tenant_id)
 
     state = LinePickerState(
         map_file,
@@ -232,7 +241,12 @@ def get_state(tenant_id: str) -> LinePickerState:
         width=int(map_entity.photo.width),
         height=int(map_entity.photo.height),
     )
-    state.lines = from_line_repo(LINES_DIR, map_entity.id)
+
+    if session is not None:
+        state.lines = from_line_repo_pg(session, map_entity.id)
+    else:
+        state.lines = from_line_repo(LINES_DIR, map_entity.id)
+
     _states[tenant_id] = state
     return state
 
@@ -357,6 +371,59 @@ def list_line_map_ids(data_dir: Path) -> list[str]:
     repo = _get_line_repo(data_dir)
     all_lines = repo.get_all()
     return sorted({line.map_id for line in all_lines})
+
+
+def from_line_repo_pg(session: Session, map_id: str) -> list[Line]:
+    """Load lines from ``RepoPostgresLine``."""
+    from poc_homography.infrastructure.repositories import RepoPostgresLine
+
+    repo = RepoPostgresLine(session)
+    return [
+        Line(
+            line_id=dl.name,
+            start_x=float(dl.start.x),
+            start_y=float(dl.start.y),
+            end_x=float(dl.end.x),
+            end_y=float(dl.end.y),
+        )
+        for dl in repo.get_by_map_id(map_id)
+    ]
+
+
+def save_line_to_repo_pg(
+    line_id: str,
+    start_x: float,
+    start_y: float,
+    end_x: float,
+    end_y: float,
+    map_id: str,
+    session: Session,
+) -> None:
+    """Persist a line via ``RepoPostgresLine``."""
+    from poc_homography.domain.entities.line import Line as DomainLine
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+    from poc_homography.infrastructure.repositories import RepoPostgresLine
+
+    repo = RepoPostgresLine(session)
+    domain_line = DomainLine(
+        name=line_id,
+        map_id=map_id,
+        start=PixelPoint.create(start_x, start_y),
+        end=PixelPoint.create(end_x, end_y),
+    )
+    repo.save(domain_line)
+
+
+def delete_line_from_repo_pg(line_id: str, map_id: str, session: Session) -> None:
+    """Delete a line via ``RepoPostgresLine``."""
+    from poc_homography.domain.entities.line import Line as DomainLine
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+    from poc_homography.infrastructure.repositories import RepoPostgresLine
+
+    repo = RepoPostgresLine(session)
+    _zero = PixelPoint.create(0, 0)
+    entity_id = DomainLine(name=line_id, map_id=map_id, start=_zero, end=_zero).id
+    repo.delete(entity_id)
 
 
 register_invalidation_callback(_states.clear)

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -203,7 +203,12 @@ def get_state(tenant_id: str, session: Session | None = None) -> PointPickerStat
     if tenant_id in _states:
         return _states[tenant_id]
 
-    map_entity, map_file = resolve_map_for_tenant(tenant_id)
+    if session is not None:
+        from api.utils.frame_helpers import resolve_map_for_tenant as resolve_pg
+
+        map_entity, map_file = resolve_pg(tenant_id, session)
+    else:
+        map_entity, map_file = resolve_map_for_tenant(tenant_id)
 
     state = PointPickerState(
         map_file,

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import TYPE_CHECKING
 
 import tifffile
 from homography_web.frame_utils import (
@@ -17,6 +18,9 @@ from poc_homography.domain.vo.geotiff import GeoTiff
 from poc_homography.infrastructure.repositories import RepoYamlGroundControlPoint
 from poc_homography.map_points.gcp_registry import GCPRegistry
 from poc_homography.map_points.map_point import MapPoint
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 # Tag abbreviation mapping
 TAG_ABBREVIATIONS = {
@@ -182,11 +186,13 @@ class PointPickerState:
 _states: dict[str, PointPickerState] = {}
 
 
-def get_state(tenant_id: str) -> PointPickerState:
+def get_state(tenant_id: str, session: Session | None = None) -> PointPickerState:
     """Get or lazily initialize state for a tenant.
 
     Args:
         tenant_id: Tenant identifier.
+        session: Optional SQLAlchemy session. When provided, GCPs are loaded
+            from PostgreSQL instead of YAML files.
 
     Returns:
         PointPickerState for the given tenant.
@@ -205,8 +211,12 @@ def get_state(tenant_id: str) -> PointPickerState:
         height=int(map_entity.photo.height),
     )
 
-    # Load GCPs for this tenant's map only
-    if GCPS_DIR.exists():
+    if session is not None:
+        from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
+
+        state.registry = from_gcp_repo_pg(session, map_entity.id)
+        state.map_id = state.registry.map_id
+    elif GCPS_DIR.exists():
         from poc_homography.map_points.gcp_registry import from_gcp_repo
 
         state.registry = from_gcp_repo(GCPS_DIR, map_entity.id)
@@ -294,6 +304,45 @@ def delete_gcp_from_repo(point_id: str, map_id: str, data_dir: Path) -> None:
 
     repo = _get_gcp_repo(data_dir)
     # Use GroundControlPoint.id to derive the entity ID rather than duplicating the format.
+    _zero = PixelPoint.create(0, 0)
+    entity_id = GroundControlPoint(
+        name=point_id, map_point=DomainMapPoint(map_id=map_id, pixel_point=_zero)
+    ).id
+    repo.delete(entity_id)
+
+
+def save_gcp_to_repo_pg(
+    point_id: str,
+    pixel_x: float,
+    pixel_y: float,
+    map_id: str,
+    session: Session,
+) -> None:
+    """Persist a single GCP via ``RepoPostgresGroundControlPoint``."""
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+    from poc_homography.domain.vo.map_point import MapPoint as DomainMapPoint
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+    from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
+
+    repo = RepoPostgresGroundControlPoint(session)
+    gcp = GroundControlPoint(
+        name=point_id,
+        map_point=DomainMapPoint(
+            map_id=map_id,
+            pixel_point=PixelPoint.create(pixel_x, pixel_y),
+        ),
+    )
+    repo.save(gcp)
+
+
+def delete_gcp_from_repo_pg(point_id: str, map_id: str, session: Session) -> None:
+    """Delete a GCP via ``RepoPostgresGroundControlPoint``."""
+    from poc_homography.domain.entities.ground_control_point import GroundControlPoint
+    from poc_homography.domain.vo.map_point import MapPoint as DomainMapPoint
+    from poc_homography.domain.vo.pixel_point import PixelPoint
+    from poc_homography.infrastructure.repositories import RepoPostgresGroundControlPoint
+
+    repo = RepoPostgresGroundControlPoint(session)
     _zero = PixelPoint.create(0, 0)
     entity_id = GroundControlPoint(
         name=point_id, map_point=DomainMapPoint(map_id=map_id, pixel_point=_zero)


### PR DESCRIPTION
## Summary

Closes #254. Migrates all `frame_utils.py` RepoYaml* usages to RepoPostgres* equivalents in the API layer.

- **`api/utils/frame_helpers.py`** — new module with session-aware replacements for all repo-backed functions in `homography_web/frame_utils.py`. Re-exports pure utilities and path constants.
- **All API routers** updated to import from `frame_helpers` instead of `frame_utils`, adding `session: Session = Depends(get_db_session)` where needed.
- **`api/deps.py`** — `get_db_session` now commits on success / rolls back on error (previously never committed, so PG writes were silently lost).
- **`homography_precision.py`** — removed stale module-level caches (`_line_registry_cache`, `_image_info_cache`) that were no longer invalidated after the YAML→PG migration.
- **`webapp/line_picker/state.py`** — added `_pg` adapter functions (`save_line_to_repo_pg`, `delete_line_from_repo_pg`, `from_line_repo_pg`).
- **`vulture_whitelist.py`** — whitelisted `_pg` adapter functions used by `api/` routers (vulture doesn't scan `api/`).

## Verification

- `grep -rn "RepoYaml" api/` → no matches (only docstring mentions)
- `grep -rn "homography_web.frame_utils" api/` → only in `frame_helpers.py` (re-exports)

## Test plan

- [x] CI passes (ruff, pyright, pylint, vulture, pytest)
- [ ] SPA functional test with running database