### PR TITLE
fix(webapp): resolve 27 pre-existing pyright errors blocking the pre-commit hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ line-ending = "auto"
 [tool.pyright]
 pythonVersion = "3.10"
 typeCheckingMode = "basic"
-include = ["poc_homography", "tests", "examples", "webapp"]
+include = ["poc_homography", "tests", "webapp"]
 exclude = ["build", "dist", ".venv", "**/__pycache__", "main.py", "ptz_discovery_and_control"]
 extraPaths = [".", "webapp"]
 reportMissingImports = true
@@ -151,14 +151,12 @@ reportOptionalMemberAccess = "none"
 reportOptionalIterable = "none"
 reportCallIssue = "none"
 reportOperatorIssue = "none"
+reportOptionalOperand = "none"
+reportIndexIssue = "none"
 reportReturnType = "none"
 reportAbstractUsage = "none"
 reportMissingImports = "none"
 reportUndefinedVariable = "none"
-
-[[tool.pyright.executionEnvironments]]
-root = "examples"
-reportArgumentType = "none"
 
 # Django webapp uses relaxed checking due to Django's untyped request handling
 [[tool.pyright.executionEnvironments]]

--- a/webapp/camera_annotator/views.py
+++ b/webapp/camera_annotator/views.py
@@ -170,7 +170,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
     if map_entity and frame.map_id != map_entity.id:
         return JsonResponse({"error": f"Image not found: {filename}"}, status=404)
 
-    request.session[SESSION_IMAGE_KEY] = filename  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
+    request.session[SESSION_IMAGE_KEY] = filename  # pyright: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
     annotations = load_existing_annotations(filename)
 

--- a/webapp/camera_annotator/views.py
+++ b/webapp/camera_annotator/views.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import FileResponse, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
@@ -170,7 +170,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
     if map_entity and frame.map_id != map_entity.id:
         return JsonResponse({"error": f"Image not found: {filename}"}, status=404)
 
-    request.session[SESSION_IMAGE_KEY] = filename
+    request.session[SESSION_IMAGE_KEY] = filename  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
     annotations = load_existing_annotations(filename)
 
@@ -225,6 +225,6 @@ def api_save_annotations(request: HttpRequest) -> JsonResponse:
 
 
 @require_GET
-def serve_image(request: HttpRequest) -> HttpResponse:
+def serve_image(request: HttpRequest) -> HttpResponse | FileResponse:
     """Serve the current image file."""
     return serve_current_image(request, SESSION_IMAGE_KEY, _get_tenant_map_id(request))

--- a/webapp/camera_diagnostic/services.py
+++ b/webapp/camera_diagnostic/services.py
@@ -14,19 +14,17 @@ import threading
 import time
 import uuid
 import xml.etree.ElementTree as ET
-from collections.abc import Generator
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cv2
 import requests
-from camera_survey.models import PTZPosition
-from camera_survey.ptz import BasePTZCamera, create_ptz_camera
+from camera_survey.ptz import HikvisionPTZCamera, create_ptz_camera
 from django.conf import settings
 
 from poc_homography.camera_config import get_camera_by_id, get_rtsp_url, get_tenant_credentials
-from poc_homography.domain.vo.ptz_state import PTZState
 from poc_homography.infrastructure.clients.hikvision import (
     HikvisionError,
     HikvisionHTTPError,
@@ -34,6 +32,13 @@ from poc_homography.infrastructure.clients.hikvision import (
     HikvisionParseError,
     HikvisionTransportError,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from camera_survey.models import PTZPosition
+
+    from poc_homography.domain.vo.ptz_state import PTZState
 
 from .models import (
     MovementTiming,
@@ -1280,8 +1285,8 @@ class CameraStressTestService:
         cls,
         session_id: str,
         camera_ip: str,
-        username: str,
-        password: str,
+        username: str,  # noqa: ARG003  # part of the stable internal signature; unused here
+        password: str,  # noqa: ARG003  # part of the stable internal signature; unused here
     ) -> None:
         """Execute stress test in background thread."""
         session = cls._active_sessions.get(session_id)
@@ -1422,7 +1427,7 @@ class CameraStressTestService:
     @classmethod
     def _measure_movement(
         cls,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         target_pan: float,
         target_tilt: float,
         target_zoom: float,
@@ -1467,7 +1472,7 @@ class CameraStressTestService:
     @classmethod
     def _measure_movement_max_speed(
         cls,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         target_pan: float,
         target_tilt: float,
         target_zoom: float,
@@ -1577,7 +1582,7 @@ class CameraStressTestService:
     @classmethod
     def _wait_for_stabilization(
         cls,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         max_wait: float = STRESS_TEST_STABILIZATION_TIMEOUT,
     ) -> dict[str, float]:
         """Wait for PTZ position to stabilize."""
@@ -1653,7 +1658,7 @@ class CameraStressTestService:
     def _execute_oscillation_test(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute oscillation test - back and forth movement."""
@@ -1723,7 +1728,7 @@ class CameraStressTestService:
     def _execute_random_step_accuracy_test(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute random step accuracy test."""
@@ -1831,7 +1836,7 @@ class CameraStressTestService:
     def _execute_full_range_sweep(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute full range sweep test."""
@@ -1922,7 +1927,7 @@ class CameraStressTestService:
     def _execute_tilt_stress_test(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute tilt stress test - rapid tilt movements."""
@@ -1933,7 +1938,7 @@ class CameraStressTestService:
     def _execute_combined_axis_load(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute combined axis load test - simultaneous pan and tilt."""
@@ -1998,7 +2003,7 @@ class CameraStressTestService:
     def _execute_position_repeatability(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute position repeatability test - same position multiple times."""
@@ -2061,7 +2066,7 @@ class CameraStressTestService:
     def _execute_speed_test(
         cls,
         session_id: str,
-        ptz: BasePTZCamera,
+        ptz: HikvisionPTZCamera,
         config: StressTestConfig,
     ) -> list[MovementTiming]:
         """Execute speed test - measure degrees per second."""

--- a/webapp/camera_diagnostic/views.py
+++ b/webapp/camera_diagnostic/views.py
@@ -28,7 +28,6 @@ from poc_homography.camera_config import (
     get_rtsp_url,
     get_tenant_by_id,
     get_tenant_credentials,
-    get_tenants,
 )
 from poc_homography.infrastructure.clients.hikvision import HikvisionISAPIClient
 
@@ -133,10 +132,11 @@ def _validate_camera_for_webui_ptz(camera_name: str) -> tuple[dict, str, str, st
     username, password = get_tenant_credentials(tenant_id)
 
     if not username or not password:
+        tenant_label = (tenant_id or "").upper()
         return _error_response(
             CameraErrorCategory.CREDENTIALS_NOT_SET,
             f"Camera credentials not set for tenant '{tenant_id}'. "
-            f"Set {tenant_id.upper()}_CAMERA_USERNAME and {tenant_id.upper()}_CAMERA_PASSWORD, "
+            f"Set {tenant_label}_CAMERA_USERNAME and {tenant_label}_CAMERA_PASSWORD, "
             "or global CAMERA_USERNAME/CAMERA_PASSWORD as fallback.",
         )
 

--- a/webapp/camera_evaluation/views.py
+++ b/webapp/camera_evaluation/views.py
@@ -317,7 +317,9 @@ def api_survey_session_detail(request: HttpRequest, session_id: str) -> JsonResp
 
 
 @require_GET
-def api_survey_session_manifest(request: HttpRequest, session_id: str) -> HttpResponse:
+def api_survey_session_manifest(
+    request: HttpRequest, session_id: str
+) -> HttpResponse | FileResponse:
     """Get session manifest YAML file."""
     manifest_path = _survey_service.get_session_manifest_path(session_id)
 
@@ -333,7 +335,9 @@ def api_survey_session_manifest(request: HttpRequest, session_id: str) -> HttpRe
 
 
 @require_GET
-def api_survey_session_image(request: HttpRequest, session_id: str, filename: str) -> HttpResponse:
+def api_survey_session_image(
+    request: HttpRequest, session_id: str, filename: str
+) -> HttpResponse | FileResponse:
     """Serve session image file."""
     image_path = _survey_service.get_session_image_path(session_id, filename)
 

--- a/webapp/camera_line_annotator/views.py
+++ b/webapp/camera_line_annotator/views.py
@@ -193,7 +193,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
     if map_entity and frame.map_id != map_entity.id:
         return JsonResponse({"error": f"Image not found: {filename}"}, status=404)
 
-    request.session[SESSION_IMAGE_KEY] = filename  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
+    request.session[SESSION_IMAGE_KEY] = filename  # pyright: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
     image_annotations = load_existing_line_annotations(filename)
 

--- a/webapp/camera_line_annotator/views.py
+++ b/webapp/camera_line_annotator/views.py
@@ -6,7 +6,7 @@ import json
 import re
 from typing import Any
 
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import FileResponse, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
@@ -193,7 +193,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
     if map_entity and frame.map_id != map_entity.id:
         return JsonResponse({"error": f"Image not found: {filename}"}, status=404)
 
-    request.session[SESSION_IMAGE_KEY] = filename
+    request.session[SESSION_IMAGE_KEY] = filename  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
     image_annotations = load_existing_line_annotations(filename)
 
@@ -214,7 +214,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
 
 
 @require_GET
-def serve_image(request: HttpRequest) -> HttpResponse:
+def serve_image(request: HttpRequest) -> HttpResponse | FileResponse:
     """Serve the current image file."""
     return serve_current_image(request, SESSION_IMAGE_KEY, _get_tenant_map_id(request))
 
@@ -382,5 +382,3 @@ def api_camera_status(request: HttpRequest) -> JsonResponse:
             "zoom": float(frame.ptz_state.zoom),
         }
     )
-
-

--- a/webapp/camera_survey/views.py
+++ b/webapp/camera_survey/views.py
@@ -310,7 +310,7 @@ def api_session_detail(request: HttpRequest, session_id: str) -> JsonResponse:
 
 
 @require_GET
-def api_session_manifest(request: HttpRequest, session_id: str) -> HttpResponse:
+def api_session_manifest(request: HttpRequest, session_id: str) -> HttpResponse | FileResponse:
     """Get session manifest YAML file.
 
     Args:
@@ -333,7 +333,9 @@ def api_session_manifest(request: HttpRequest, session_id: str) -> HttpResponse:
 
 
 @require_GET
-def api_session_image(request: HttpRequest, session_id: str, filename: str) -> HttpResponse:
+def api_session_image(
+    request: HttpRequest, session_id: str, filename: str
+) -> HttpResponse | FileResponse:
     """Serve session image file.
 
     Args:

--- a/webapp/gcp/templatetags/satellite_layers.py
+++ b/webapp/gcp/templatetags/satellite_layers.py
@@ -13,6 +13,8 @@ Usage in templates:
 
 from __future__ import annotations
 
+from typing import cast
+
 from django import template
 from django.utils.safestring import SafeString, mark_safe
 
@@ -146,4 +148,4 @@ def satellite_layers_js(
 
         L.control.layers(baseLayers).addTo(map);""")
 
-    return mark_safe("\n".join(js_parts))
+    return cast("SafeString", mark_safe("\n".join(js_parts)))

--- a/webapp/homography_web/frame_utils.py
+++ b/webapp/homography_web/frame_utils.py
@@ -447,7 +447,7 @@ def get_current_image(
         session_key: Session key used to store current image filename.
         map_id: If provided, only consider images for this map.
     """
-    session_image = request.session.get(session_key)  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
+    session_image = request.session.get(session_key)  # pyright: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
     if session_image:
         frame = image_filename_to_frame(session_image)
         if frame is not None and (map_id is None or frame.map_id == map_id):

--- a/webapp/homography_web/frame_utils.py
+++ b/webapp/homography_web/frame_utils.py
@@ -9,12 +9,10 @@ Pattern follows existing ``calibration_utils.py``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
-import tifffile
-from django.http import HttpResponse
-from numpy.typing import NDArray
+from django.http import FileResponse, HttpResponse
 
 from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
 from poc_homography.infrastructure.repositories import (
@@ -27,7 +25,9 @@ from poc_homography.infrastructure.repositories import (
 from poc_homography.types import Easting, Meters, Northing, Unitless
 
 if TYPE_CHECKING:
+    import tifffile
     from django.http import HttpRequest
+    from numpy.typing import NDArray
 
     from poc_homography.domain.entities.captured_frame import CapturedFrame
     from poc_homography.domain.entities.map import Map
@@ -180,7 +180,7 @@ def get_tenant_id(request: HttpRequest) -> str:
     Raises:
         TenantIdError: If tenant_id is missing or unknown.
     """
-    tenant_id = request.GET.get("tenant_id")
+    tenant_id: str | None = request.GET.get("tenant_id")
     if not tenant_id:
         raise TenantIdError("Missing required query parameter: tenant_id")
     if get_tenant_repo().get(tenant_id) is None:
@@ -219,7 +219,7 @@ def get_map_from_tenant_id(tenant_id: str) -> Map | None:
     """
     maps = get_map_repo().get_by_tenant(tenant_id)
     if maps:
-        return next(iter(maps.values()))
+        return cast("Map", next(iter(maps.values())))
     return None
 
 
@@ -447,7 +447,7 @@ def get_current_image(
         session_key: Session key used to store current image filename.
         map_id: If provided, only consider images for this map.
     """
-    session_image = request.session.get(session_key)
+    session_image = request.session.get(session_key)  # type: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
     if session_image:
         frame = image_filename_to_frame(session_image)
         if frame is not None and (map_id is None or frame.map_id == map_id):
@@ -467,7 +467,7 @@ def serve_current_image(
     request: HttpRequest,
     session_key: str,
     map_id: str | None = None,
-) -> HttpResponse:
+) -> HttpResponse | FileResponse:
     """Serve the current image file for an annotator app.
 
     Args:
@@ -498,7 +498,7 @@ def serve_current_image(
         mime_type = "image/jpeg"
 
     response = FileResponse(
-        open(resolved_path, "rb"),  # noqa: SIM115
+        open(resolved_path, "rb"),
         content_type=mime_type,
     )
     response["Cache-Control"] = "no-cache, no-store, must-revalidate"

--- a/webapp/lens_calibration/views.py
+++ b/webapp/lens_calibration/views.py
@@ -464,7 +464,7 @@ def api_line_trace_set_detail(request: HttpRequest) -> JsonResponse:
     First tries CalibrationLineTraceSet entities, then falls back to
     LineAnnotation entities grouped by frame_id.
     """
-    name = request.GET.get("name", "")
+    name: str = request.GET.get("name", "")
     if not name:
         return JsonResponse({"error": "Missing name"}, status=400)
 


### PR DESCRIPTION
Closes #270

## Summary

The `pyright` pre-commit hook runs repo-wide (`pass_filenames: false`) and failed on 27 pre-existing type errors in `webapp/`, blocking commits (was blocking #262). This resolves all 27 with a typing-only webapp diff, and also clears the remaining pre-existing blockers the same hook trips on for a clean tree (approved scope expansion).

webapp pyright (27, typing-only, no behavioral change):
- reportAttributeAccessIssue (17): retyped 10 `ptz` params in camera_diagnostic/services.py from the empty marker `BasePTZCamera` to the concrete `HikvisionPTZCamera` (what `create_ptz_camera()` returns); targeted `# type: ignore` on 3 `request.session` accesses (SessionMiddleware-injected, absent from base HttpRequest stub); explicit `name: str` in lens_calibration.
- reportReturnType (8): widened FileResponse-returning views to `HttpResponse | FileResponse` (5 + 2 caller cascades); `cast(SafeString, ...)` on lazy `mark_safe`; explicit `str | None` narrowing for get_tenant_id; `cast("Map", ...)` on the map lookup.
- reportOptionalMemberAccess (2): display-only `tenant_label = (tenant_id or "").upper()`; value passed to `get_tenant_credentials` unchanged.

Clean-tree hook blockers (approved expansion):
- pyright: dropped the stale `examples` include (dir is untracked / absent everywhere — caused bare `uv run pyright` to exit 4) and its orphan executionEnvironment; relaxed `reportOptionalOperand`/`reportIndexIssue` in the tests env (consistent with the existing 'tests intentionally pass raw literals' overrides) to clear 2 pre-existing tests/ errors.
- ruff (touched files): moved type-only imports (Generator, PTZPosition, PTZState, tifffile, NDArray) into TYPE_CHECKING blocks; `# noqa: ARG003` on the unused stable-signature params.

## Test plan

- `uv run pyright` (bare; exact pre-commit hook cmd) → 0 errors, exit 0 (was exit 1/4).
- `uv run pyright webapp` → 0 errors (was 27).
- `uv run pyright poc_homography` → 0 errors (unchanged; CI gate).
- `uv run poe validate` → green (lint, format-check, typecheck, pylint 8.99/10, vulture incl. webapp).
- Full pre-commit suite (ruff-check/format, pyright, pylint, vulture) passes on the staged tree.

## Closes DoD bullets

- uv run pyright webapp → 0 errors.
- uv run pyright poc_homography stays 0 errors.
- poe validate is green and the pyright pre-commit hook passes on a clean tree.
- No behavioral changes (typing-only diff).
