### PR TITLE
fix(tests): cam-04 live integration tests silently skipped (conftest DATABASE_URL gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ uv run poe test          # Run all tests
 uv run poe test-cov      # With coverage
 ```
 
+#### Live camera tests
+
+The Hikvision live integration suite
+(`tests/infrastructure/test_hikvision_isapi_live.py`) talks to a real PTZ
+camera and is **skipped by default**. It is gated solely on `ICO_CAMERA_IP`
+(independent of `DATABASE_URL`), so it runs whenever a camera is reachable:
+
+| Env var               | Required | Purpose                                                        |
+| --------------------- | -------- | -------------------------------------------------------------- |
+| `ICO_CAMERA_IP`       | yes      | Camera host/IP. Its presence enables the read tests.           |
+| `ICO_CAMERA_USERNAME` | no       | Login (defaults to `admin`).                                   |
+| `ICO_CAMERA_PASSWORD` | no       | Login password (defaults to empty).                            |
+| `ICO_CAMERA_WRITE`    | no       | Set to any value to enable the move/restore test (moves PTZ).  |
+
+```bash
+# Read-only suite against cam-04
+ICO_CAMERA_IP=10.107.50.5 ICO_CAMERA_USERNAME=admin ICO_CAMERA_PASSWORD=... \
+  uv run pytest tests/infrastructure/test_hikvision_isapi_live.py
+
+# Include the physical move/restore test
+ICO_CAMERA_IP=10.107.50.5 ICO_CAMERA_WRITE=1 ICO_CAMERA_USERNAME=admin ICO_CAMERA_PASSWORD=... \
+  uv run pytest tests/infrastructure/test_hikvision_isapi_live.py
+```
+
+No `DATABASE_URL` is needed; the Postgres integration tests remain gated
+separately on `DATABASE_URL`.
+
 ### Code Quality
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,11 @@ Reference documentation for the PTZ homography project.
 - [hikvision_improvement_assessment.md](./hikvision_improvement_assessment.md)
   — review of the prior four-implementation duplication, the wrong tilt
   default, and the applied-vs-deferred improvements.
+- **Live camera tests** —
+  [`../tests/infrastructure/test_hikvision_isapi_live.py`](../tests/infrastructure/test_hikvision_isapi_live.py)
+  exercises a real PTZ camera. Gated on `ICO_CAMERA_IP` alone (no database
+  required); see the [README run-tests section](../README.md#live-camera-tests)
+  for the `ICO_CAMERA_*` env-var contract.
 
 ## Camera intrinsics and pose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ filterwarnings = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
+    "live_camera: marks live camera integration tests (gated on ICO_CAMERA_IP; need no database)",
 ]
 
 [tool.coverage.run]

--- a/tests/infrastructure/conftest.py
+++ b/tests/infrastructure/conftest.py
@@ -22,11 +22,17 @@ if TYPE_CHECKING:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip all postgres integration tests if DATABASE_URL is not set."""
+    """Skip postgres integration tests if DATABASE_URL is not set.
+
+    Live camera tests (marked ``live_camera``) need no database and are gated
+    independently on ``ICO_CAMERA_IP``, so they are exempt from this DB gate.
+    """
     if not os.environ.get("DATABASE_URL"):
         skip = pytest.mark.skip(reason="DATABASE_URL not set")
         for item in items:
-            if item.get_closest_marker("integration"):
+            if item.get_closest_marker("integration") and not item.get_closest_marker(
+                "live_camera"
+            ):
                 item.add_marker(skip)
 
 

--- a/tests/infrastructure/test_hikvision_isapi_live.py
+++ b/tests/infrastructure/test_hikvision_isapi_live.py
@@ -22,6 +22,7 @@ from poc_homography.infrastructure.clients.hikvision.isapi_client import Hikvisi
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.live_camera,
     pytest.mark.skipif(
         not os.getenv("ICO_CAMERA_IP"),
         reason="ICO_CAMERA_IP not set (live camera unavailable)",


### PR DESCRIPTION
## Summary

The autouse skip in `tests/infrastructure/conftest.py` skipped **every** `integration`-marked item when `DATABASE_URL` was unset, which silently skipped the Hikvision live camera suite (`tests/infrastructure/test_hikvision_isapi_live.py`) — even though it needs **no database** and is already gated on `ICO_CAMERA_IP`. Net effect: every survey PR that "passed tests" did so **without exercising the real camera**.

This:
- Adds a `live_camera` pytest marker (registered in `pyproject.toml`).
- Narrows the conftest DB gate to exempt `live_camera` tests.
- Tags the live module with `live_camera`, so the suite RUNS whenever `ICO_CAMERA_IP` is set, **independent of `DATABASE_URL`**.
- Documents the `ICO_CAMERA_*` env-var contract in the README + docs index.

Postgres DB tests still skip on `DATABASE_URL` as before.

## Test plan

- **Offline** (no `DATABASE_URL`, no `ICO_CAMERA_IP`): live tests skip on their own `ICO_CAMERA_IP not set` reason; Postgres tests skip on `DATABASE_URL not set`. ✅ verified
- **`ICO_CAMERA_IP` set + `DATABASE_URL` unset**: live tests RUN — verified via a fast connection-refused against `127.0.0.1` (collected and executed, **not** skipped). Against cam-04 (10.107.50.5) they pass 8/8 per the issue's primary evidence. ✅
- `poe validate` exits 0 (green). ✅

> Note: the local-only `test_camera_diagnostic::test_start_stress_test_no_credentials` failure pre-exists on `main` and is environment-specific (main CI is green on base `b5f0083`); unrelated to this change. The whole-project `uv run pyright` pre-commit hook is likewise pre-existing-red (29 errors in `webapp/` + `tests/`, none in files touched here); CI's pyright gate is `pyright poc_homography`, which is green.

## Definition of Done

- [x] With `ICO_CAMERA_IP` set and `DATABASE_URL` unset, the camera live tests RUN (not skipped).
- [x] With `DATABASE_URL` unset, the Postgres DB tests still skip as before.
- [x] The camera env-var contract is documented (README + docs index).
- [x] `poe validate` and offline `poe test` remain green.

Closes #266
