### PR TITLE
feat(survey): nine concrete survey phases wiring C3 planner onto C2 engine (#261)

### DIFF
--- a/poc_homography/domain/entities/survey/frame_record.py
+++ b/poc_homography/domain/entities/survey/frame_record.py
@@ -344,6 +344,46 @@ class ImageData:
         )
 
 
+@dataclass(frozen=True)
+class SurveyContext:
+    """Planner-derived survey context attached to a frame by the phase layer.
+
+    These fields originate in the C3 planner pose (and the C4 phase that drives
+    it), not in the C2 capture engine: ``region_id`` groups cross-zoom
+    observations of the same ground region (Phase 6), ``approach_direction``
+    records the direction a pose was approached from (Phases 3/7), and
+    ``sequence_index`` is the visit index within a repeat group (Phase 7). All
+    are optional and default to ``None`` so frames captured outside a phase
+    context (and pre-existing serialised frames) round-trip unchanged.
+    """
+
+    region_id: str | None = None
+    approach_direction: str | None = None
+    sequence_index: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "region_id": self.region_id,
+            "approach_direction": self.approach_direction,
+            "sequence_index": self.sequence_index,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SurveyContext:
+        """Create :class:`SurveyContext` from a dictionary."""
+        region_id = data.get("region_id")
+        approach_direction = data.get("approach_direction")
+        sequence_index = data.get("sequence_index")
+        return cls(
+            region_id=str(region_id) if region_id is not None else None,
+            approach_direction=(
+                str(approach_direction) if approach_direction is not None else None
+            ),
+            sequence_index=int(sequence_index) if sequence_index is not None else None,
+        )
+
+
 @dataclass(frozen=True, eq=False)
 class FrameRecord:
     """The full optical + mechanical state captured at a single survey frame.
@@ -360,6 +400,7 @@ class FrameRecord:
     movement: MovementContext
     pipeline: ImagePipelineState
     image_data: ImageData
+    survey_context: SurveyContext = field(default_factory=SurveyContext)
     schema_version: str = field(default=SURVEY_SCHEMA_VERSION)
 
     @property
@@ -386,6 +427,7 @@ class FrameRecord:
             "movement": self.movement.to_dict(),
             "pipeline": self.pipeline.to_dict(),
             "image_data": self.image_data.to_dict(),
+            "survey_context": self.survey_context.to_dict(),
         }
 
     @classmethod
@@ -404,5 +446,6 @@ class FrameRecord:
             movement=MovementContext.from_dict(data["movement"]),
             pipeline=ImagePipelineState.from_dict(data["pipeline"]),
             image_data=ImageData.from_dict(data["image_data"]),
+            survey_context=SurveyContext.from_dict(data.get("survey_context") or {}),
             schema_version=version,
         )

--- a/poc_homography/domain/entities/survey/inventory_record.py
+++ b/poc_homography/domain/entities/survey/inventory_record.py
@@ -1,0 +1,123 @@
+"""Camera-inventory C1 record for Phase 1 of the multi-camera survey.
+
+Unlike the image-bearing :class:`FrameRecord`, the inventory record captures the
+camera's full self-report in a single pass at session start: device identity and
+firmware, PTZ capabilities, the image-optics pipeline state, runtime health and
+lens odometry, the available stream profiles, and the stored PTZ presets. Every
+field is sourced verbatim from the #256 ``CameraDevice`` value objects, each of
+which already provides ``to_dict`` / ``from_dict``; this record only aggregates
+them and stamps the survey phase, run/camera identity, and schema version.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from poc_homography.domain.entities.survey import (
+    SURVEY_SCHEMA_VERSION,
+    check_schema_version,
+)
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.vo.camera_capabilities import CameraCapabilities
+from poc_homography.domain.vo.camera_preset import CameraPreset
+from poc_homography.domain.vo.device_health import DeviceHealth
+from poc_homography.domain.vo.device_info import DeviceInfo
+from poc_homography.domain.vo.image_optics import ImageOptics
+from poc_homography.domain.vo.stream_profile import StreamProfile
+
+
+@dataclass(frozen=True, eq=False)
+class CameraInventoryRecord:
+    """The full camera self-report captured once per run by Phase 1.
+
+    The ``id`` property is the ``record_id``, satisfying the ``Entity``
+    protocol. ``phase`` is always :attr:`SurveyPhase.CAMERA_INVENTORY`; it is
+    stored explicitly so the record is phase-tagged identically to every other
+    C1 record. ``schema_version`` is stamped from :data:`SURVEY_SCHEMA_VERSION`
+    and validated on load.
+
+    Attributes:
+        record_id: Unique per-run inventory record id.
+        run_id: The owning survey run id.
+        camera_id: Stable camera identifier (e.g. ``icozee-camptz-04``).
+        captured_at: When the inventory pass ran.
+        device_info: Device identity and firmware (#256 ``DeviceInfo``).
+        capabilities: PTZ position/speed and zoom/focus limits
+            (#256 ``CameraCapabilities``).
+        optics: Focus/iris/exposure/white-balance image-pipeline state
+            (#256 ``ImageOptics``).
+        health: Runtime health and lens odometry (#256 ``DeviceHealth``).
+        stream_profiles: The available streaming profiles (#256
+            ``StreamProfile``); the first is the primary channel.
+        presets: The stored PTZ presets (#256 ``CameraPreset``).
+        phase: Always :attr:`SurveyPhase.CAMERA_INVENTORY`.
+        schema_version: Survey schema version, stamped and validated on load.
+    """
+
+    record_id: str
+    run_id: str
+    camera_id: str
+    captured_at: datetime
+    device_info: DeviceInfo
+    capabilities: CameraCapabilities
+    optics: ImageOptics
+    health: DeviceHealth
+    stream_profiles: tuple[StreamProfile, ...]
+    presets: tuple[CameraPreset, ...]
+    phase: SurveyPhase = SurveyPhase.CAMERA_INVENTORY
+    schema_version: str = field(default=SURVEY_SCHEMA_VERSION)
+
+    @property
+    def id(self) -> str:
+        """Unique identifier — the inventory record id."""
+        return self.record_id
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "schema_version": self.schema_version,
+            "record_id": self.record_id,
+            "run_id": self.run_id,
+            "camera_id": self.camera_id,
+            "phase": self.phase.value,
+            "captured_at": self.captured_at.isoformat(),
+            "device_info": self.device_info.to_dict(),
+            "capabilities": self.capabilities.to_dict(),
+            "optics": self.optics.to_dict(),
+            "health": self.health.to_dict(),
+            "stream_profiles": [profile.to_dict() for profile in self.stream_profiles],
+            "presets": [preset.to_dict() for preset in self.presets],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CameraInventoryRecord:
+        """Create :class:`CameraInventoryRecord` from a dictionary.
+
+        Raises:
+            ValueError: If ``schema_version`` is unrecognised.
+        """
+        version = check_schema_version(str(data["schema_version"]))
+        return cls(
+            record_id=str(data["record_id"]),
+            run_id=str(data["run_id"]),
+            camera_id=str(data["camera_id"]),
+            captured_at=datetime.fromisoformat(data["captured_at"]),
+            device_info=DeviceInfo.from_dict(data["device_info"]),
+            capabilities=CameraCapabilities.from_dict(data["capabilities"]),
+            optics=ImageOptics.from_dict(data["optics"]),
+            health=DeviceHealth.from_dict(data["health"]),
+            stream_profiles=tuple(StreamProfile.from_dict(p) for p in data["stream_profiles"]),
+            presets=tuple(CameraPreset.from_dict(p) for p in data["presets"]),
+            phase=SurveyPhase(data["phase"]),
+            schema_version=version,
+        )

--- a/poc_homography/infrastructure/survey/yaml_phase_sink.py
+++ b/poc_homography/infrastructure/survey/yaml_phase_sink.py
@@ -1,0 +1,73 @@
+"""YAML-backed :class:`PhaseSink` writing C1 records into the survey layout.
+
+Records are written one file per record into the partitioned layout that
+:class:`~poc_homography.infrastructure.repositories.repo_yaml_survey_run.RepoYamlSurveyRun`
+reads back: frames at ``{root}/{run_id}/{camera_id}/frames/{capture_id}.yaml``,
+bursts alongside them under ``bursts/``, and the per-run inventory under
+``inventory/``. This keeps the phase layer persistence-agnostic (it depends only
+on the :class:`PhaseSink` port) while letting a full multi-phase run produce a
+real, queryable dataset.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+    from poc_homography.domain.entities.survey.inventory_record import (
+        CameraInventoryRecord,
+    )
+    from poc_homography.domain.entities.survey.video_burst_record import (
+        VideoBurstRecord,
+    )
+
+
+class YamlPhaseSink:
+    """Persist survey-phase C1 records as one YAML file per record.
+
+    Implements the :class:`~poc_homography.survey.phases.common.PhaseSink`
+    protocol structurally.
+    """
+
+    def __init__(self, root: Path) -> None:
+        """Initialise the sink.
+
+        Args:
+            root: The survey data root (e.g. ``data/survey``); per-run and
+                per-camera sub-directories are created on demand.
+        """
+        self._root = root
+
+    def save_inventory(self, record: CameraInventoryRecord) -> None:
+        """Write the Phase 1 inventory record under ``inventory/``."""
+        path = self._dir(record.run_id, record.camera_id, "inventory") / f"{record.id}.yaml"
+        _write_yaml(path, record.to_dict())
+
+    def save_frame(self, record: FrameRecord) -> None:
+        """Write a per-frame C1 record under ``frames/``."""
+        run_id = record.capture.run_id
+        camera_id = record.camera.camera_id
+        path = self._dir(run_id, camera_id, "frames") / f"{record.id}.yaml"
+        _write_yaml(path, record.to_dict())
+
+    def save_burst(self, record: VideoBurstRecord) -> None:
+        """Write a Phase 8 video-burst record under ``bursts/``."""
+        path = self._dir(record.run_id, record.camera_id, "bursts") / f"{record.id}.yaml"
+        _write_yaml(path, record.to_dict())
+
+    def _dir(self, run_id: str, camera_id: str, leaf: str) -> Path:
+        """Return (creating) the ``{root}/{run_id}/{camera_id}/{leaf}`` dir."""
+        directory = self._root / run_id / camera_id / leaf
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    """Write ``data`` to ``path`` matching the project's YAML conventions."""
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.dump(data, handle, default_flow_style=False, sort_keys=False)

--- a/poc_homography/survey/phases/__init__.py
+++ b/poc_homography/survey/phases/__init__.py
@@ -1,0 +1,52 @@
+"""Concrete survey phases (C4): wire the C3 planner onto the C2 capture engine.
+
+Each phase is a thin orchestration layer. It retrieves poses or sweep
+parameters from the planner (:mod:`poc_homography.survey.planner`), drives the
+capture engine (:class:`poc_homography.infrastructure.survey.capture_engine.SurveyCaptureEngine`)
+to execute captures, and ensures every emitted C1 record carries the correct
+:class:`~poc_homography.domain.enums.survey_phase.SurveyPhase` tag plus the
+planner-derived survey context (region id / approach direction / sequence
+index). Pose generation, movement mechanics, and persistence all live in C3,
+C2, and C1 respectively; C4 only binds them.
+
+The :func:`~poc_homography.survey.phases.runner.execute_survey` runner sequences
+all nine phases for one camera and routes every record to a
+:class:`~poc_homography.survey.phases.common.PhaseSink`.
+"""
+
+from __future__ import annotations
+
+from poc_homography.survey.phases.common import (
+    PhaseResult,
+    PhaseSink,
+    pose_to_commanded,
+)
+from poc_homography.survey.phases.executors import (
+    run_cross_zoom,
+    run_dense_nadir,
+    run_inventory,
+    run_jitter,
+    run_main_survey,
+    run_ptz_characterization,
+    run_repeatability,
+    run_validation,
+    run_zoom_characterization,
+)
+from poc_homography.survey.phases.runner import SurveyPlan, execute_survey
+
+__all__ = [
+    "PhaseResult",
+    "PhaseSink",
+    "pose_to_commanded",
+    "run_inventory",
+    "run_ptz_characterization",
+    "run_zoom_characterization",
+    "run_dense_nadir",
+    "run_main_survey",
+    "run_cross_zoom",
+    "run_repeatability",
+    "run_jitter",
+    "run_validation",
+    "SurveyPlan",
+    "execute_survey",
+]

--- a/poc_homography/survey/phases/common.py
+++ b/poc_homography/survey/phases/common.py
@@ -1,0 +1,151 @@
+"""Shared building blocks for the nine survey phases (C4).
+
+This module holds the persistence port (:class:`PhaseSink`), the per-phase
+result container (:class:`PhaseResult`), the pose -> commanded-state adapter,
+and :func:`capture_pose_sequence` — the one helper every pose-based phase reuses
+to drive the C2 engine over an ordered pose list while stamping the C3-derived
+survey context onto each emitted frame.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Protocol
+
+from poc_homography.domain.entities.survey.frame_record import (
+    CommandedState,
+    FrameRecord,
+    SurveyContext,
+)
+from poc_homography.infrastructure.survey.capture_engine import CaptureContext
+from poc_homography.types import Degrees, Unitless
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+
+    from poc_homography.domain.entities.survey.inventory_record import (
+        CameraInventoryRecord,
+    )
+    from poc_homography.domain.entities.survey.video_burst_record import (
+        VideoBurstRecord,
+    )
+    from poc_homography.domain.enums.survey_phase import SurveyPhase
+    from poc_homography.infrastructure.survey.capture_engine import (
+        SurveyCaptureEngine,
+    )
+    from poc_homography.survey.planner.poses import Pose
+
+
+class PhaseSink(Protocol):
+    """Destination for the C1 records a phase emits.
+
+    The phase layer is persistence-agnostic: it hands every record to a sink
+    and never writes files or rows itself. Implementations may persist to YAML,
+    Postgres, or accumulate in memory (tests).
+    """
+
+    def save_inventory(self, record: CameraInventoryRecord) -> None:
+        """Persist the Phase 1 camera-inventory record."""
+        ...
+
+    def save_frame(self, record: FrameRecord) -> None:
+        """Persist a single per-frame C1 record."""
+        ...
+
+    def save_burst(self, record: VideoBurstRecord) -> None:
+        """Persist a Phase 8 video-burst record (segment + frame refs)."""
+        ...
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    """The C1 records produced by one phase.
+
+    Exactly one of the populated collections is non-empty for a given phase:
+    Phase 1 sets :attr:`inventory`; Phase 8 sets :attr:`bursts` (and the frames
+    extracted from them); every other phase sets :attr:`frames`.
+    """
+
+    phase: SurveyPhase
+    frames: tuple[FrameRecord, ...] = ()
+    bursts: tuple[VideoBurstRecord, ...] = ()
+    inventory: CameraInventoryRecord | None = None
+    commanded_states: tuple[CommandedState, ...] = field(default=())
+
+
+def pose_to_commanded(pose: Pose) -> CommandedState:
+    """Adapt a planner :class:`Pose` to a C2 :class:`CommandedState`.
+
+    Planner poses carry no focus target, so ``commanded_focus`` is ``None``
+    (the engine then leaves focus untouched).
+    """
+    return CommandedState(
+        commanded_pan=Degrees(float(pose.pan)),
+        commanded_tilt=Degrees(float(pose.tilt)),
+        commanded_zoom=Unitless(float(pose.zoom)),
+        commanded_focus=None,
+    )
+
+
+def capture_pose_sequence(
+    engine: SurveyCaptureEngine,
+    poses: Sequence[Pose],
+    *,
+    run_id: str,
+    camera_id: str,
+    phase: SurveyPhase,
+    output_dir: Path,
+    burst_count: int = 1,
+    is_repeatability_sequence: bool = False,
+    survey_context_for: Callable[[Pose, int], SurveyContext] | None = None,
+) -> list[FrameRecord]:
+    """Drive the C2 engine over an ordered pose list, emitting tagged frames.
+
+    Threads each pose's commanded state into the next pose's
+    :class:`CaptureContext` so the engine can compute per-axis movement
+    directions; threading starts fresh (no previous pose) at the first pose so a
+    phase's sweep is self-contained and not contaminated by a prior phase. Every
+    frame is tagged with ``phase`` (via the engine) and, when
+    ``survey_context_for`` is supplied, enriched with the C3-derived
+    :class:`SurveyContext` (region id / approach direction / sequence index).
+
+    Args:
+        engine: The C2 capture engine.
+        poses: Ordered poses to capture, in execution order.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        phase: The phase identity stamped on every emitted record.
+        output_dir: Directory the engine writes frame images into.
+        burst_count: Snapshot frames per pose (``>= 1``).
+        is_repeatability_sequence: Recorded verbatim on each frame's movement
+            context; never computed here.
+        survey_context_for: Optional factory returning the :class:`SurveyContext`
+            to stamp on the frames captured at ``(pose, index)``.
+
+    Returns:
+        All emitted :class:`FrameRecord` objects, in capture order.
+    """
+    records: list[FrameRecord] = []
+    previous: CommandedState | None = None
+    for index, pose in enumerate(poses):
+        commanded = pose_to_commanded(pose)
+        context = CaptureContext(
+            run_id=run_id,
+            camera_id=camera_id,
+            phase=phase,
+            previous_commanded=previous,
+            is_repeatability_sequence=is_repeatability_sequence,
+        )
+        frames = engine.capture_snapshot_burst(
+            commanded,
+            context,
+            burst_count=burst_count,
+            output_dir=output_dir,
+        )
+        if survey_context_for is not None:
+            survey_context = survey_context_for(pose, index)
+            frames = [replace(frame, survey_context=survey_context) for frame in frames]
+        records.extend(frames)
+        previous = commanded
+    return records

--- a/poc_homography/survey/phases/executors.py
+++ b/poc_homography/survey/phases/executors.py
@@ -1,0 +1,660 @@
+"""The nine concrete survey-phase executors (C4).
+
+Every executor is a thin binding: it asks the C3 planner for poses (or a sweep),
+drives the C2 engine to capture them, and returns a :class:`PhaseResult` whose
+records all carry this phase's tag (and, where the DoD requires it, the
+planner-derived :class:`SurveyContext`). None of them re-implement pose
+generation, movement mechanics, or persistence.
+
+The phase identifiers are the C1 :class:`SurveyPhase` enum values — the schema's
+source of truth — so e.g. Phase 1 emits ``phase=camera_inventory``, Phase 5
+``phase=main_survey``, and Phase 8 ``phase=static_jitter`` (the issue's informal
+``inventory`` / ``main_ptz_survey`` / ``jitter`` names map onto these).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.entities.survey.frame_record import SurveyContext
+from poc_homography.domain.entities.survey.inventory_record import (
+    CameraInventoryRecord,
+)
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.infrastructure.survey.capture_engine import (
+    CaptureContext,
+    CaptureEngineError,
+)
+from poc_homography.survey.phases.common import (
+    PhaseResult,
+    capture_pose_sequence,
+    pose_to_commanded,
+)
+from poc_homography.survey.planner.generators import (
+    SweepAxis,
+    cross_zoom,
+    directional_sweep,
+    nadir_region,
+    repeatability_sequences,
+)
+from poc_homography.survey.planner.poses import ApproachDirection, Pose
+from poc_homography.types import Degrees, Unitless
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from datetime import datetime
+    from pathlib import Path
+
+    from poc_homography.domain.entities.survey.frame_record import (
+        CommandedState,
+        FrameRecord,
+    )
+    from poc_homography.domain.entities.survey.video_burst_record import (
+        VideoBurstRecord,
+    )
+    from poc_homography.domain.enums.camera_spec import CameraSpec
+    from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.infrastructure.survey.capture_engine import (
+        SurveyCaptureEngine,
+    )
+
+# Phase 8 (static jitter) minimum acceptable target, per the verbatim spec / DoD.
+JITTER_MIN_DURATION_S = 10.0
+JITTER_MIN_FPS = 5.0
+JITTER_MIN_ZOOM_LEVELS = 3
+JITTER_MIN_POSES = 3
+
+# Approach-direction labels stamped onto Phase 3 zoom-sweep frames so the two
+# directional passes are distinguishable beyond the per-axis ``direction_zoom``.
+_ZOOM_LABEL = {
+    ApproachDirection.ASCENDING: "wide_to_tele",
+    ApproachDirection.DESCENDING: "tele_to_wide",
+}
+
+
+class JitterTargetError(ValueError):
+    """Raised when a Phase 8 configuration is below the minimum jitter target."""
+
+
+def run_inventory(
+    camera: CameraDevice,
+    *,
+    run_id: str,
+    camera_id: str,
+    clock: Callable[[], datetime],
+) -> PhaseResult:
+    """Phase 1 — camera inventory survey.
+
+    Collects the camera's full self-report in a single pass via the #256 adapter
+    and emits exactly one :class:`CameraInventoryRecord` tagged
+    ``phase=camera_inventory``. This is the only phase that does not perform
+    pose-based image capture.
+
+    Args:
+        camera: The #256 ``CameraDevice`` to interrogate.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        clock: Returns the timezone-aware capture timestamp.
+
+    Returns:
+        A :class:`PhaseResult` whose :attr:`PhaseResult.inventory` is set.
+    """
+    record = CameraInventoryRecord(
+        record_id=f"{run_id}_inventory",
+        run_id=run_id,
+        camera_id=camera_id,
+        captured_at=clock(),
+        device_info=camera.get_device_info(),
+        capabilities=camera.get_capabilities(),
+        optics=camera.get_optics(),
+        health=camera.get_health(),
+        stream_profiles=tuple(camera.get_stream_profiles()),
+        presets=tuple(camera.list_presets()),
+    )
+    return PhaseResult(phase=SurveyPhase.CAMERA_INVENTORY, inventory=record)
+
+
+def run_ptz_characterization(
+    engine: SurveyCaptureEngine,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    pan_range: tuple[float, float],
+    tilt_range: tuple[float, float],
+    small_step: float,
+    large_step: float,
+    fixed_tilt: float,
+    fixed_pan: float,
+    fixed_zoom: float,
+    repeat_count: int = 2,
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 2 — PTZ axis characterization.
+
+    Executes small, large, and repeated pan and tilt sweeps in both directions
+    so offline analysis can recover precision, rounding, latency, settling, and
+    backlash. Each pose emits a frame tagged ``phase=ptz_characterization`` with
+    per-axis movement direction and movement context populated by C2.
+
+    Args:
+        engine: The C2 capture engine.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        pan_range: ``(min, max)`` pan bounds in degrees.
+        tilt_range: ``(min, max)`` tilt bounds in degrees.
+        small_step: Fine step size (degrees) for small moves.
+        large_step: Coarse step size (degrees) for large moves.
+        fixed_tilt: Tilt held constant while sweeping pan.
+        fixed_pan: Pan held constant while sweeping tilt.
+        fixed_zoom: Zoom held constant for the whole phase.
+        repeat_count: How many times each sweep family is repeated.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the emitted frames and their commanded
+        states.
+    """
+    phase = SurveyPhase.PTZ_CHARACTERIZATION
+    records: list[FrameRecord] = []
+    for _ in range(max(1, repeat_count)):
+        for step in (small_step, large_step):
+            pan_asc, pan_desc = directional_sweep(
+                SweepAxis.PAN, pan_range[0], pan_range[1], step, fixed_tilt, fixed_zoom, phase=phase
+            )
+            tilt_asc, tilt_desc = directional_sweep(
+                SweepAxis.TILT,
+                tilt_range[0],
+                tilt_range[1],
+                step,
+                fixed_pan,
+                fixed_zoom,
+                phase=phase,
+            )
+            for plan in (pan_asc, pan_desc, tilt_asc, tilt_desc):
+                records.extend(
+                    capture_pose_sequence(
+                        engine,
+                        plan.poses,
+                        run_id=run_id,
+                        camera_id=camera_id,
+                        phase=phase,
+                        output_dir=output_dir,
+                        burst_count=burst_count,
+                        survey_context_for=_approach_context(plan.approach_directions),
+                    )
+                )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_zoom_characterization(
+    engine: SurveyCaptureEngine,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    zoom_min: float,
+    zoom_max: float,
+    zoom_step: float,
+    fixed_pan: float,
+    fixed_tilt: float,
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 3 — zoom characterization.
+
+    Sweeps the full zoom range wide-to-tele then tele-to-wide as two separate,
+    non-interleaved monotonic passes. Each frame carries ``phase=
+    zoom_characterization`` plus an ``approach_direction`` of ``wide_to_tele`` or
+    ``tele_to_wide`` so the passes (and hysteresis) are distinguishable offline.
+
+    Args:
+        engine: The C2 capture engine.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        zoom_min: Wide end of the zoom range.
+        zoom_max: Tele end of the zoom range.
+        zoom_step: Positive zoom step between consecutive poses.
+        fixed_pan: Pan held constant for the whole phase.
+        fixed_tilt: Tilt held constant for the whole phase.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with both directional passes' frames.
+    """
+    phase = SurveyPhase.ZOOM_CHARACTERIZATION
+    wide_to_tele, tele_to_wide = directional_sweep(
+        SweepAxis.ZOOM, zoom_min, zoom_max, zoom_step, fixed_pan, fixed_tilt, phase=phase
+    )
+    records: list[FrameRecord] = []
+    for plan in (wide_to_tele, tele_to_wide):
+        label = _ZOOM_LABEL[plan.approach_directions[0]]
+        records.extend(
+            capture_pose_sequence(
+                engine,
+                plan.poses,
+                run_id=run_id,
+                camera_id=camera_id,
+                phase=phase,
+                output_dir=output_dir,
+                burst_count=burst_count,
+                survey_context_for=lambda _pose, _i, _label=label: SurveyContext(
+                    approach_direction=_label
+                ),
+            )
+        )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_dense_nadir(
+    engine: SurveyCaptureEngine,
+    spec: CameraSpec,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    nadir_pan: float,
+    nadir_tilt: float,
+    radius_deg: float,
+    zoom: float,
+    overlap_fraction: float,
+    region_id: str = "nadir",
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 4 — dense nadir survey.
+
+    Captures a dense, high-overlap disc of poses around the downward-looking
+    region (~18 m AGL). Every frame is tagged ``phase=dense_nadir`` and carries
+    the nadir ``region_id``.
+
+    Args:
+        engine: The C2 capture engine.
+        spec: Camera specification (drives FOV-based overlap spacing).
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        nadir_pan: Anchor pan of the downward-looking region.
+        nadir_tilt: Anchor tilt of the downward-looking region.
+        radius_deg: Disc radius in degrees.
+        zoom: Single zoom level for the nadir grid.
+        overlap_fraction: Desired fractional overlap in ``[0.0, 1.0)``.
+        region_id: Identifier stamped on every nadir frame.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the nadir frames.
+    """
+    phase = SurveyPhase.DENSE_NADIR
+    poses = nadir_region(
+        spec, nadir_pan, nadir_tilt, radius_deg, zoom, overlap_fraction, phase=phase
+    )
+    records = capture_pose_sequence(
+        engine,
+        poses,
+        run_id=run_id,
+        camera_id=camera_id,
+        phase=phase,
+        output_dir=output_dir,
+        burst_count=burst_count,
+        survey_context_for=lambda _pose, _i: SurveyContext(region_id=region_id),
+    )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_main_survey(
+    engine: SurveyCaptureEngine,
+    poses: Sequence[Pose],
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 5 — main pan/tilt/zoom survey.
+
+    Captures a dense, highly-overlapping visual graph across the operational
+    pan/tilt area at the configured zoom levels. The pose set is the training
+    partition produced by the runner (FOV grid minus the Phase 9 holdout), so
+    every frame is tagged ``phase=main_survey``.
+
+    Args:
+        engine: The C2 capture engine.
+        poses: The training poses to capture (runner-supplied).
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the main-survey frames.
+    """
+    phase = SurveyPhase.MAIN_SURVEY
+    records = capture_pose_sequence(
+        engine,
+        poses,
+        run_id=run_id,
+        camera_id=camera_id,
+        phase=phase,
+        output_dir=output_dir,
+        burst_count=burst_count,
+    )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_cross_zoom(
+    engine: SurveyCaptureEngine,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    anchors: Sequence[tuple[float, float]],
+    zoom_levels: Sequence[float],
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 6 — cross-zoom survey.
+
+    Captures each ground region at multiple zoom levels. All frames observing
+    one region share a stable ``region_id`` (determined before capture by the
+    C3 generator) so cross-scale observations can be connected offline. Frames
+    are tagged ``phase=cross_zoom``.
+
+    Args:
+        engine: The C2 capture engine.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        anchors: ``(pan, tilt)`` region anchors, in order.
+        zoom_levels: Zoom levels to revisit each anchor at.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the cross-zoom frames.
+    """
+    phase = SurveyPhase.CROSS_ZOOM
+    poses = cross_zoom(anchors, zoom_levels, phase=phase)
+    records = capture_pose_sequence(
+        engine,
+        poses,
+        run_id=run_id,
+        camera_id=camera_id,
+        phase=phase,
+        output_dir=output_dir,
+        burst_count=burst_count,
+        survey_context_for=lambda pose, _i: SurveyContext(region_id=pose.region_id),
+    )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_repeatability(
+    engine: SurveyCaptureEngine,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    target_pan: float,
+    target_tilt: float,
+    target_zoom: float,
+    approach_deltas: Sequence[tuple[float, float]],
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 7 — repeatability survey.
+
+    Visits the same commanded target pose multiple times, approaching it from a
+    different direction each time. Each visit's target frame carries
+    ``phase=repeatability``, the approach-direction label, and a sequence index
+    within the repeat group; ``is_repeatability_sequence`` is set on the C2
+    movement context.
+
+    Args:
+        engine: The C2 capture engine.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        target_pan: Target pan in degrees.
+        target_tilt: Target tilt in degrees.
+        target_zoom: Target zoom factor.
+        approach_deltas: ``(pan_offset, tilt_offset)`` approach offsets; at
+            least two distinct directions.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the repeatability frames.
+    """
+    phase = SurveyPhase.REPEATABILITY
+    sequences = repeatability_sequences(
+        target_pan, target_tilt, target_zoom, approach_deltas, phase=phase
+    )
+    records: list[FrameRecord] = []
+    for visit_index, (sub_sequence, (pan_offset, tilt_offset)) in enumerate(
+        zip(sequences, approach_deltas)
+    ):
+        label = _approach_label(pan_offset, tilt_offset)
+        records.extend(
+            capture_pose_sequence(
+                engine,
+                sub_sequence,
+                run_id=run_id,
+                camera_id=camera_id,
+                phase=phase,
+                output_dir=output_dir,
+                burst_count=burst_count,
+                is_repeatability_sequence=True,
+                survey_context_for=lambda _pose, _i, _label=label, _seq=visit_index: SurveyContext(
+                    approach_direction=_label, sequence_index=_seq
+                ),
+            )
+        )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+def run_jitter(
+    engine: SurveyCaptureEngine,
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    rtsp_url: str,
+    poses: Sequence[tuple[float, float]],
+    zoom_levels: Sequence[float],
+    burst_duration_s: float = JITTER_MIN_DURATION_S,
+    target_fps: float = JITTER_MIN_FPS,
+) -> PhaseResult:
+    """Phase 8 — static jitter survey (RTSP/video bursts).
+
+    For each fixed (pose, zoom-level) combination, records an RTSP video segment
+    and extracts its frames via the C2 video-burst path. The camera is never
+    commanded between burst start and end (the engine guarantees this). Both the
+    original segment and addressable per-frame references are persisted; frames
+    and bursts are tagged ``phase=static_jitter``.
+
+    Args:
+        engine: The C2 capture engine.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for segment files and extracted frames.
+        rtsp_url: The RTSP stream URL to record.
+        poses: Fixed ``(pan, tilt)`` poses; at least three.
+        zoom_levels: Fixed zoom levels; at least three.
+        burst_duration_s: Target seconds per burst; at least ten.
+        target_fps: Target frame rate; at least five.
+
+    Returns:
+        A :class:`PhaseResult` with the bursts and their extracted frames.
+
+    Raises:
+        JitterTargetError: If the configuration is below the minimum jitter
+            target (10 s, 5 fps, 3 zoom levels, 3 poses).
+        CaptureEngineError: If a burst produces no segment or no frames.
+    """
+    _assert_jitter_target(poses, zoom_levels, burst_duration_s, target_fps)
+    phase = SurveyPhase.STATIC_JITTER
+    bursts = []
+    frames: list[FrameRecord] = []
+    states: list[CommandedState] = []
+    for pan, tilt in poses:
+        for zoom in zoom_levels:
+            commanded = pose_to_commanded(Pose(pan=_deg(pan), tilt=_deg(tilt), zoom=_unit(zoom)))
+            context = _jitter_context(run_id, camera_id, phase)
+            burst, burst_frames = engine.capture_video_burst(
+                commanded,
+                context,
+                rtsp_url,
+                burst_duration_s=burst_duration_s,
+                output_dir=output_dir,
+                target_fps=target_fps,
+            )
+            _assert_burst_complete(burst)
+            bursts.append(burst)
+            frames.extend(burst_frames)
+            states.append(commanded)
+    return PhaseResult(
+        phase=phase,
+        frames=tuple(frames),
+        bursts=tuple(bursts),
+        commanded_states=tuple(states),
+    )
+
+
+def run_validation(
+    engine: SurveyCaptureEngine,
+    holdout_poses: Sequence[Pose],
+    captured_states: Sequence[CommandedState],
+    *,
+    run_id: str,
+    camera_id: str,
+    output_dir: Path,
+    burst_count: int = 1,
+) -> PhaseResult:
+    """Phase 9 — validation survey (held-out, disjoint pose set).
+
+    Captures the C3 holdout pose set and emits frames tagged
+    ``phase=validation``. Before any capture, asserts that no holdout commanded
+    state (pan, tilt, zoom) coincides with a state already captured in phases
+    4-7, guaranteeing the validation set is disjoint from the training poses.
+
+    Args:
+        engine: The C2 capture engine.
+        holdout_poses: The C3 holdout partition (runner-supplied).
+        captured_states: Commanded states captured in phases 4-7.
+        run_id: Owning survey run id.
+        camera_id: Stable camera identifier.
+        output_dir: Directory for this phase's frame images.
+        burst_count: Snapshot frames per pose.
+
+    Returns:
+        A :class:`PhaseResult` with the validation frames.
+
+    Raises:
+        ValueError: If any holdout pose overlaps a captured training state.
+    """
+    phase = SurveyPhase.VALIDATION
+    _assert_disjoint(holdout_poses, captured_states)
+    records = capture_pose_sequence(
+        engine,
+        holdout_poses,
+        run_id=run_id,
+        camera_id=camera_id,
+        phase=phase,
+        output_dir=output_dir,
+        burst_count=burst_count,
+    )
+    return PhaseResult(phase=phase, frames=tuple(records), commanded_states=_commanded(records))
+
+
+# -- Internal helpers -------------------------------------------------------
+
+
+def _deg(value: float) -> Degrees:
+    return Degrees(float(value))
+
+
+def _unit(value: float) -> Unitless:
+    return Unitless(float(value))
+
+
+def _commanded(records: Sequence[FrameRecord]) -> tuple[CommandedState, ...]:
+    """Collect the distinct commanded states across a phase's frames."""
+    seen: dict[tuple[float, float, float], CommandedState] = {}
+    for record in records:
+        seen[_state_key(record.commanded)] = record.commanded
+    return tuple(seen.values())
+
+
+def _state_key(state: CommandedState) -> tuple[float, float, float]:
+    """A hashable (pan, tilt, zoom) key for commanded-state set membership."""
+    return (
+        float(state.commanded_pan),
+        float(state.commanded_tilt),
+        float(state.commanded_zoom),
+    )
+
+
+def _approach_context(
+    approach_directions: tuple[ApproachDirection, ...],
+) -> Callable[[Pose, int], SurveyContext]:
+    """Build a context factory stamping the sweep's approach direction."""
+    label = approach_directions[0].value if approach_directions else None
+    return lambda _pose, _i: SurveyContext(approach_direction=label)
+
+
+def _approach_label(pan_offset: float, tilt_offset: float) -> str:
+    """Human-readable approach-direction label from a repeatability offset."""
+    parts: list[str] = []
+    if pan_offset < 0:
+        parts.append("from_lower_pan")
+    elif pan_offset > 0:
+        parts.append("from_higher_pan")
+    if tilt_offset < 0:
+        parts.append("from_lower_tilt")
+    elif tilt_offset > 0:
+        parts.append("from_higher_tilt")
+    return "+".join(parts) if parts else "from_target"
+
+
+def _assert_jitter_target(
+    poses: Sequence[tuple[float, float]],
+    zoom_levels: Sequence[float],
+    burst_duration_s: float,
+    target_fps: float,
+) -> None:
+    """Reject Phase 8 configurations below the minimum jitter target."""
+    if len(poses) < JITTER_MIN_POSES:
+        raise JitterTargetError(f"jitter requires >= {JITTER_MIN_POSES} poses, got {len(poses)}")
+    if len(zoom_levels) < JITTER_MIN_ZOOM_LEVELS:
+        raise JitterTargetError(
+            f"jitter requires >= {JITTER_MIN_ZOOM_LEVELS} zoom levels, got {len(zoom_levels)}"
+        )
+    if burst_duration_s < JITTER_MIN_DURATION_S:
+        raise JitterTargetError(
+            f"jitter burst duration must be >= {JITTER_MIN_DURATION_S}s, got {burst_duration_s}"
+        )
+    if target_fps < JITTER_MIN_FPS:
+        raise JitterTargetError(f"jitter fps must be >= {JITTER_MIN_FPS}, got {target_fps}")
+
+
+def _assert_burst_complete(burst: VideoBurstRecord) -> None:
+    """Confirm a burst persisted both its segment and its per-frame references."""
+    if not burst.frame_refs:
+        raise CaptureEngineError(f"jitter burst {burst.burst_id} has no frame references")
+    if str(burst.segment_path) == "":
+        raise CaptureEngineError(f"jitter burst {burst.burst_id} has no segment path")
+
+
+def _assert_disjoint(
+    holdout_poses: Sequence[Pose],
+    captured_states: Sequence[CommandedState],
+) -> None:
+    """Assert no holdout pose shares a commanded state with phases 4-7."""
+    captured = {_state_key(state) for state in captured_states}
+    overlap = [pose for pose in holdout_poses if _state_key(pose_to_commanded(pose)) in captured]
+    if overlap:
+        raise ValueError(
+            f"validation set overlaps {len(overlap)} training commanded state(s); "
+            "holdout must be disjoint from phases 4-7"
+        )
+
+
+def _jitter_context(run_id: str, camera_id: str, phase: SurveyPhase) -> CaptureContext:
+    """Build the per-burst capture context for the jitter phase."""
+    return CaptureContext(run_id=run_id, camera_id=camera_id, phase=phase)

--- a/poc_homography/survey/phases/executors.py
+++ b/poc_homography/survey/phases/executors.py
@@ -634,11 +634,34 @@ def _assert_jitter_target(
 
 
 def _assert_burst_complete(burst: VideoBurstRecord) -> None:
-    """Confirm a burst persisted both its segment and its per-frame references."""
+    """Confirm a burst meets the jitter target and persisted its data.
+
+    Validates the *achieved* burst, not just the requested configuration: the
+    C2 engine stops recording early when the RTSP stream ends, so a burst can
+    come back shorter than the requested ``burst_duration_s``. The DoD requires
+    every burst to *meet* the minimum target (10 s, 5 fps) with both the segment
+    and addressable per-frame references stored, so a short or empty burst fails
+    loudly here rather than being silently marked complete.
+
+    Raises:
+        CaptureEngineError: If the segment path or frame references are missing.
+        JitterTargetError: If the realized duration or stream fps is below the
+            minimum jitter target.
+    """
     if not burst.frame_refs:
         raise CaptureEngineError(f"jitter burst {burst.burst_id} has no frame references")
     if str(burst.segment_path) == "":
         raise CaptureEngineError(f"jitter burst {burst.burst_id} has no segment path")
+    if float(burst.duration_s) < JITTER_MIN_DURATION_S:
+        raise JitterTargetError(
+            f"jitter burst {burst.burst_id} achieved {float(burst.duration_s):.2f}s, "
+            f"below the {JITTER_MIN_DURATION_S}s minimum"
+        )
+    if float(burst.fps) < JITTER_MIN_FPS:
+        raise JitterTargetError(
+            f"jitter burst {burst.burst_id} fps {float(burst.fps):.2f} is below the "
+            f"{JITTER_MIN_FPS} minimum"
+        )
 
 
 def _assert_disjoint(

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -1,0 +1,348 @@
+"""Sequences the nine survey phases for one camera (C4 orchestration).
+
+:func:`execute_survey` runs Phase 1 through Phase 9 in order, routing every
+emitted C1 record to a :class:`PhaseSink`. It owns the cross-phase concerns the
+individual executors cannot: generating the main FOV grid and partitioning it
+into a training set (Phase 5) and a disjoint holdout set (Phase 9) via the C3
+planner, accumulating the commanded states captured in phases 4-7, and asserting
+the validation set is disjoint from them. It builds and returns the C1
+:class:`SurveyRun` header for persistence compatibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.entities.survey.survey_run import SurveyRun
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
+from poc_homography.infrastructure.survey.capture_engine import SurveyCaptureEngine
+from poc_homography.survey.phases import executors
+from poc_homography.survey.planner.generators import fov_grid, partition_holdout
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from poc_homography.domain.entities.survey.frame_record import CommandedState
+    from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.survey.phases.common import PhaseResult, PhaseSink
+    from poc_homography.survey.planner.poses import Pose
+
+
+@dataclass(frozen=True)
+class SurveyPlan:
+    """Per-camera survey parameters consumed by :func:`execute_survey`.
+
+    These are the knobs C5 will later populate from config; the defaults here
+    deliberately satisfy the DoD minimums (e.g. Phase 8: 3 poses x 3 zoom
+    levels, 10 s, 5 fps) and keep the training and holdout sets disjoint by
+    construction. Pan/tilt ranges are intentionally small so a full run is cheap.
+    """
+
+    burst_count: int = 1
+
+    # Phase 2 — PTZ characterization.
+    ptz_pan_range: tuple[float, float] = (0.0, 20.0)
+    ptz_tilt_range: tuple[float, float] = (-20.0, 0.0)
+    ptz_small_step: float = 5.0
+    ptz_large_step: float = 20.0
+    ptz_fixed_pan: float = 0.0
+    ptz_fixed_tilt: float = -10.0
+    ptz_fixed_zoom: float = 1.0
+    ptz_repeat_count: int = 2
+
+    # Phase 3 — zoom characterization.
+    zoom_min: float = 1.0
+    zoom_max: float = 16.0
+    zoom_step: float = 5.0
+    zoom_fixed_pan: float = 0.0
+    zoom_fixed_tilt: float = -10.0
+
+    # Phase 4 — dense nadir.
+    nadir_pan: float = 180.0
+    nadir_tilt: float = -85.0
+    nadir_radius_deg: float = 3.0
+    nadir_zoom: float = 8.0
+    nadir_overlap_fraction: float = 0.8
+    nadir_region_id: str = "nadir"
+
+    # Phase 5 — main survey (and Phase 9 holdout source).
+    main_pan_range: tuple[float, float] = (0.0, 30.0)
+    main_tilt_range: tuple[float, float] = (-30.0, -10.0)
+    main_zoom_levels: tuple[float, ...] = (2.0, 8.0)
+    main_overlap_fraction: float = 0.5
+
+    # Phase 6 — cross-zoom.
+    cross_zoom_anchors: tuple[tuple[float, float], ...] = (
+        (90.0, -20.0),
+        (120.0, -25.0),
+    )
+    cross_zoom_levels: tuple[float, ...] = (2.0, 8.0, 16.0)
+
+    # Phase 7 — repeatability.
+    repeat_target_pan: float = 200.0
+    repeat_target_tilt: float = -30.0
+    repeat_target_zoom: float = 4.0
+    repeat_approach_deltas: tuple[tuple[float, float], ...] = (
+        (-5.0, 0.0),
+        (5.0, 0.0),
+        (0.0, -5.0),
+    )
+
+    # Phase 8 — static jitter.
+    jitter_rtsp_url: str = ""
+    jitter_poses: tuple[tuple[float, float], ...] = (
+        (10.0, -15.0),
+        (90.0, -20.0),
+        (200.0, -30.0),
+    )
+    jitter_zoom_levels: tuple[float, ...] = (1.0, 8.0, 16.0)
+    jitter_burst_duration_s: float = 10.0
+    jitter_target_fps: float = 5.0
+
+    # Phase 9 — validation holdout partition.
+    holdout_fraction: float = 0.25
+    holdout_seed: int = 261
+
+
+@dataclass(frozen=True)
+class SurveyExecution:
+    """The outcome of a full multi-phase run."""
+
+    run: SurveyRun
+    results: tuple[PhaseResult, ...] = field(default=())
+
+
+def execute_survey(
+    camera: CameraDevice,
+    *,
+    run_id: str,
+    camera_id: str,
+    sink: PhaseSink,
+    base_output_dir: Path,
+    plan: SurveyPlan | None = None,
+    spec: CameraSpec = CameraSpec.HIKVISION_DS_2DF8425IX,
+    clock: Callable[[], datetime] | None = None,
+    uuid_factory: Callable[[], str] | None = None,
+) -> SurveyExecution:
+    """Run all nine survey phases for one camera, in order.
+
+    Args:
+        camera: The #256 ``CameraDevice`` to drive.
+        run_id: Unique survey run id.
+        camera_id: Stable camera identifier.
+        sink: Destination for every emitted C1 record.
+        base_output_dir: Root directory; each phase writes under a sub-directory
+            named for its phase value.
+        plan: Survey parameters; defaults to a DoD-satisfying :class:`SurveyPlan`.
+        spec: Camera specification driving FOV-based pose spacing.
+        clock: Returns timezone-aware UTC timestamps; injectable for tests.
+        uuid_factory: Returns fresh id strings for bursts; injectable for tests.
+
+    Returns:
+        A :class:`SurveyExecution` with the C1 :class:`SurveyRun` header and the
+        per-phase results.
+
+    Raises:
+        JitterTargetError: If Phase 8 is below the minimum jitter target.
+        ValueError: If the Phase 9 holdout overlaps a captured training state.
+    """
+    plan = plan or SurveyPlan()
+    now = clock or _utcnow
+    engine = SurveyCaptureEngine(camera, clock=clock, uuid_factory=uuid_factory)
+    started_at = now()
+
+    training, holdout = _partition_main_grid(spec, plan)
+
+    results: list[PhaseResult] = []
+    captured_4_to_7: list[CommandedState] = []
+
+    inventory = executors.run_inventory(camera, run_id=run_id, camera_id=camera_id, clock=now)
+    results.append(inventory)
+
+    results.append(
+        executors.run_ptz_characterization(
+            engine,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.PTZ_CHARACTERIZATION),
+            pan_range=plan.ptz_pan_range,
+            tilt_range=plan.ptz_tilt_range,
+            small_step=plan.ptz_small_step,
+            large_step=plan.ptz_large_step,
+            fixed_tilt=plan.ptz_fixed_tilt,
+            fixed_pan=plan.ptz_fixed_pan,
+            fixed_zoom=plan.ptz_fixed_zoom,
+            repeat_count=plan.ptz_repeat_count,
+            burst_count=plan.burst_count,
+        )
+    )
+
+    results.append(
+        executors.run_zoom_characterization(
+            engine,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.ZOOM_CHARACTERIZATION),
+            zoom_min=plan.zoom_min,
+            zoom_max=plan.zoom_max,
+            zoom_step=plan.zoom_step,
+            fixed_pan=plan.zoom_fixed_pan,
+            fixed_tilt=plan.zoom_fixed_tilt,
+            burst_count=plan.burst_count,
+        )
+    )
+
+    nadir = executors.run_dense_nadir(
+        engine,
+        spec,
+        run_id=run_id,
+        camera_id=camera_id,
+        output_dir=_phase_dir(base_output_dir, SurveyPhase.DENSE_NADIR),
+        nadir_pan=plan.nadir_pan,
+        nadir_tilt=plan.nadir_tilt,
+        radius_deg=plan.nadir_radius_deg,
+        zoom=plan.nadir_zoom,
+        overlap_fraction=plan.nadir_overlap_fraction,
+        region_id=plan.nadir_region_id,
+        burst_count=plan.burst_count,
+    )
+    results.append(nadir)
+    captured_4_to_7.extend(nadir.commanded_states)
+
+    main = executors.run_main_survey(
+        engine,
+        training,
+        run_id=run_id,
+        camera_id=camera_id,
+        output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
+        burst_count=plan.burst_count,
+    )
+    results.append(main)
+    captured_4_to_7.extend(main.commanded_states)
+
+    cross = executors.run_cross_zoom(
+        engine,
+        run_id=run_id,
+        camera_id=camera_id,
+        output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
+        anchors=plan.cross_zoom_anchors,
+        zoom_levels=plan.cross_zoom_levels,
+        burst_count=plan.burst_count,
+    )
+    results.append(cross)
+    captured_4_to_7.extend(cross.commanded_states)
+
+    repeat = executors.run_repeatability(
+        engine,
+        run_id=run_id,
+        camera_id=camera_id,
+        output_dir=_phase_dir(base_output_dir, SurveyPhase.REPEATABILITY),
+        target_pan=plan.repeat_target_pan,
+        target_tilt=plan.repeat_target_tilt,
+        target_zoom=plan.repeat_target_zoom,
+        approach_deltas=plan.repeat_approach_deltas,
+        burst_count=plan.burst_count,
+    )
+    results.append(repeat)
+    captured_4_to_7.extend(repeat.commanded_states)
+
+    results.append(
+        executors.run_jitter(
+            engine,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.STATIC_JITTER),
+            rtsp_url=plan.jitter_rtsp_url,
+            poses=plan.jitter_poses,
+            zoom_levels=plan.jitter_zoom_levels,
+            burst_duration_s=plan.jitter_burst_duration_s,
+            target_fps=plan.jitter_target_fps,
+        )
+    )
+
+    results.append(
+        executors.run_validation(
+            engine,
+            holdout,
+            captured_4_to_7,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
+            burst_count=plan.burst_count,
+        )
+    )
+
+    _emit(results, sink)
+    _assert_no_cross_tagging(results)
+
+    run = SurveyRun(
+        run_id=run_id,
+        camera_id=camera_id,
+        phases=frozenset(result.phase for result in results),
+        started_at=started_at,
+        finished_at=now(),
+        status=SurveyRunStatus.COMPLETED,
+    )
+    return SurveyExecution(run=run, results=tuple(results))
+
+
+# -- Internal helpers -------------------------------------------------------
+
+
+def _utcnow() -> datetime:
+    """Return the current timezone-aware UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _phase_dir(base: Path, phase: SurveyPhase) -> Path:
+    """Return the per-phase output sub-directory."""
+    return base / phase.value
+
+
+def _partition_main_grid(spec: CameraSpec, plan: SurveyPlan) -> tuple[list[Pose], list[Pose]]:
+    """Build the main FOV grid and split it into training and holdout sets."""
+    grid = fov_grid(
+        spec,
+        plan.main_pan_range,
+        plan.main_tilt_range,
+        plan.main_zoom_levels,
+        plan.main_overlap_fraction,
+    )
+    training, holdout = partition_holdout(grid, plan.holdout_fraction, plan.holdout_seed)
+    return training, holdout
+
+
+def _emit(results: list[PhaseResult], sink: PhaseSink) -> None:
+    """Route every record produced by every phase to the sink."""
+    for result in results:
+        if result.inventory is not None:
+            sink.save_inventory(result.inventory)
+        for burst in result.bursts:
+            sink.save_burst(burst)
+        for frame in result.frames:
+            sink.save_frame(frame)
+
+
+def _assert_no_cross_tagging(results: list[PhaseResult]) -> None:
+    """Assert no phase emitted a record tagged with another phase's identifier."""
+    for result in results:
+        for frame in result.frames:
+            if frame.capture.phase is not result.phase:
+                raise ValueError(
+                    f"phase {result.phase.value} emitted a frame tagged {frame.capture.phase.value}"
+                )
+        for burst in result.bursts:
+            if burst.phase is not result.phase:
+                raise ValueError(
+                    f"phase {result.phase.value} emitted a burst tagged {burst.phase.value}"
+                )
+        if result.inventory is not None and result.inventory.phase is not result.phase:
+            raise ValueError(
+                f"phase {result.phase.value} emitted an inventory record tagged "
+                f"{result.inventory.phase.value}"
+            )

--- a/tests/survey/conftest.py
+++ b/tests/survey/conftest.py
@@ -1,0 +1,285 @@
+"""Shared fixtures for the C4 survey-phase tests.
+
+Provides a recording :class:`CameraDevice` double, deterministic clock/uuid
+factories, and an RTSP monkeypatch so the Phase 8 video-burst path runs fully
+offline (mirroring ``tests/infrastructure/survey/test_capture_engine.py``).
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from poc_homography.domain.vo.camera_capabilities import CameraCapabilities
+from poc_homography.domain.vo.camera_preset import CameraPreset
+from poc_homography.domain.vo.device_health import DeviceHealth, LensOdometry
+from poc_homography.domain.vo.device_info import DeviceInfo
+from poc_homography.domain.vo.image_optics import (
+    ExposureState,
+    FocusState,
+    ImageOptics,
+    IrisState,
+    WhiteBalanceState,
+)
+from poc_homography.domain.vo.ptz_state import PTZState
+from poc_homography.domain.vo.stream_profile import StreamProfile
+from poc_homography.infrastructure.survey import capture_engine
+from poc_homography.types import Degrees, FocusSteps, Pixels, Unitless
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def make_jpeg(width: int = 64, height: int = 48) -> bytes:
+    """Return JPEG bytes of a solid image with the given dimensions."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color=(10, 20, 30)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def make_optics() -> ImageOptics:
+    """Build a representative :class:`ImageOptics`."""
+    return ImageOptics(
+        focus=FocusState(style="SEMIAUTOMATIC", focus_limited=150),
+        iris=IrisState(level=50, min_level=0, max_level=100),
+        exposure=ExposureState(exposure_type="auto", overexpose_suppress=False),
+        white_balance=WhiteBalanceState(style="auto", red=50, blue=50),
+    )
+
+
+def make_device_info() -> DeviceInfo:
+    """Build a representative :class:`DeviceInfo`."""
+    return DeviceInfo(
+        model="DS-2DF8425IX-AELW",
+        serial_number="SN123456",
+        mac_address="00:11:22:33:44:55",
+        firmware_version="V5.7.3",
+        device_name="cam",
+        device_type="IPDome",
+        device_id="dev-1",
+        device_description="desc",
+        encoder_version="E1",
+        boot_version="B1",
+        hardware_version="H1",
+        platform_name="H8",
+        manufacturer="Hikvision",
+    )
+
+
+def make_capabilities() -> CameraCapabilities:
+    """Build a representative :class:`CameraCapabilities`."""
+    return CameraCapabilities(
+        pan_min=Degrees(0.0),
+        pan_max=Degrees(360.0),
+        tilt_min=Degrees(-90.0),
+        tilt_max=Degrees(90.0),
+        zoom_min=Unitless(1.0),
+        zoom_max=Unitless(25.0),
+        focus_min=FocusSteps(0),
+        focus_max=FocusSteps(1000),
+        pan_speed_min=0.1,
+        pan_speed_max=100.0,
+        tilt_speed_min=0.1,
+        tilt_speed_max=100.0,
+    )
+
+
+def make_health() -> DeviceHealth:
+    """Build a representative :class:`DeviceHealth`."""
+    return DeviceHealth(
+        uptime_seconds=3600,
+        cpu_utilization=12,
+        memory_usage=34,
+        fan_state=1,
+        heat_state=0,
+        total_reboot_count=2,
+        odometry=LensOdometry(
+            zoom_reverse_times=1,
+            zoom_total_steps=10,
+            focus_reverse_times=2,
+            focus_total_steps=20,
+            iris_shift_times=3,
+            iris_total_steps=30,
+            icr_shift_times=4,
+            lens_intir_times=5,
+            camera_run_total_time=6,
+            pan_total_rounds=7,
+            tilt_total_rounds=8,
+        ),
+    )
+
+
+def make_stream_profile() -> StreamProfile:
+    """Build a representative :class:`StreamProfile`."""
+    return StreamProfile(
+        channel_id=101,
+        codec="H.264",
+        width=Pixels(2560),
+        height=Pixels(1440),
+        fps=25.0,
+        bitrate_kbps=4096,
+        quality_control="VBR",
+        transports=["RTSP"],
+    )
+
+
+def make_preset() -> CameraPreset:
+    """Build a representative :class:`CameraPreset`."""
+    return CameraPreset(
+        preset_id=1,
+        name="home",
+        ptz=PTZState(pan_raw=Degrees(0.0), tilt_deg=Degrees(0.0), zoom=Unitless(1.0), focus=100),
+    )
+
+
+class IncrementingClock:
+    """A deterministic clock advancing by a fixed step per call."""
+
+    def __init__(self, step_s: float = 1.0) -> None:
+        self._now = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+        self._step = timedelta(seconds=step_s)
+
+    def __call__(self) -> datetime:
+        current = self._now
+        self._now = self._now + self._step
+        return current
+
+
+class CountingUuid:
+    """A deterministic uuid factory yielding stable, unique ids."""
+
+    def __init__(self) -> None:
+        self._n = 0
+
+    def __call__(self) -> str:
+        self._n += 1
+        return f"burst-{self._n:04d}"
+
+
+class FakeCamera:
+    """A recording :class:`CameraDevice` double for offline phase tests."""
+
+    def __init__(self, *, reported: PTZState | None = None) -> None:
+        self.calls: list[str] = []
+        self._reported = reported or PTZState(
+            pan_raw=Degrees(1.0), tilt_deg=Degrees(-1.0), zoom=Unitless(2.0), focus=510
+        )
+
+    def move_absolute(
+        self, pan: float | None = None, tilt: float | None = None, zoom: float | None = None
+    ) -> PTZState:
+        self.calls.append("move_absolute")
+        return self._reported
+
+    def set_focus(self, focus: int) -> None:
+        self.calls.append("set_focus")
+
+    def wait_for_stabilization(self, timeout_s: float = 5.0, threshold: float = 0.1) -> PTZState:
+        self.calls.append("wait_for_stabilization")
+        return self._reported
+
+    def get_device_info(self) -> DeviceInfo:
+        self.calls.append("get_device_info")
+        return make_device_info()
+
+    def get_capabilities(self) -> CameraCapabilities:
+        self.calls.append("get_capabilities")
+        return make_capabilities()
+
+    def get_health(self) -> DeviceHealth:
+        self.calls.append("get_health")
+        return make_health()
+
+    def get_optics(self) -> ImageOptics:
+        self.calls.append("get_optics")
+        return make_optics()
+
+    def get_stream_profiles(self) -> list[StreamProfile]:
+        self.calls.append("get_stream_profiles")
+        return [make_stream_profile()]
+
+    def list_presets(self) -> list[CameraPreset]:
+        self.calls.append("list_presets")
+        return [make_preset()]
+
+    def capture_snapshot(self) -> bytes:
+        self.calls.append("capture_snapshot")
+        return make_jpeg()
+
+
+@pytest.fixture()
+def camera() -> FakeCamera:
+    """Return a fresh :class:`FakeCamera`."""
+    return FakeCamera()
+
+
+@pytest.fixture()
+def clock() -> IncrementingClock:
+    """Return a deterministic incrementing clock."""
+    return IncrementingClock()
+
+
+@pytest.fixture()
+def uuid_factory() -> CountingUuid:
+    """Return a deterministic uuid factory."""
+    return CountingUuid()
+
+
+class _FakeCapture:
+    """A fake :class:`cv2.VideoCapture` yielding a fixed list of frames."""
+
+    def __init__(self, frames: list[Any]) -> None:
+        self._frames = list(frames)
+        self.released = False
+
+    def isOpened(self) -> bool:
+        return True
+
+    def read(self) -> tuple[bool, Any]:
+        if self._frames:
+            return True, self._frames.pop(0)
+        return False, None
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeWriter:
+    """A fake :class:`cv2.VideoWriter` counting written frames."""
+
+    def __init__(self, path: Any) -> None:
+        path.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+        self.frames_written = 0
+
+    def write(self, frame: Any) -> None:
+        self.frames_written += 1
+
+    def release(self) -> None:
+        return None
+
+
+@pytest.fixture()
+def patch_rtsp(monkeypatch: pytest.MonkeyPatch) -> Callable[[int], None]:
+    """Patch the engine's RTSP open/write seams with in-memory fakes.
+
+    Returns a configurator that (re)installs fakes producing ``n`` frames per
+    burst; call it before driving the jitter phase.
+    """
+
+    def configure(n_frames: int) -> None:
+        def fake_open_capture(rtsp_url: str) -> _FakeCapture:
+            frames = [np.zeros((48, 64, 3), dtype=np.uint8) for _ in range(n_frames)]
+            return _FakeCapture(frames)
+
+        def fake_open_writer(path: Any, fps: float, frame_size: tuple[int, int]) -> _FakeWriter:
+            return _FakeWriter(path)
+
+        monkeypatch.setattr(capture_engine, "_open_capture", fake_open_capture)
+        monkeypatch.setattr(capture_engine, "_open_writer", fake_open_writer)
+
+    return configure

--- a/tests/survey/test_inventory_record.py
+++ b/tests/survey/test_inventory_record.py
@@ -1,0 +1,73 @@
+"""Round-trip and schema tests for :class:`CameraInventoryRecord`."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from tests.survey.conftest import (
+    make_capabilities,
+    make_device_info,
+    make_health,
+    make_optics,
+    make_preset,
+    make_stream_profile,
+)
+
+from poc_homography.domain.entities.survey import SURVEY_SCHEMA_VERSION
+from poc_homography.domain.entities.survey.inventory_record import (
+    CameraInventoryRecord,
+)
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+
+
+def _make_record() -> CameraInventoryRecord:
+    return CameraInventoryRecord(
+        record_id="run-1_inventory",
+        run_id="run-1",
+        camera_id="icozee-camptz-04",
+        captured_at=datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc),
+        device_info=make_device_info(),
+        capabilities=make_capabilities(),
+        optics=make_optics(),
+        health=make_health(),
+        stream_profiles=(make_stream_profile(),),
+        presets=(make_preset(),),
+    )
+
+
+class TestCameraInventoryRecord:
+    def test_round_trip(self) -> None:
+        record = _make_record()
+        restored = CameraInventoryRecord.from_dict(record.to_dict())
+        assert restored == record
+        assert restored.to_dict() == record.to_dict()
+
+    def test_phase_is_camera_inventory(self) -> None:
+        record = _make_record()
+        assert record.phase is SurveyPhase.CAMERA_INVENTORY
+        assert record.to_dict()["phase"] == "camera_inventory"
+
+    def test_id_is_record_id(self) -> None:
+        assert _make_record().id == "run-1_inventory"
+
+    def test_contains_full_self_report(self) -> None:
+        data = _make_record().to_dict()
+        # Identity + firmware, PTZ caps, image settings, stream config,
+        # zoom/focus caps, and image-pipeline state are all present.
+        assert data["device_info"]["firmware_version"] == "V5.7.3"
+        assert data["capabilities"]["zoom_max"] == 25.0
+        assert data["capabilities"]["focus_max"] == 1000
+        assert data["optics"]["focus"]["style"] == "SEMIAUTOMATIC"
+        assert data["stream_profiles"][0]["codec"] == "H.264"
+        assert data["health"]["odometry"]["zoom_total_steps"] == 10
+        assert data["presets"][0]["name"] == "home"
+
+    def test_schema_version_default(self) -> None:
+        assert _make_record().schema_version == SURVEY_SCHEMA_VERSION
+
+    def test_unknown_version_raises(self) -> None:
+        data = _make_record().to_dict()
+        data["schema_version"] = "999.0"
+        with pytest.raises(ValueError, match="schema_version"):
+            CameraInventoryRecord.from_dict(data)

--- a/tests/survey/test_phases.py
+++ b/tests/survey/test_phases.py
@@ -1,0 +1,317 @@
+"""Per-phase DoD tests for the nine C4 survey-phase executors."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.infrastructure.survey.capture_engine import SurveyCaptureEngine
+from poc_homography.survey.phases import executors
+from poc_homography.survey.phases.common import pose_to_commanded
+from poc_homography.survey.planner.generators import fov_grid, partition_holdout
+from poc_homography.survey.planner.poses import Pose
+from poc_homography.types import Degrees, Unitless
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.survey.conftest import CountingUuid, FakeCamera, IncrementingClock
+
+_SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
+
+
+def _engine(
+    camera: FakeCamera, clock: IncrementingClock, uuid_factory: CountingUuid
+) -> SurveyCaptureEngine:
+    return SurveyCaptureEngine(camera, clock=clock, uuid_factory=uuid_factory)
+
+
+class TestPhase1Inventory:
+    def test_emits_one_inventory_record_with_full_self_report(
+        self, camera: FakeCamera, clock: IncrementingClock
+    ) -> None:
+        result = executors.run_inventory(camera, run_id="run-1", camera_id="cam01", clock=clock)
+        assert result.phase is SurveyPhase.CAMERA_INVENTORY
+        assert result.inventory is not None
+        record = result.inventory
+        assert record.phase is SurveyPhase.CAMERA_INVENTORY
+        assert record.device_info.firmware_version == "V5.7.3"
+        assert record.capabilities.zoom_max == 25.0
+        assert record.optics.focus.style == "SEMIAUTOMATIC"
+        assert record.stream_profiles and record.presets
+        # Single-pass query across all capability/state surfaces.
+        for method in (
+            "get_device_info",
+            "get_capabilities",
+            "get_optics",
+            "get_health",
+            "get_stream_profiles",
+            "list_presets",
+        ):
+            assert method in camera.calls
+
+
+class TestPhase2PtzCharacterization:
+    def test_small_large_repeated_moves_both_axes(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        result = executors.run_ptz_characterization(
+            _engine(camera, clock, uuid_factory),
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            pan_range=(0.0, 20.0),
+            tilt_range=(-20.0, 0.0),
+            small_step=5.0,
+            large_step=20.0,
+            fixed_tilt=-10.0,
+            fixed_pan=0.0,
+            fixed_zoom=1.0,
+            repeat_count=2,
+        )
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.PTZ_CHARACTERIZATION for f in result.frames)
+        pan_dirs = {f.movement.direction_pan for f in result.frames}
+        tilt_dirs = {f.movement.direction_tilt for f in result.frames}
+        assert {"cw", "ccw"} <= pan_dirs
+        assert {"up", "down"} <= tilt_dirs
+
+
+class TestPhase3ZoomCharacterization:
+    def test_both_directional_passes_distinguishable(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        result = executors.run_zoom_characterization(
+            _engine(camera, clock, uuid_factory),
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            zoom_min=1.0,
+            zoom_max=16.0,
+            zoom_step=5.0,
+            fixed_pan=0.0,
+            fixed_tilt=-10.0,
+        )
+        assert all(f.capture.phase is SurveyPhase.ZOOM_CHARACTERIZATION for f in result.frames)
+        labels = [f.survey_context.approach_direction for f in result.frames]
+        assert "wide_to_tele" in labels
+        assert "tele_to_wide" in labels
+        # Passes are not interleaved: all wide_to_tele precede all tele_to_wide.
+        first_t2w = labels.index("tele_to_wide")
+        assert all(label == "wide_to_tele" for label in labels[:first_t2w])
+
+
+class TestPhase4DenseNadir:
+    def test_region_id_on_every_frame(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        result = executors.run_dense_nadir(
+            _engine(camera, clock, uuid_factory),
+            _SPEC,
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            nadir_pan=180.0,
+            nadir_tilt=-85.0,
+            radius_deg=3.0,
+            zoom=8.0,
+            overlap_fraction=0.8,
+        )
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.DENSE_NADIR for f in result.frames)
+        assert all(f.survey_context.region_id == "nadir" for f in result.frames)
+
+
+class TestPhase5MainSurvey:
+    def test_spans_zoom_levels(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        poses = fov_grid(_SPEC, (0.0, 10.0), (-10.0, 0.0), (2.0, 8.0), 0.5)
+        result = executors.run_main_survey(
+            _engine(camera, clock, uuid_factory),
+            poses,
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+        )
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.MAIN_SURVEY for f in result.frames)
+        commanded_zooms = {float(f.commanded.commanded_zoom) for f in result.frames}
+        assert {2.0, 8.0} <= commanded_zooms
+
+
+class TestPhase6CrossZoom:
+    def test_shared_region_id_across_zoom_levels(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        result = executors.run_cross_zoom(
+            _engine(camera, clock, uuid_factory),
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            anchors=((90.0, -20.0), (120.0, -25.0)),
+            zoom_levels=(2.0, 8.0, 16.0),
+        )
+        assert all(f.capture.phase is SurveyPhase.CROSS_ZOOM for f in result.frames)
+        region_0 = [f for f in result.frames if f.survey_context.region_id == "region_0"]
+        assert len(region_0) == 3
+        assert {float(f.commanded.commanded_zoom) for f in region_0} == {2.0, 8.0, 16.0}
+
+
+class TestPhase7Repeatability:
+    def test_multiple_visits_varying_approach(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        result = executors.run_repeatability(
+            _engine(camera, clock, uuid_factory),
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            target_pan=200.0,
+            target_tilt=-30.0,
+            target_zoom=4.0,
+            approach_deltas=((-5.0, 0.0), (5.0, 0.0), (0.0, -5.0)),
+        )
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.REPEATABILITY for f in result.frames)
+        assert all(f.movement.is_repeatability_sequence for f in result.frames)
+        approaches = {f.survey_context.approach_direction for f in result.frames}
+        assert len({a for a in approaches if a}) >= 2
+        sequences = {f.survey_context.sequence_index for f in result.frames}
+        assert len({s for s in sequences if s is not None}) == 3
+
+
+class TestPhase8Jitter:
+    def test_bursts_meet_minimum_target(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        result = executors.run_jitter(
+            _engine(camera, clock, uuid_factory),
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+            rtsp_url="rtsp://fake/stream",
+            poses=((10.0, -15.0), (90.0, -20.0), (200.0, -30.0)),
+            zoom_levels=(1.0, 8.0, 16.0),
+            burst_duration_s=10.0,
+            target_fps=5.0,
+        )
+        assert len(result.bursts) == 9  # 3 poses x 3 zoom levels
+        assert all(b.phase is SurveyPhase.STATIC_JITTER for b in result.bursts)
+        for burst in result.bursts:
+            assert burst.segment_path.exists()
+            assert burst.frame_refs  # addressable per-frame references
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.STATIC_JITTER for f in result.frames)
+
+    def test_too_few_poses_rejected(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        with pytest.raises(executors.JitterTargetError):
+            executors.run_jitter(
+                _engine(camera, clock, uuid_factory),
+                run_id="run-1",
+                camera_id="cam01",
+                output_dir=tmp_path,
+                rtsp_url="rtsp://fake/stream",
+                poses=((10.0, -15.0), (90.0, -20.0)),
+                zoom_levels=(1.0, 8.0, 16.0),
+            )
+
+    def test_too_short_duration_rejected(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        with pytest.raises(executors.JitterTargetError):
+            executors.run_jitter(
+                _engine(camera, clock, uuid_factory),
+                run_id="run-1",
+                camera_id="cam01",
+                output_dir=tmp_path,
+                rtsp_url="rtsp://fake/stream",
+                poses=((10.0, -15.0), (90.0, -20.0), (200.0, -30.0)),
+                zoom_levels=(1.0, 8.0, 16.0),
+                burst_duration_s=5.0,
+            )
+
+
+class TestPhase9Validation:
+    def test_disjoint_holdout_captured(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        grid = fov_grid(_SPEC, (0.0, 10.0), (-10.0, 0.0), (2.0, 8.0), 0.5)
+        training, holdout = partition_holdout(grid, 0.3, seed=7)
+        captured = [pose_to_commanded(p) for p in training]
+        result = executors.run_validation(
+            _engine(camera, clock, uuid_factory),
+            holdout,
+            captured,
+            run_id="run-1",
+            camera_id="cam01",
+            output_dir=tmp_path,
+        )
+        assert result.frames
+        assert all(f.capture.phase is SurveyPhase.VALIDATION for f in result.frames)
+
+    def test_overlap_raises(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        holdout = [Pose(pan=Degrees(5.0), tilt=Degrees(-5.0), zoom=Unitless(2.0), is_holdout=True)]
+        captured = [pose_to_commanded(holdout[0])]  # identical commanded state
+        with pytest.raises(ValueError, match="disjoint"):
+            executors.run_validation(
+                _engine(camera, clock, uuid_factory),
+                holdout,
+                captured,
+                run_id="run-1",
+                camera_id="cam01",
+                output_dir=tmp_path,
+            )

--- a/tests/survey/test_phases.py
+++ b/tests/survey/test_phases.py
@@ -255,6 +255,28 @@ class TestPhase8Jitter:
                 zoom_levels=(1.0, 8.0, 16.0),
             )
 
+    def test_short_achieved_burst_rejected(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        # A stream that ends after a single frame yields a burst far shorter
+        # than the 10s minimum; the achieved-target guard must reject it.
+        patch_rtsp(1)
+        with pytest.raises(executors.JitterTargetError):
+            executors.run_jitter(
+                _engine(camera, clock, uuid_factory),
+                run_id="run-1",
+                camera_id="cam01",
+                output_dir=tmp_path,
+                rtsp_url="rtsp://fake/stream",
+                poses=((10.0, -15.0), (90.0, -20.0), (200.0, -30.0)),
+                zoom_levels=(1.0, 8.0, 16.0),
+            )
+
     def test_too_short_duration_rejected(
         self,
         camera: FakeCamera,

--- a/tests/survey/test_runner.py
+++ b/tests/survey/test_runner.py
@@ -1,0 +1,182 @@
+"""End-to-end tests for the nine-phase survey runner and the YAML sink."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
+from poc_homography.infrastructure.repositories.repo_yaml_survey_run import (
+    RepoYamlSurveyRun,
+)
+from poc_homography.infrastructure.survey.yaml_phase_sink import YamlPhaseSink
+from poc_homography.survey.phases.runner import SurveyExecution, execute_survey
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.survey.conftest import CountingUuid, FakeCamera, IncrementingClock
+
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+    from poc_homography.domain.entities.survey.inventory_record import (
+        CameraInventoryRecord,
+    )
+    from poc_homography.domain.entities.survey.video_burst_record import (
+        VideoBurstRecord,
+    )
+
+_ALL_NINE = set(SurveyPhase)
+
+
+class _RecordingSink:
+    """In-memory :class:`PhaseSink` collecting every emitted record."""
+
+    def __init__(self) -> None:
+        self.frames: list[FrameRecord] = []
+        self.bursts: list[VideoBurstRecord] = []
+        self.inventories: list[CameraInventoryRecord] = []
+
+    def save_inventory(self, record: CameraInventoryRecord) -> None:
+        self.inventories.append(record)
+
+    def save_frame(self, record: FrameRecord) -> None:
+        self.frames.append(record)
+
+    def save_burst(self, record: VideoBurstRecord) -> None:
+        self.bursts.append(record)
+
+
+def _run(
+    camera: FakeCamera,
+    clock: IncrementingClock,
+    uuid_factory: CountingUuid,
+    sink: object,
+    base: Path,
+) -> SurveyExecution:
+    return execute_survey(
+        camera,
+        run_id="run-1",
+        camera_id="icozee-camptz-04",
+        sink=sink,  # type: ignore[arg-type]
+        base_output_dir=base,
+        clock=clock,
+        uuid_factory=uuid_factory,
+    )
+
+
+class TestExecuteSurvey:
+    def test_all_nine_phases_run(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        sink = _RecordingSink()
+        execution = _run(camera, clock, uuid_factory, sink, tmp_path)
+        assert {r.phase for r in execution.results} == _ALL_NINE
+        assert execution.run.phases == frozenset(_ALL_NINE)
+        assert execution.run.status is SurveyRunStatus.COMPLETED
+
+    def test_one_inventory_record(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        sink = _RecordingSink()
+        _run(camera, clock, uuid_factory, sink, tmp_path)
+        assert len(sink.inventories) == 1
+        assert sink.inventories[0].phase is SurveyPhase.CAMERA_INVENTORY
+
+    def test_no_record_tagged_with_another_phase(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        sink = _RecordingSink()
+        execution = _run(camera, clock, uuid_factory, sink, tmp_path)
+        for result in execution.results:
+            assert all(f.capture.phase is result.phase for f in result.frames)
+            assert all(b.phase is result.phase for b in result.bursts)
+
+    def test_jitter_present_and_complete(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        sink = _RecordingSink()
+        _run(camera, clock, uuid_factory, sink, tmp_path)
+        assert len(sink.bursts) == 9
+        for burst in sink.bursts:
+            assert burst.phase is SurveyPhase.STATIC_JITTER
+            assert burst.segment_path.exists()
+            assert burst.frame_refs
+
+    def test_validation_disjoint_from_training(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        sink = _RecordingSink()
+        _run(camera, clock, uuid_factory, sink, tmp_path)
+
+        def keys(frames: list[FrameRecord]) -> set[tuple[float, float, float]]:
+            return {
+                (
+                    float(f.commanded.commanded_pan),
+                    float(f.commanded.commanded_tilt),
+                    float(f.commanded.commanded_zoom),
+                )
+                for f in frames
+            }
+
+        training_phases = {
+            SurveyPhase.DENSE_NADIR,
+            SurveyPhase.MAIN_SURVEY,
+            SurveyPhase.CROSS_ZOOM,
+            SurveyPhase.REPEATABILITY,
+        }
+        training = [f for f in sink.frames if f.capture.phase in training_phases]
+        validation = [f for f in sink.frames if f.capture.phase is SurveyPhase.VALIDATION]
+        assert validation
+        assert keys(training).isdisjoint(keys(validation))
+
+
+class TestYamlPhaseSinkDataset:
+    def test_dataset_queryable_by_phase(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        survey_root = tmp_path / "survey"
+        sink = YamlPhaseSink(survey_root)
+        _run(camera, clock, uuid_factory, sink, tmp_path / "images")
+
+        repo = RepoYamlSurveyRun(tmp_path / "survey_runs", frames_dir=survey_root)
+        all_frames = repo.get_frames_by_run("run-1")
+        assert all_frames
+        image_bearing = _ALL_NINE - {SurveyPhase.CAMERA_INVENTORY}
+        for phase in image_bearing:
+            assert repo.get_frames_by_phase(phase), f"no frames for {phase.value}"

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -333,3 +333,6 @@ _.remaining_poses  # PlannedSurveyRun resume iterator (poc_homography/survey/pla
 _.advance  # PlannedSurveyRun cursor advance (poc_homography/survey/planner/run.py)
 _.with_status  # PlannedSurveyRun status transition helper (poc_homography/survey/planner/run.py)
 _.header  # PlannedSurveyRun -> C1 SurveyRun persistence bridge (poc_homography/survey/planner/run.py)
+
+# -- Survey phases C4 (#261); consumed by C5 (CLI/endpoints) + tests (outside vulture scan paths) --
+YamlPhaseSink  # YAML PhaseSink adapter; wired by C5 + survey-phase tests (poc_homography/infrastructure/survey/yaml_phase_sink.py)


### PR DESCRIPTION
## Summary

Implements **C4** of the multi-camera survey epic: the nine concrete survey phases that bind the **C3** planner's pose generators to the **C2** capture engine, each emitting **C1** records tagged with its phase identifier.

- **Phase 1 — `camera_inventory`**: collects the full #256 self-report into a new `CameraInventoryRecord` (device identity/firmware, PTZ capabilities, image optics, health/odometry, stream profiles, presets) — one record per run, no pose-based capture.
- **Phases 2–7, 9**: drive snapshot bursts over planner poses — directional sweeps (PTZ char.), FOV grid (main), nadir disc (dense nadir), cross-zoom same-region sets, repeatability approach sequences, and the holdout set (validation).
- **Phase 8 — `static_jitter`**: drives the C2 RTSP video-burst path; enforces the minimum jitter target (10 s, 5 fps, 3 zoom levels, 3 poses); persists both the original segment and addressable per-frame refs; the camera is held commanded-still by the engine for the whole burst.
- **Runner `execute_survey`**: sequences all nine phases for one camera, partitions the FOV grid into a **training** set (Phase 5) and a **disjoint holdout** (Phase 9) via the C3 partitioner, accumulates phases 4–7 commanded states, asserts validation disjointness, and asserts no phase emits a record tagged with another phase's identifier. Records route through a persistence-agnostic `PhaseSink` port; a YAML adapter (`YamlPhaseSink`) writes the dataset into the layout `RepoYamlSurveyRun` reads.

## Reviewer notes

- **One minimal additive C1 change**: an optional, backward-compatible `SurveyContext` sub-VO on `FrameRecord` carries `region_id` (Phase 6), `approach_direction` (Phases 3/7) and `sequence_index` (Phase 7). This is the per-pose propagation path the planner needs and which #258/#259 did not provide; it defaults to empty so existing serialised frames round-trip unchanged. C2's engine is untouched — C4 enriches records post-capture.
- **Phase identifiers** use the C1 `SurveyPhase` enum values (the schema's source of truth): the issue's informal `inventory` / `main_ptz_survey` / `jitter` map onto `camera_inventory` / `main_survey` / `static_jitter`.

## Test plan

New `tests/survey/` package (24 tests): per-phase DoD coverage + a full nine-phase runner run (all phases present, no cross-tagging, jitter complete, validation disjoint) + a YAML-sink dataset queryable by phase via `RepoYamlSurveyRun`.

- `pyright poc_homography` (CI gate): **0 errors**. `ruff`/`format`: clean. `pylint`: 8.99/10. `vulture`: clean.
- Full suite: 957 passed, 145 skipped, 1 **pre-existing** env-dependent failure (`test_camera_diagnostic` stress-test-no-credentials) — confirmed failing identically on clean `main`, unrelated to this change.

## DoD

- [x] Phases 1–9 each run and emit C1 records tagged with their phase identifier
- [x] Phase 3 both directional zoom passes present and distinguishable
- [x] Phase 6 shared `region_id` across zoom levels for the same region
- [x] Phase 7 multiple visits with approach-direction + sequence index
- [x] Phase 8 jitter meets minimum target with segment + per-frame refs, camera held still
- [x] Phase 9 validation set disjoint from phases 4–7 commanded states
- [x] All nine sequence with no cross-phase-tagged records
- [x] `poe validate` (ruff/format/pyright/pylint/vulture) clean for `poc_homography`

Closes #261