### PR TITLE
feat(survey): plan-config, reproducibility, concurrent-run CLI/API & docs (#262)

### DIFF
--- a/api/routers/camera_evaluation.py
+++ b/api/routers/camera_evaluation.py
@@ -492,7 +492,10 @@ def api_survey_run_start(
     except ValueError as e:
         return _error_response(str(e), status_code=400)
 
-    result = _survey_run_service.start_run(cfg, body.camera_ids)
+    try:
+        result = _survey_run_service.start_run(cfg, body.camera_ids)
+    except ValueError as e:
+        return _error_response(str(e), status_code=400)
     return _success_response(
         {
             "run_id": result["run_id"],
@@ -544,7 +547,7 @@ def api_survey_runs(
     SPA-hook: GET /camera-evaluation/survey/runs/ — returns
     ``{"runs", "limit", "offset"}``.
     """
-    runs = _survey_run_service.list_runs(limit=limit)
+    runs = _survey_run_service.list_runs(limit=limit, offset=offset)
     return _success_response({"runs": runs, "limit": limit, "offset": offset})
 
 
@@ -561,5 +564,8 @@ def api_survey_run_groups(
     SPA-hook: GET /camera-evaluation/survey/runs/{run_id}/groups/ — optional
     ``phase``/``camera``/``zoom`` filters; returns ``{"groups": [...]}``.
     """
-    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    try:
+        groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    except ValueError as e:
+        return _error_response(str(e), status_code=400)
     return _success_response({"groups": groups})

--- a/api/routers/camera_evaluation.py
+++ b/api/routers/camera_evaluation.py
@@ -16,16 +16,23 @@ from camera_survey.services import CameraSurveyService, get_survey_presets
 from camera_survey.validation import parse_fixed_axis_values, validate_fixed_axis_ranges
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from webapp.camera_evaluation.services import generate_mjpeg_frames
 
 from api.deps import get_current_user
-from api.schemas.camera_evaluation import SurveyStartRequest
+from api.schemas.camera_evaluation import (  # noqa: TC001 — runtime-resolved by FastAPI body model
+    SurveyRunStartRequest,
+    SurveyStartRequest,
+)
 from poc_homography.camera_config import (
     get_camera_by_id,
     get_cameras_for_tenant,
     get_tenants,
 )
-from poc_homography.infrastructure.models.user import UserModel
-from webapp.camera_evaluation.services import generate_mjpeg_frames
+from poc_homography.domain.vo import SurveyPlanConfig
+from poc_homography.infrastructure.models.user import (  # noqa: TC001 — runtime-resolved by FastAPI Depends
+    UserModel,
+)
+from poc_homography.survey.run_service import build_survey_run_service
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +41,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _survey_service = CameraSurveyService()
+_survey_run_service = build_survey_run_service()
 
 # ---------------------------------------------------------------------------
 # Router
@@ -462,3 +470,96 @@ def api_camera_position(
     except Exception as e:
         logger.exception("Error getting position for %s", camera_id)
         return _error_response(f"Failed to get camera position: {e}", status_code=502)
+
+
+# =============================================================================
+# Multi-camera survey-run API endpoints (issue #262)
+# =============================================================================
+
+
+@router.post("/survey/run/start/")
+def api_survey_run_start(
+    body: SurveyRunStartRequest,
+    user: UserModel = Depends(get_current_user),
+) -> JSONResponse:
+    """Launch a multi-camera survey run.
+
+    SPA-hook: POST /camera-evaluation/survey/run/start/ — body
+    ``{"plan_config", "camera_ids"}``; returns ``{"run_id", "session_ids"}``.
+    """
+    try:
+        cfg = SurveyPlanConfig.from_dict(body.plan_config)
+    except ValueError as e:
+        return _error_response(str(e), status_code=400)
+
+    result = _survey_run_service.start_run(cfg, body.camera_ids)
+    return _success_response(
+        {
+            "run_id": result["run_id"],
+            "session_ids": result["session_ids"],
+        }
+    )
+
+
+@router.get("/survey/run/{run_id}/status/")
+def api_survey_run_status(
+    run_id: str,
+    user: UserModel = Depends(get_current_user),
+) -> JSONResponse:
+    """Get per-camera status for a survey run.
+
+    SPA-hook: GET /camera-evaluation/survey/run/{run_id}/status/ — returns
+    ``{"run_id", "cameras": {camera_id: {phase, frame_count, ...}}}``.
+    """
+    status = _survey_run_service.get_status(run_id)
+    if status is None:
+        return _error_response("Run not found", status_code=404)
+    return _success_response(status)
+
+
+@router.post("/survey/run/{run_id}/abort/")
+def api_survey_run_abort(
+    run_id: str,
+    user: UserModel = Depends(get_current_user),
+) -> JSONResponse:
+    """Request graceful abort of a survey run.
+
+    SPA-hook: POST /camera-evaluation/survey/run/{run_id}/abort/ — returns
+    ``{"run_id", "message"}``.
+    """
+    result = _survey_run_service.abort_run(run_id)
+    if result is None:
+        return _error_response("Run not found", status_code=404)
+    return _success_response(result)
+
+
+@router.get("/survey/runs/")
+def api_survey_runs(
+    limit: int = Query(20),
+    offset: int = Query(0),
+    user: UserModel = Depends(get_current_user),
+) -> JSONResponse:
+    """List survey-run summaries (newest first).
+
+    SPA-hook: GET /camera-evaluation/survey/runs/ — returns
+    ``{"runs", "limit", "offset"}``.
+    """
+    runs = _survey_run_service.list_runs(limit=limit)
+    return _success_response({"runs": runs, "limit": limit, "offset": offset})
+
+
+@router.get("/survey/runs/{run_id}/groups/")
+def api_survey_run_groups(
+    run_id: str,
+    phase: int | None = Query(None),
+    camera: str | None = Query(None),
+    zoom: float | None = Query(None),
+    user: UserModel = Depends(get_current_user),
+) -> JSONResponse:
+    """Browse dataset grouping keys with frame counts for a survey run.
+
+    SPA-hook: GET /camera-evaluation/survey/runs/{run_id}/groups/ — optional
+    ``phase``/``camera``/``zoom`` filters; returns ``{"groups": [...]}``.
+    """
+    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    return _success_response({"groups": groups})

--- a/api/schemas/camera_evaluation.py
+++ b/api/schemas/camera_evaluation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-
 # ---------------------------------------------------------------------------
 # Survey request schemas
 # ---------------------------------------------------------------------------
@@ -25,3 +24,10 @@ class SurveyStartRequest(BaseModel):
     fixed_pan: float | None = None
     fixed_tilt: float | None = None
     fixed_zoom: float | None = None
+
+
+class SurveyRunStartRequest(BaseModel):
+    """Body for ``POST /camera-evaluation/survey/run/start/``."""
+
+    plan_config: dict
+    camera_ids: list[str]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,52 @@
+# Documentation Index
+
+Reference documentation for the PTZ homography project. The pages below are
+grouped by topic: the multi-phase **Survey** system, the **Hikvision / PTZ**
+ISAPI reference, **Camera intrinsics and pose**, and the **Domain model**.
+
+## Survey
+
+- [survey_run_guide.md](./survey_run_guide.md) — step-by-step operator guide:
+  author a `plan_config.yaml`, launch with `hom survey run`, monitor with
+  `hom survey status`, abort with `hom survey abort`, and the equivalent
+  `curl` REST calls.
+- [survey_phase_catalog.md](./survey_phase_catalog.md) — one section per phase
+  (1–9): purpose, the `SurveyPlanConfig` fields it consumes, expected output
+  record types, and a frame-count estimate. Includes the Phase 8 jitter spec.
+- [survey_dataset_schema.md](./survey_dataset_schema.md) — field-by-field
+  reference for the C1 dataset schema: `SurveyRun`, `FrameRecord` and its nested
+  value objects, `VideoBurstRecord`, and the grouping index fields.
+- [survey_offline_reprocessing.md](./survey_offline_reprocessing.md) — using a
+  dataset without a camera: `dvc pull`, reload the plan config, browse
+  groupings, and access images and video bursts.
+
+## Hikvision / PTZ
+
+- [HIKVISION_PTZ_API_SUMMARY.md](./HIKVISION_PTZ_API_SUMMARY.md) — ISAPI
+  endpoint catalog grounded in a live probe of cam-04: paths, methods, returns,
+  sample values, unit conventions, and HTTP status semantics.
+- [hikvision_isapi_capability_matrix.md](./hikvision_isapi_capability_matrix.md)
+  — per-endpoint live-hardware report: readable, PUT-only setter, or absent,
+  keyed to the committed fixtures.
+- [hikvision_improvement_assessment.md](./hikvision_improvement_assessment.md)
+  — review of prior duplication, the tilt default, and applied-vs-deferred
+  improvements.
+- [ptz_commands.md](./ptz_commands.md) — notes on PTZ command helpers.
+
+## Camera intrinsics and pose
+
+- [ptz_intrinsics_and_pose.md](./ptz_intrinsics_and_pose.md) — computing the
+  intrinsic matrix from zoom and recovering camera position and orientation.
+- [lens_calibration_requirements.md](./lens_calibration_requirements.md) —
+  minimum data requirements for lens-distortion calibration.
+
+## Domain model
+
+- [domain-model-assessment.md](./domain-model-assessment.md) — assessment of
+  entities, value objects, and legacy types (issue #172 DDD refactoring).
+- [domain-model-refactoring.md](./domain-model-refactoring.md) — domain model
+  and refactoring plan for the homography system.
+
+## Other
+
+- [README.md](./README.md) — the prior documentation index page.

--- a/docs/survey_dataset_schema.md
+++ b/docs/survey_dataset_schema.md
@@ -1,0 +1,260 @@
+# Survey Dataset Schema (C1)
+
+This is the field-by-field reference for the multi-phase, multi-camera survey
+dataset. The C1 domain entities are the **single source of truth** for the
+schema: every capture, planning, and phase component emits into and queries
+from these entities. The schema version stamped onto each record is the
+constant `SURVEY_SCHEMA_VERSION = "1.0"`
+(`poc_homography/domain/entities/survey/__init__.py`).
+
+Each entity is a frozen dataclass with symmetric `to_dict()` / `from_dict()`
+methods. On load, `from_dict()` calls `check_schema_version()`, which raises
+`ValueError` if the serialized `schema_version` does not equal the current
+`SURVEY_SCHEMA_VERSION`. That mismatch is the explicit signal that a migration
+hook is required before the record can be read.
+
+> Note on versions: the dataset schema version (`SURVEY_SCHEMA_VERSION`,
+> `"1.0"`) is deliberately distinct from the plan-config sidecar version
+> (`PLAN_CONFIG_SCHEMA_VERSION`, `"1"`). The sidecar
+> (`SurveyPlanConfig`, see [survey_phase_catalog.md](./survey_phase_catalog.md))
+> evolves independently of the run/frame dataset.
+
+---
+
+## `SurveyRun` — the run aggregate
+
+Source: `poc_homography/domain/entities/survey/survey_run.py`
+
+A single survey run for **one camera** across a set of phases. The `id`
+property returns `run_id` (satisfies the `Entity` protocol). A multi-camera
+launch produces one `SurveyRun` per camera, all sharing the same logical
+run id reported by the operator surface.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `run_id` | `str` | Unique run identifier; also the entity `id`. |
+| `camera_id` | `str` | The camera this run targets. |
+| `phases` | `frozenset[SurveyPhase]` | Phases executed; serialized as a sorted list of stable string `.value`s. |
+| `started_at` | `datetime` | Run start; serialized as ISO-8601. |
+| `finished_at` | `datetime \| None` | Run end, or `None` while in flight. |
+| `status` | `SurveyRunStatus` | Lifecycle status; defaults to `PENDING`. Enables a planner to resume interrupted runs. |
+| `schema_version` | `str` | Defaults to `SURVEY_SCHEMA_VERSION` (`"1.0"`). |
+
+The `status` field is what makes a run **resumable**: a planner can inspect a
+persisted run and continue from where it stopped. Run manifests are persisted
+one file per run (YAML repository at `data/survey_runs/{run_id}.yaml`).
+
+---
+
+## Session
+
+In the multi-camera operator surface, a **session** is the per-camera
+execution context of a run. When a run is started for N cameras, the operator
+surface returns a `session_ids` map of `{camera_id: session_id}` (see
+[survey_run_guide.md](./survey_run_guide.md)). Per-frame records reference the
+camera through `CameraIdentity` and the run through `CaptureIdentity.run_id`;
+session-scoped image and manifest assets are addressable through the survey
+session endpoints (`/camera-evaluation/api/survey/sessions/{session_id}/...`).
+
+---
+
+## `FrameRecord` — the per-frame capture record
+
+Source: `poc_homography/domain/entities/survey/frame_record.py`
+
+`FrameRecord` captures the full optical and mechanical state at a single survey
+frame. Its `id` property returns the per-frame `capture_id`. Fields are grouped
+into named nested value objects that mirror how they are populated; each nested
+VO has its own `to_dict()` / `from_dict()`.
+
+| Field | Type |
+|-------|------|
+| `camera` | `CameraIdentity` |
+| `capture` | `CaptureIdentity` |
+| `commanded` | `CommandedState` |
+| `reported` | `ReportedState` |
+| `movement` | `MovementContext` |
+| `pipeline` | `ImagePipelineState` |
+| `image_data` | `ImageData` |
+| `survey_context` | `SurveyContext` (defaults to an empty `SurveyContext`) |
+| `schema_version` | `str` (defaults to `SURVEY_SCHEMA_VERSION`) |
+
+### `CameraIdentity`
+
+Stable identity of the camera that produced the frame.
+
+| Field | Type |
+|-------|------|
+| `camera_id` | `str` |
+| `brand` | `str` |
+| `model` | `str` |
+| `serial` | `str` |
+| `firmware` | `str` |
+| `channel_id` | `str` |
+| `stream_id` | `str` |
+
+### `CaptureIdentity`
+
+Identity and timing of an individual capture within a run.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `capture_id` | `str` | The frame's unique id. |
+| `run_id` | `str` | Owning run. |
+| `phase` | `SurveyPhase` | Serialized as the phase `.value`. |
+| `burst_id` | `str \| None` | Set for frames extracted from a Phase 8 video burst; otherwise `None`. |
+| `frame_index` | `int` | Index within the capture/burst. |
+| `timestamp_before_move` | `datetime` | Before commanding PTZ movement. |
+| `timestamp_after_move` | `datetime` | After movement completed. |
+| `timestamp_at_capture` | `datetime` | At image capture. |
+
+### `CommandedState`
+
+The PTZ + focus state commanded to the camera for this frame. Also reused by
+`VideoBurstRecord`.
+
+| Field | Type |
+|-------|------|
+| `commanded_pan` | `Degrees` |
+| `commanded_tilt` | `Degrees` |
+| `commanded_zoom` | `Unitless` |
+| `commanded_focus` | `int \| None` |
+
+### `ReportedState`
+
+The PTZ + optics state reported back by the camera for this frame. The
+commanded-vs-reported pairing is what lets offline analysis measure mechanical
+error.
+
+| Field | Type |
+|-------|------|
+| `reported_pan` | `Degrees` |
+| `reported_azimuth` | `Degrees \| None` |
+| `reported_tilt` | `Degrees` |
+| `reported_elevation` | `Degrees \| None` |
+| `reported_zoom` | `Unitless` |
+| `reported_focal_length_mm` | `Millimeters \| None` |
+| `reported_focus` | `int \| None` |
+| `ptz_settled` | `bool` |
+
+### `MovementContext`
+
+Movement that preceded this frame and its settling context.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `prev_pan` | `Degrees` | Pose before the move. |
+| `prev_tilt` | `Degrees` | |
+| `prev_zoom` | `Unitless` | |
+| `direction_pan` | `"cw" \| "ccw" \| "none"` | Approach direction in pan. |
+| `direction_tilt` | `"up" \| "down" \| "none"` | Approach direction in tilt. |
+| `direction_zoom` | `"tele" \| "wide" \| "none"` | Approach direction in zoom. |
+| `settling_delay_s` | `Seconds` | Settle wait applied before capture. |
+| `is_repeatability_sequence` | `bool` | True for Phase 7 repeatability frames. |
+
+### `ImagePipelineState`
+
+Encoder / image-pipeline state, from `StreamProfile` + `ImageOptics`.
+
+| Field | Type |
+|-------|------|
+| `resolution_width` | `Pixels` |
+| `resolution_height` | `Pixels` |
+| `codec` | `str` |
+| `profile` | `str` |
+| `fps` | `FPS` |
+| `eis_enabled` | `bool` |
+| `eptz_enabled` | `bool` |
+| `digital_zoom` | `Unitless` |
+| `digital_zoom_limit` | `Unitless` |
+| `mirror` | `bool` |
+| `flip` | `bool` |
+| `corridor_mode` | `bool` |
+| `day_night_mode` | `str` |
+| `crop_enabled` | `bool` |
+| `stabilization_enabled` | `bool` |
+| `exposure_mode` | `str` |
+| `focus_mode` | `str` |
+
+### `ImageData`
+
+The persisted image file and its integrity / dimension metadata.
+
+| Field | Type |
+|-------|------|
+| `image_path` | `Path` |
+| `checksum` | `str` |
+| `width` | `Pixels` |
+| `height` | `Pixels` |
+| `capture_format` | `str` |
+
+### `SurveyContext`
+
+Planner-derived survey context attached to a frame by the phase layer. These
+fields originate in the C3 planner pose (and the C4 phase that drives it), not
+in the C2 capture engine. All are optional and default to `None`, so frames
+captured outside a phase context round-trip unchanged.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `region_id` | `str \| None` | Groups cross-zoom observations of the same ground region (Phase 6). |
+| `approach_direction` | `str \| None` | The direction a pose was approached from (Phases 3 / 7). |
+| `sequence_index` | `int \| None` | Visit index within a repeat group (Phase 7). |
+
+---
+
+## `VideoBurstRecord` — Phase 8 RTSP segments
+
+Source: `poc_homography/domain/entities/survey/video_burst_record.py`
+
+Preserves the original encoded RTSP segment while making each contained frame
+addressable for offline processing. The `id` property returns `burst_id`. The
+`phase` field is typed generally but is always `SurveyPhase.STATIC_JITTER`
+(Phase 8) in practice.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `burst_id` | `str` | Burst id; also the entity `id`. |
+| `run_id` | `str` | Owning run. |
+| `camera_id` | `str` | Source camera. |
+| `phase` | `SurveyPhase` | Always `STATIC_JITTER` in practice. |
+| `segment_path` | `Path` | The encoded RTSP segment on disk. |
+| `duration_s` | `Seconds` | Burst duration. |
+| `fps` | `FPS` | Effective frame rate of the segment. |
+| `codec` | `str` | Segment codec. |
+| `commanded_state` | `CommandedState` | The pose held during the burst. |
+| `frame_refs` | `tuple[FrameRef, ...]` | Per-frame pointers (see below). |
+
+Helper: `frame_by_index(frame_index)` returns the `FrameRef` with that
+`frame_index`, or `None`.
+
+### `FrameRef`
+
+A lightweight pointer to one frame within a video burst. The full
+`FrameRecord` for each frame is stored separately under the frame layout.
+
+| Field | Type |
+|-------|------|
+| `capture_id` | `str` |
+| `frame_index` | `int` |
+| `timestamp_at_capture` | `datetime` |
+| `image_path` | `Path` |
+
+---
+
+## Grouping index fields
+
+For browsing, frames are grouped by the tuple **`(phase, camera, zoom)`** and
+counted. The grouping projection (the operator-surface `browse` view, see
+[survey_offline_reprocessing.md](./survey_offline_reprocessing.md)) exposes:
+
+| Group field | Source |
+|-------------|--------|
+| `phase` | `FrameRecord.capture.phase.value` (the stable phase string). |
+| `camera` | `FrameRecord.camera.camera_id`. |
+| `zoom` | `FrameRecord.reported.reported_zoom`, rounded to one decimal place. |
+| `frame_count` | Count of frames in the group. |
+
+The `zoom` filter matches a reported zoom factor to one decimal place, and the
+`phase` filter accepts a 1..9 phase number that is mapped to the corresponding
+`SurveyPhase` member before matching.

--- a/docs/survey_offline_reprocessing.md
+++ b/docs/survey_offline_reprocessing.md
@@ -1,0 +1,125 @@
+# Survey Offline Reprocessing
+
+A survey dataset is designed to be reprocessed **without a camera**. The plan
+config is a camera-free sidecar, and every per-frame record carries the full
+commanded-vs-reported optical and mechanical state (see
+[survey_dataset_schema.md](./survey_dataset_schema.md)). This page describes how
+to pull a dataset, reload its plan, browse its groupings, and fetch its image
+and video-burst assets.
+
+---
+
+## 1. Pull the dataset
+
+Datasets are versioned with DVC. Pull the tracked data into your working tree:
+
+```bash
+dvc pull
+```
+
+This materializes the run manifests, per-frame records, captured images, and
+Phase 8 video-burst segments referenced by the DVC-tracked pointers.
+
+---
+
+## 2. Reload the plan config
+
+The plan config is reproducible from its YAML sidecar. Load it back into a
+`SurveyPlanConfig` value object; `from_dict()` tolerates partial payloads
+(missing keys fall back to defaults) and rejects an unsupported
+`schema_version` with a `ValueError`.
+
+```python
+import yaml
+
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+with open("plan_config.yaml") as f:
+    cfg = SurveyPlanConfig.from_dict(yaml.safe_load(f))
+
+print(sorted(cfg.enabled_phases))      # e.g. [1, 2, 3, 4, 5, 6, 7, 8, 9]
+print(cfg.jitter_zoom_levels)          # e.g. [1.0, 5.0, 12.0, 25.0]
+print(cfg.holdout_fraction)            # e.g. 0.15
+```
+
+A full `to_dict()` payload round-trips back to an equal object, so the reloaded
+config exactly reproduces the planning inputs of the original run.
+
+---
+
+## 3. Browse groupings
+
+Frames are grouped by the tuple `(phase, camera, zoom)` and counted. Browse from
+the CLI:
+
+```bash
+hom survey browse --run-id <run_id>
+hom survey browse --run-id <run_id> --phase 5
+hom survey browse --run-id <run_id> --camera cam-04
+hom survey browse --run-id <run_id> --zoom 12.0
+```
+
+- `--phase` is a 1..9 phase number (mapped to the corresponding `SurveyPhase`).
+- `--camera` is a camera id.
+- `--zoom` is a reported zoom factor, matched to one decimal place.
+
+The output is a table of `phase`, `camera`, `zoom`, `frame_count`. When the run
+has no backing repository wired, no groupings are returned.
+
+The REST equivalent is:
+
+`GET /camera-evaluation/survey/runs/<run_id>/groups/`
+
+```bash
+curl -u "$USER:$PASS" \
+  "http://localhost:8000/camera-evaluation/survey/runs/<run_id>/groups/?phase=5&camera=cam-04&zoom=12.0"
+```
+
+All three query parameters are optional and combine as filters.
+
+---
+
+## 4. Access images
+
+Images persisted for a session are served by the existing survey image
+endpoint:
+
+`GET /camera-evaluation/api/survey/sessions/{session_id}/images/{filename}`
+
+```bash
+curl -u "$USER:$PASS" \
+  http://localhost:8000/camera-evaluation/api/survey/sessions/<session_id>/images/<filename> \
+  -o frame.jpg
+```
+
+The `session_id` is the per-camera session id returned when the run was started
+(see [survey_run_guide.md](./survey_run_guide.md)); the `filename` corresponds to
+the image file name under the session's image layout. Requires HTTP Basic auth.
+
+---
+
+## 5. Access video bursts
+
+Phase 8 (static jitter) produces `VideoBurstRecord`s, each pointing at an
+encoded RTSP segment (`segment_path`) with `FrameRef`s into the extracted
+per-frame records. The burst-serve endpoint is the streaming equivalent of the
+image endpoint above:
+
+`GET /camera-evaluation/api/survey/sessions/{session_id}/bursts/{filename}`
+
+> Status: the burst-serve endpoint is **to be added by C2**. Until then, access
+> the segment directly from `VideoBurstRecord.segment_path` after `dvc pull`,
+> for example:
+
+```python
+from poc_homography.domain.entities.survey.video_burst_record import VideoBurstRecord
+
+burst = VideoBurstRecord.from_dict(burst_payload)
+print(burst.segment_path)              # path to the encoded RTSP segment
+ref = burst.frame_by_index(0)          # FrameRef for frame 0, or None
+print(ref.image_path)                  # extracted frame image on disk
+```
+
+Each `FrameRef` exposes `capture_id`, `frame_index`, `timestamp_at_capture`, and
+`image_path`, so individual frames within a burst are directly addressable for
+offline jitter analysis.

--- a/docs/survey_phase_catalog.md
+++ b/docs/survey_phase_catalog.md
@@ -1,0 +1,191 @@
+# Survey Phase Catalog
+
+A survey run executes up to nine phases. Phases are identified by a 1..9 number
+and by a stable string `.value` from the `SurveyPhase` enum
+(`poc_homography/domain/enums/survey_phase.py`). The numeric order matches the
+enum declaration order, so phase number N maps to the Nth enum member.
+
+| # | Enum member | `.value` |
+|---|-------------|----------|
+| 1 | `CAMERA_INVENTORY` | `camera_inventory` |
+| 2 | `PTZ_CHARACTERIZATION` | `ptz_characterization` |
+| 3 | `ZOOM_CHARACTERIZATION` | `zoom_characterization` |
+| 4 | `DENSE_NADIR` | `dense_nadir` |
+| 5 | `MAIN_SURVEY` | `main_survey` |
+| 6 | `CROSS_ZOOM` | `cross_zoom` |
+| 7 | `REPEATABILITY` | `repeatability` |
+| 8 | `STATIC_JITTER` | `static_jitter` |
+| 9 | `VALIDATION` | `validation` |
+
+Which phases run is controlled by `SurveyPlanConfig.enabled_phases` (a subset of
+`{1..9}`; defaults to all nine). Every phase below names the
+`SurveyPlanConfig` fields it consumes (source:
+`poc_homography/domain/vo/survey_plan_config.py`). Where a phase reads a
+`phase_*_range` dict for a phase that is absent from the dict, the planner falls
+back to the live camera capabilities at plan time.
+
+The frame-count formulas are estimates of the dominant term; actual counts also
+depend on the geometric pose generators and camera capabilities. Unless noted,
+phases emit `FrameRecord`s.
+
+---
+
+## Phase 1 — Camera inventory (`camera_inventory`)
+
+**Purpose.** Enumerate the cameras in the run and their capabilities. This is
+the entry phase that establishes camera identity and the operating envelope
+used by later phases.
+
+**Config consumed.** `enabled_phases` (whether the phase runs). No geometric
+range fields are consumed; identity and capabilities are read from the live
+camera (or the persisted capabilities sidecar).
+
+**Output records.** Inventory metadata per camera (camera identity and
+capabilities); minimal or no `FrameRecord` capture.
+
+**Estimated frame count.** `~0` capture frames per camera (inventory is
+metadata-only).
+
+---
+
+## Phase 2 — PTZ characterization (`ptz_characterization`)
+
+**Purpose.** Characterize pan/tilt mechanical behaviour, including settling and
+repeatable positioning.
+
+**Config consumed.** `phase_pan_range[2]`, `phase_tilt_range[2]` for the swept
+bounds; `burst_frame_count[2]` for snapshot-burst depth; `repeat_count[2]`
+(default `3`) for repetitions.
+
+**Output records.** `FrameRecord`s, with `MovementContext.direction_*` and
+settling fields populated.
+
+**Estimated frame count.** `poses x burst_frame_count[2] x repeat_count[2]`,
+where `poses` is the number of pan/tilt sample positions across the configured
+ranges.
+
+---
+
+## Phase 3 — Zoom characterization (`zoom_characterization`)
+
+**Purpose.** Characterize zoom/optics behaviour across the lens range
+(reported zoom, focal length, focus).
+
+**Config consumed.** `zoom_levels` (default `[1.0, 5.0, 12.0, 25.0]`),
+`phase_zoom_range[3]` for bounding, and `burst_frame_count[3]` for burst depth.
+`SurveyContext.approach_direction` is populated here.
+
+**Output records.** `FrameRecord`s spanning the configured zoom levels.
+
+**Estimated frame count.** `len(zoom_levels) x burst_frame_count[3]` per camera.
+
+---
+
+## Phase 4 — Dense nadir (`dense_nadir`)
+
+**Purpose.** Dense, near-nadir-pointing capture used for high-overlap ground
+coverage.
+
+**Config consumed.** `phase_pan_range[4]`, `phase_tilt_range[4]`,
+`phase_zoom_range[4]`, and `grid_overlap_pct[4]` (default `80.0`). The overlap
+percentage drives the tile spacing of the grid.
+
+**Output records.** `FrameRecord`s on a dense overlapping grid.
+
+**Estimated frame count.** `tiles(grid_overlap_pct[4], ranges)` — the tile
+count grows as overlap increases (higher overlap = more, more tightly spaced
+tiles).
+
+---
+
+## Phase 5 — Main survey (`main_survey`)
+
+**Purpose.** The primary survey sweep that provides the bulk of coverage.
+
+**Config consumed.** `phase_pan_range[5]`, `phase_tilt_range[5]`,
+`phase_zoom_range[5]`, and `grid_overlap_pct[5]` (default `80.0`).
+
+**Output records.** `FrameRecord`s on the main coverage grid.
+
+**Estimated frame count.** `tiles(grid_overlap_pct[5], ranges)` — typically the
+largest contributor to a run's total frame count.
+
+---
+
+## Phase 6 — Cross zoom (`cross_zoom`)
+
+**Purpose.** Capture the same ground region at multiple zoom levels for
+cross-zoom consistency checks.
+
+**Config consumed.** `zoom_levels` (default `[1.0, 5.0, 12.0, 25.0]`) and
+`phase_zoom_range[6]`. Frames carry `SurveyContext.region_id` to group
+observations of the same region.
+
+**Output records.** `FrameRecord`s grouped by `region_id`, one per zoom level
+per region.
+
+**Estimated frame count.** `regions x len(zoom_levels)`.
+
+---
+
+## Phase 7 — Repeatability (`repeatability`)
+
+**Purpose.** Re-visit the same poses repeatedly to quantify positioning
+repeatability.
+
+**Config consumed.** `phase_pan_range[7]`, `phase_tilt_range[7]`,
+`burst_frame_count[7]`, and `repeat_count[7]` (default `3`). Frames carry
+`SurveyContext.sequence_index` (visit index within a repeat group) and
+`SurveyContext.approach_direction`; `MovementContext.is_repeatability_sequence`
+is `True`.
+
+**Output records.** `FrameRecord`s tagged as repeatability frames.
+
+**Estimated frame count.** `poses x repeat_count[7] x burst_frame_count[7]`.
+
+---
+
+## Phase 8 — Static jitter (`static_jitter`)
+
+**Purpose.** Measure static (no-commanded-movement) jitter by recording video
+while the camera holds a fixed pose.
+
+**Jitter spec (verbatim).** Video bursts of 30 s duration at the native FPS
+target, sweeping wide/mid/high/max zoom levels, capturing representative poses
+per camera.
+
+**Config consumed.**
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `jitter_burst_duration_s` | `30.0` | Burst duration in seconds. |
+| `jitter_burst_fps` | `0.0` | Burst frame rate; `0.0` is the sentinel for "use the native FPS target". |
+| `jitter_zoom_levels` | `[1.0, 5.0, 12.0, 25.0]` | The wide / mid / high / max zoom levels swept. |
+| `jitter_pose_count` | `1` | Representative poses per camera. |
+
+**Output records.** `VideoBurstRecord`s (one encoded RTSP segment per
+zoom level per pose), each carrying `FrameRef`s into the per-frame
+`FrameRecord`s extracted from the segment.
+
+**Estimated frame count.** Bursts:
+`jitter_pose_count x len(jitter_zoom_levels)` segments. Extracted frames per
+burst: `effective_fps x jitter_burst_duration_s`, where `effective_fps` is the
+camera's native FPS target when `jitter_burst_fps == 0.0`, otherwise
+`jitter_burst_fps`. Total extracted frames:
+`jitter_pose_count x len(jitter_zoom_levels) x effective_fps x jitter_burst_duration_s`.
+
+---
+
+## Phase 9 — Validation (`validation`)
+
+**Purpose.** Validation / repeatability re-check, holding out a fraction of
+poses to verify the dataset and the planner's geometric assumptions.
+
+**Config consumed.** `holdout_fraction` (default `0.15`) — the fraction of
+poses reserved as a validation holdout. Pan/tilt/zoom ranges fall back to the
+same envelope used by the survey phases.
+
+**Output records.** `FrameRecord`s captured at the held-out validation poses.
+
+**Estimated frame count.** `round(holdout_fraction x survey_poses)`, where
+`survey_poses` is the number of poses the main survey phases produced.

--- a/docs/survey_run_guide.md
+++ b/docs/survey_run_guide.md
@@ -1,0 +1,227 @@
+# Survey Run Guide
+
+This guide walks an operator through launching, monitoring, and aborting a
+multi-camera survey run, both from the `hom survey` CLI and over REST. It
+assumes familiarity with PTZ cameras; for the phase semantics see
+[survey_phase_catalog.md](./survey_phase_catalog.md) and for the resulting
+dataset see [survey_dataset_schema.md](./survey_dataset_schema.md).
+
+A run is driven by a **plan config** — a camera-free YAML sidecar that captures
+every knob the survey planner needs, so a run can be replayed deterministically.
+The YAML is loaded into a `SurveyPlanConfig`
+(`poc_homography/domain/vo/survey_plan_config.py`).
+
+---
+
+## 1. Author a `plan_config.yaml`
+
+Every field below is annotated with its purpose and its source default. The
+values shown are exactly the `SurveyPlanConfig` defaults; `from_dict()`
+tolerates missing keys (they fall back to these defaults), so you only need to
+include the fields you want to override.
+
+```yaml
+# plan_config.yaml — reproducible nine-phase survey plan.
+
+# Sidecar schema version. Must be the literal "1"; from_dict() rejects anything
+# else with a ValueError. Distinct from the dataset SURVEY_SCHEMA_VERSION.
+schema_version: "1"
+
+# Subset of phases (1..9) to execute. Default: all nine.
+enabled_phases: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+# Per-phase pan bounds (lo, hi) in degrees. Keys are phase numbers. Phases
+# absent here fall back to the live camera capabilities at plan time.
+# Default: {} (empty -> all phases use camera capabilities).
+phase_pan_range: {}
+
+# Per-phase tilt bounds (lo, hi) in degrees. Default: {}.
+phase_tilt_range: {}
+
+# Per-phase zoom-factor bounds (lo, hi). Default: {}.
+phase_zoom_range: {}
+
+# Per-phase tile overlap percentage (used by the grid phases 4 and 5).
+# Default: {4: 80.0, 5: 80.0}.
+grid_overlap_pct:
+  "4": 80.0
+  "5": 80.0
+
+# Per-phase snapshot-burst frame count (phases 2, 3, 7). Default: {} (the
+# planner uses its built-in per-phase burst depth where unset).
+burst_frame_count: {}
+
+# Phase 8 (static jitter) settings.
+# Burst duration in seconds. Default: 30.0.
+jitter_burst_duration_s: 30.0
+# Burst frame rate. 0.0 is the sentinel meaning "use the native FPS target".
+# Default: 0.0.
+jitter_burst_fps: 0.0
+# Phase 8 zoom factors: wide / mid / high / max. Default: [1.0, 5.0, 12.0, 25.0].
+jitter_zoom_levels: [1.0, 5.0, 12.0, 25.0]
+# Phase 8 representative poses per camera. Default: 1.
+jitter_pose_count: 1
+
+# Zoom factors swept by phases 3, 6 and 8. Default: [1.0, 5.0, 12.0, 25.0].
+zoom_levels: [1.0, 5.0, 12.0, 25.0]
+
+# Per-phase repetition count (phases 2 and 7). Default: {2: 3, 7: 3}.
+repeat_count:
+  "2": 3
+  "7": 3
+
+# Phase 9 validation holdout fraction. Default: 0.15.
+holdout_fraction: 0.15
+```
+
+Notes on serialization:
+
+- Int-keyed maps (`grid_overlap_pct`, `burst_frame_count`, `repeat_count`, the
+  `phase_*_range` dicts) use **string keys** in YAML; `from_dict()` coerces them
+  back to ints.
+- `phase_*_range` values are 2-element lists `[lo, hi]` that become tuples.
+- `enabled_phases` is a list on disk and a `frozenset` in memory.
+
+---
+
+## 2. Launch a run
+
+```bash
+hom survey run --plan plan_config.yaml --cameras cam-04,cam-07
+```
+
+`--plan` is the path to the YAML plan above; `--cameras` is a comma-separated
+list of camera ids. The command reads the YAML, builds a `SurveyPlanConfig`,
+starts a run for the given cameras, and prints the run id and per-camera session
+ids, then streams progress:
+
+```
+run_id: <run_id>
+  cam-04: <session_id>
+  cam-07: <session_id>
+[cam-04] phase=main_survey frames=128 status=running
+[cam-07] phase=main_survey frames=131 status=running
+...
+```
+
+If the plan fails to load (bad path, invalid YAML, or an unsupported
+`schema_version`) the command exits non-zero with an error on stderr. Providing
+no valid camera ids also exits non-zero.
+
+---
+
+## 3. Monitor a run
+
+```bash
+hom survey status --run-id <run_id>
+```
+
+Prints per-camera status for the run:
+
+```
+run_id: <run_id>
+  cam-04: phase=repeatability frames=842 status=running
+  cam-07: phase=repeatability frames=851 status=running
+```
+
+An unknown `--run-id` exits non-zero with `Error: Unknown run_id: ...`.
+
+To list recent runs as a table:
+
+```bash
+hom survey list --limit 20
+```
+
+---
+
+## 4. Abort a run
+
+```bash
+hom survey abort --run-id <run_id>
+```
+
+Requests a **graceful** abort and prints the confirmation message
+(`Run abort requested`). An unknown run id exits non-zero.
+
+---
+
+## 5. Equivalent REST calls
+
+The same operator surface is exposed under the `/camera-evaluation` router. All
+endpoints require **HTTP Basic** authentication (the API uses
+`HTTPBasic`; on a failed login it returns `401` with a
+`WWW-Authenticate: Basic` header). Pass credentials with `curl -u user:pass` or
+an explicit `Authorization: Basic <base64>` header. Examples below use
+`http://localhost:8000` as the base URL.
+
+### Start a run
+
+`POST /camera-evaluation/survey/run/start/`
+
+Body matches `SurveyRunStartRequest`: a `plan_config` object (the same fields as
+`plan_config.yaml`) plus a `camera_ids` list.
+
+```bash
+curl -u "$USER:$PASS" \
+  -X POST http://localhost:8000/camera-evaluation/survey/run/start/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "plan_config": {
+      "schema_version": "1",
+      "enabled_phases": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      "jitter_burst_duration_s": 30.0,
+      "jitter_zoom_levels": [1.0, 5.0, 12.0, 25.0],
+      "holdout_fraction": 0.15
+    },
+    "camera_ids": ["cam-04", "cam-07"]
+  }'
+```
+
+Returns the `run_id` and a `session_ids` map of `{camera_id: session_id}`.
+
+### Run status
+
+`GET /camera-evaluation/survey/run/{run_id}/status/`
+
+```bash
+curl -u "$USER:$PASS" \
+  http://localhost:8000/camera-evaluation/survey/run/<run_id>/status/
+```
+
+Returns `{"run_id", "cameras": {camera_id: {session_id, phase, frame_count, status}}}`.
+
+### Abort a run
+
+`POST /camera-evaluation/survey/run/{run_id}/abort/`
+
+```bash
+curl -u "$USER:$PASS" \
+  -X POST http://localhost:8000/camera-evaluation/survey/run/<run_id>/abort/
+```
+
+Returns `{"run_id", "message": "Run abort requested"}`.
+
+### List runs
+
+`GET /camera-evaluation/survey/runs/`
+
+```bash
+curl -u "$USER:$PASS" \
+  http://localhost:8000/camera-evaluation/survey/runs/
+```
+
+Returns run summaries (newest first): `run_id`, `start_time`, `camera_count`,
+`total_frame_count`, `status`.
+
+### Browse dataset groupings
+
+`GET /camera-evaluation/survey/runs/{run_id}/groups/`
+
+```bash
+curl -u "$USER:$PASS" \
+  http://localhost:8000/camera-evaluation/survey/runs/<run_id>/groups/
+```
+
+Returns the `(phase, camera, zoom, frame_count)` groupings for the run. See
+[survey_offline_reprocessing.md](./survey_offline_reprocessing.md) for filtering
+and offline use.

--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -10,10 +10,12 @@ app = typer.Typer(
 # Subcommand groups - will be populated as tools are migrated
 calibrate_app = typer.Typer(help="Calibration commands")
 camera_app = typer.Typer(help="Camera intrinsics and validation commands")
+survey_app = typer.Typer(help="Survey commands")
 test_app = typer.Typer(help="Testing and data generation commands")
 
 app.add_typer(calibrate_app, name="calibrate")
 app.add_typer(camera_app, name="camera")
+app.add_typer(survey_app, name="survey")
 app.add_typer(test_app, name="test")
 
 
@@ -31,6 +33,7 @@ def _register_commands() -> None:
         interactive,
         line_picker,
         point_picker,
+        survey,
         test_cmds,
     )
 
@@ -40,6 +43,7 @@ def _register_commands() -> None:
     _ = interactive
     _ = line_picker
     _ = point_picker
+    _ = survey
     _ = test_cmds
 
 

--- a/poc_homography/cli/survey.py
+++ b/poc_homography/cli/survey.py
@@ -113,7 +113,11 @@ def browse_command(
     zoom: float | None = typer.Option(None, help="Filter by reported zoom factor"),
 ) -> None:
     """Browse dataset groupings (phase, camera, zoom) with frame counts."""
-    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    try:
+        groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
     if not groups:
         typer.echo("No groupings found")
         return

--- a/poc_homography/cli/survey.py
+++ b/poc_homography/cli/survey.py
@@ -1,0 +1,123 @@
+"""Multi-camera survey operator CLI commands (C5, issue #262)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import typer
+import yaml
+
+from poc_homography.cli.main import survey_app
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.survey.run_service import build_survey_run_service
+
+# Module-level service accessor; tests monkeypatch this attribute.
+_survey_run_service = build_survey_run_service()
+
+
+@survey_app.command("run")
+def run_command(
+    plan: Path = typer.Option(..., help="Path to a YAML survey plan config file"),
+    cameras: str = typer.Option(..., help="Comma-separated camera ids"),
+) -> None:
+    """
+    Launch a multi-camera survey run from a plan config and stream progress.
+
+    Reads the YAML plan, builds a SurveyPlanConfig, starts a run for the given
+    cameras, and prints per-camera session ids followed by streamed progress.
+    """
+    try:
+        with Path(plan).open() as f:
+            data = yaml.safe_load(f)
+        cfg = SurveyPlanConfig.from_dict(data)
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as e:
+        typer.echo(f"Error: Failed to load plan config: {e}", err=True)
+        raise typer.Exit(1)
+
+    camera_ids = [c.strip() for c in cameras.split(",") if c.strip()]
+    if not camera_ids:
+        typer.echo("Error: No camera ids provided", err=True)
+        raise typer.Exit(1)
+
+    try:
+        result = _survey_run_service.start_run(cfg, camera_ids)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+    run_id = str(result["run_id"])
+    session_ids = cast("dict[str, str]", result["session_ids"])
+    typer.echo(f"run_id: {run_id}")
+    for camera_id, session_id in session_ids.items():
+        typer.echo(f"  {camera_id}: {session_id}")
+
+    for event in _survey_run_service.iter_progress(run_id):
+        typer.echo(
+            f"[{event['camera_id']}] phase={event['phase']} "
+            f"frames={event['frame_count']} status={event['status']}"
+        )
+
+
+@survey_app.command("status")
+def status_command(
+    run_id: str = typer.Option(..., help="Run id to query"),
+) -> None:
+    """Print per-camera status for a survey run."""
+    status = _survey_run_service.get_status(run_id)
+    if status is None:
+        typer.echo(f"Error: Unknown run_id: {run_id}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"run_id: {status['run_id']}")
+    cameras = cast("dict[str, dict[str, object]]", status["cameras"])
+    for camera_id, cam in cameras.items():
+        typer.echo(
+            f"  {camera_id}: phase={cam['phase']} "
+            f"frames={cam['frame_count']} status={cam['status']}"
+        )
+
+
+@survey_app.command("abort")
+def abort_command(
+    run_id: str = typer.Option(..., help="Run id to abort"),
+) -> None:
+    """Request a graceful abort of a survey run."""
+    result = _survey_run_service.abort_run(run_id)
+    if result is None:
+        typer.echo(f"Error: Unknown run_id: {run_id}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(result["message"])
+
+
+@survey_app.command("list")
+def list_command(
+    limit: int = typer.Option(20, help="Maximum number of runs to list"),
+) -> None:
+    """List recent survey runs as a table."""
+    runs = _survey_run_service.list_runs(limit)
+    typer.echo("run_id\tstatus\tstart_time\tcamera_count\ttotal_frame_count")
+    for run in runs:
+        typer.echo(
+            f"{run['run_id']}\t{run['status']}\t{run['start_time']}\t"
+            f"{run['camera_count']}\t{run['total_frame_count']}"
+        )
+
+
+@survey_app.command("browse")
+def browse_command(
+    run_id: str = typer.Option(..., help="Run id to browse"),
+    phase: int | None = typer.Option(None, help="Filter by phase number (1..9)"),
+    camera: str | None = typer.Option(None, help="Filter by camera id"),
+    zoom: float | None = typer.Option(None, help="Filter by reported zoom factor"),
+) -> None:
+    """Browse dataset groupings (phase, camera, zoom) with frame counts."""
+    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    if not groups:
+        typer.echo("No groupings found")
+        return
+
+    typer.echo("phase\tcamera\tzoom\tframe_count")
+    for group in groups:
+        typer.echo(f"{group['phase']}\t{group['camera']}\t{group['zoom']}\t{group['frame_count']}")

--- a/poc_homography/domain/protocols/__init__.py
+++ b/poc_homography/domain/protocols/__init__.py
@@ -10,9 +10,23 @@ from poc_homography.domain.protocols.camera_controller import (
     CameraControllerError,
 )
 from poc_homography.domain.protocols.camera_device import CameraDevice
+from poc_homography.domain.protocols.survey_orchestrator import (
+    CameraStatus,
+    ConcurrentSurveyOrchestrator,
+    ProgressEvent,
+    RunHandle,
+    RunSummary,
+)
+from poc_homography.domain.protocols.survey_run_repository import SurveyRunRepository
 
 __all__ = [
     "CameraController",
     "CameraControllerError",
     "CameraDevice",
+    "CameraStatus",
+    "ConcurrentSurveyOrchestrator",
+    "ProgressEvent",
+    "RunHandle",
+    "RunSummary",
+    "SurveyRunRepository",
 ]

--- a/poc_homography/domain/protocols/survey_orchestrator.py
+++ b/poc_homography/domain/protocols/survey_orchestrator.py
@@ -1,0 +1,118 @@
+"""Protocol + DTOs for the concurrent multi-camera survey orchestrator (C3 boundary).
+
+C5 (issue #262) ships only the operator-facing surface — CLI, Django views,
+FastAPI endpoints, and persistence of the reproducible plan config. The real
+concurrent orchestrator lands with C3. This module defines the boundary so the
+operator surface can be built, tested (against a stub), and wired today.
+
+The DTOs are deliberately plain, JSON-friendly value objects so the CLI and both
+HTTP layers can serialise them identically without reaching into domain
+entities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+
+@dataclass(frozen=True)
+class RunHandle:
+    """Identifiers returned when a multi-camera run starts.
+
+    Attributes:
+        run_id: The run-level identifier shared by every per-camera session.
+        session_ids: Mapping of ``camera_id`` to its per-camera ``session_id``.
+    """
+
+    run_id: str
+    session_ids: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CameraStatus:
+    """Per-camera status snapshot within a run.
+
+    Attributes:
+        session_id: The per-camera session identifier.
+        phase: Current ``SurveyPhase`` value, or a terminal marker.
+        frame_count: Frames captured by this camera so far.
+        status: Current ``SurveyRunStatus`` value for this camera.
+    """
+
+    session_id: str
+    phase: str
+    frame_count: int
+    status: str
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    """A single streamed progress update for one camera entering/finishing a phase.
+
+    Attributes:
+        camera_id: The camera this event concerns.
+        phase: The ``SurveyPhase`` value just reached or completed.
+        frame_count: Cumulative frame count for the camera at this event.
+        status: Current ``SurveyRunStatus`` value for the camera.
+    """
+
+    camera_id: str
+    phase: str
+    frame_count: int
+    status: str
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """One row in a run listing.
+
+    Attributes:
+        run_id: The run identifier.
+        start_time: ISO-8601 start timestamp.
+        camera_count: Number of cameras in the run.
+        total_frame_count: Total frames captured across all cameras.
+        status: Current ``SurveyRunStatus`` value for the run.
+    """
+
+    run_id: str
+    start_time: str
+    camera_count: int
+    total_frame_count: int
+    status: str
+
+
+class ConcurrentSurveyOrchestrator(Protocol):
+    """Boundary to the C3 concurrent multi-camera survey orchestrator.
+
+    Implementations launch one per-camera session under a shared ``run_id`` and
+    expose status / abort / progress streaming. C5 ships an in-memory stub
+    (:class:`~poc_homography.survey.orchestrator_memory.InMemorySurveyOrchestrator`)
+    so the operator surface is exercisable without a live camera; C3 replaces it
+    with the real implementation behind this same Protocol.
+    """
+
+    def start(self, plan_config: SurveyPlanConfig, camera_ids: Sequence[str]) -> RunHandle:
+        """Launch a concurrent run across ``camera_ids`` from ``plan_config``."""
+        ...
+
+    def status(self, run_id: str) -> dict[str, CameraStatus] | None:
+        """Return per-camera status keyed by ``camera_id``, or ``None`` if unknown."""
+        ...
+
+    def abort(self, run_id: str) -> bool:
+        """Request graceful abort; return ``True`` if the run existed."""
+        ...
+
+    def iter_progress(self, run_id: str) -> Iterator[ProgressEvent]:
+        """Yield progress events until every camera reaches a terminal state."""
+        ...
+
+    def list_runs(self, limit: int = 20) -> list[RunSummary]:
+        """Return up to ``limit`` run summaries, newest first."""
+        ...

--- a/poc_homography/domain/protocols/survey_run_repository.py
+++ b/poc_homography/domain/protocols/survey_run_repository.py
@@ -1,0 +1,39 @@
+"""Protocol for the survey-run persistence boundary used by the operator surface.
+
+C5 (issue #262) adds the ``plan_config.yaml`` sidecar contract on top of the C1
+``SurveyRun`` repositories. The concrete YAML and Postgres repos implement these
+methods; the service layer depends only on this Protocol so it can be tested
+with an in-memory fake.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+
+class SurveyRunRepository(Protocol):
+    """Persistence operations the survey operator surface relies on.
+
+    A subset of the full C1 repository API — only the methods C5 consumes for
+    reproducibility (``plan_config``) and dataset browsing (frame grouping).
+    """
+
+    def save_plan_config(self, run_id: str, config: SurveyPlanConfig) -> bool:
+        """Persist ``config`` for ``run_id``; return ``True`` on success."""
+        ...
+
+    def load_plan_config(self, run_id: str) -> SurveyPlanConfig:
+        """Load the persisted plan config for ``run_id``.
+
+        Raises:
+            KeyError: If no plan config is stored for ``run_id``.
+        """
+        ...
+
+    def get_frames_by_run(self, run_id: str) -> list[FrameRecord]:
+        """Return every frame captured in ``run_id``."""
+        ...

--- a/poc_homography/domain/vo/__init__.py
+++ b/poc_homography/domain/vo/__init__.py
@@ -25,6 +25,7 @@ from poc_homography.domain.vo.pixel_point import PixelPoint
 from poc_homography.domain.vo.ptz_state import PTZState
 from poc_homography.domain.vo.rotation import Rotation
 from poc_homography.domain.vo.stream_profile import StreamProfile
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.domain.vo.vector3 import Vector3
 from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
 
@@ -52,6 +53,7 @@ __all__ = [
     "PTZState",
     "Rotation",
     "StreamProfile",
+    "SurveyPlanConfig",
     "Vector3",
     "WhiteBalanceState",
     "ZoomCalibrationEntry",

--- a/poc_homography/domain/vo/survey_plan_config.py
+++ b/poc_homography/domain/vo/survey_plan_config.py
@@ -1,0 +1,180 @@
+"""Survey plan configuration value object (reproducible, camera-free sidecar)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+PLAN_CONFIG_SCHEMA_VERSION = "1"
+"""Schema version for :class:`SurveyPlanConfig`.
+
+Deliberately the literal ``"1"`` and distinct from the survey-entities
+``SURVEY_SCHEMA_VERSION`` (``"1.0"``); the plan-config sidecar evolves
+independently of the run/frame dataset schema.
+"""
+
+
+@dataclass(frozen=True)
+class SurveyPlanConfig:
+    """Reproducible configuration for a nine-phase survey plan.
+
+    Captures every knob the survey planner needs so a run can be replayed
+    deterministically from a ``plan_config.yaml`` sidecar without touching a
+    live camera. Phase numbers (1..9) map to the C4 nine-phase survey catalog:
+
+        1. camera inventory
+        2. PTZ characterization
+        3. zoom characterization
+        4. dense nadir
+        5. main survey
+        6. cross zoom
+        7. repeatability
+        8. static jitter
+        9. validation
+
+    Phases absent from the ``phase_*_range`` dicts fall back to the live camera
+    capabilities (#256 ``CameraCapabilities``) at plan time.
+
+    Attributes:
+        schema_version: Sidecar schema version (always ``"1"``).
+        enabled_phases: Subset of ``{1..9}`` to execute; defaults to all nine.
+        phase_pan_range: Per-phase ``(lo, hi)`` pan bounds in degrees.
+        phase_tilt_range: Per-phase ``(lo, hi)`` tilt bounds in degrees.
+        phase_zoom_range: Per-phase ``(lo, hi)`` zoom-factor bounds.
+        grid_overlap_pct: Per-phase tile overlap percentage (phases 4 and 5).
+        burst_frame_count: Per-phase snapshot-burst frame count (phases 2, 3, 7).
+        jitter_burst_duration_s: Phase 8 jitter burst duration in seconds.
+        jitter_burst_fps: Phase 8 jitter burst frame rate; ``0.0`` is a sentinel
+            meaning "use the native FPS target".
+        jitter_zoom_levels: Phase 8 zoom factors (wide/mid/high/max).
+        jitter_pose_count: Phase 8 representative poses per camera.
+        zoom_levels: Zoom factors swept by phases 3, 6 and 8.
+        repeat_count: Per-phase repetition count (phases 2 and 7).
+        holdout_fraction: Phase 9 validation holdout fraction.
+    """
+
+    schema_version: str = PLAN_CONFIG_SCHEMA_VERSION
+    enabled_phases: frozenset[int] = field(default=frozenset(range(1, 10)))
+    phase_pan_range: dict[int, tuple[float, float]] = field(default_factory=dict)
+    phase_tilt_range: dict[int, tuple[float, float]] = field(default_factory=dict)
+    phase_zoom_range: dict[int, tuple[float, float]] = field(default_factory=dict)
+    grid_overlap_pct: dict[int, float] = field(default_factory=lambda: {4: 80.0, 5: 80.0})
+    burst_frame_count: dict[int, int] = field(default_factory=dict)
+    jitter_burst_duration_s: float = 30.0
+    jitter_burst_fps: float = 0.0
+    jitter_zoom_levels: list[float] = field(default_factory=lambda: [1.0, 5.0, 12.0, 25.0])
+    jitter_pose_count: int = 1
+    zoom_levels: list[float] = field(default_factory=lambda: [1.0, 5.0, 12.0, 25.0])
+    repeat_count: dict[int, int] = field(default_factory=lambda: {2: 3, 7: 3})
+    holdout_fraction: float = 0.15
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serialisable dictionary.
+
+        ``frozenset`` becomes a sorted list, every ``int``-keyed dict has its
+        keys stringified, and range tuples become 2-element lists so the result
+        survives ``json.dumps`` / ``yaml.safe_dump`` round-trips.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "enabled_phases": sorted(self.enabled_phases),
+            "phase_pan_range": _ranges_to_dict(self.phase_pan_range),
+            "phase_tilt_range": _ranges_to_dict(self.phase_tilt_range),
+            "phase_zoom_range": _ranges_to_dict(self.phase_zoom_range),
+            "grid_overlap_pct": {str(k): v for k, v in self.grid_overlap_pct.items()},
+            "burst_frame_count": {str(k): v for k, v in self.burst_frame_count.items()},
+            "jitter_burst_duration_s": self.jitter_burst_duration_s,
+            "jitter_burst_fps": self.jitter_burst_fps,
+            "jitter_zoom_levels": list(self.jitter_zoom_levels),
+            "jitter_pose_count": self.jitter_pose_count,
+            "zoom_levels": list(self.zoom_levels),
+            "repeat_count": {str(k): v for k, v in self.repeat_count.items()},
+            "holdout_fraction": self.holdout_fraction,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SurveyPlanConfig:
+        """Create a :class:`SurveyPlanConfig` from a (partial) dictionary.
+
+        Tolerates missing keys by falling back to field defaults, but a full
+        ``to_dict()`` payload round-trips to an equal object.
+
+        Raises:
+            ValueError: If ``schema_version`` is not the supported version.
+        """
+        version = data.get("schema_version", PLAN_CONFIG_SCHEMA_VERSION)
+        if version != PLAN_CONFIG_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema_version {version!r}; expected {PLAN_CONFIG_SCHEMA_VERSION!r}"
+            )
+        defaults = cls()
+        enabled = data.get("enabled_phases")
+        return cls(
+            schema_version=PLAN_CONFIG_SCHEMA_VERSION,
+            enabled_phases=(
+                frozenset(int(p) for p in enabled)
+                if enabled is not None
+                else defaults.enabled_phases
+            ),
+            phase_pan_range=_ranges_from_dict(
+                data.get("phase_pan_range"), defaults.phase_pan_range
+            ),
+            phase_tilt_range=_ranges_from_dict(
+                data.get("phase_tilt_range"), defaults.phase_tilt_range
+            ),
+            phase_zoom_range=_ranges_from_dict(
+                data.get("phase_zoom_range"), defaults.phase_zoom_range
+            ),
+            grid_overlap_pct=_int_keyed(
+                data.get("grid_overlap_pct"), float, defaults.grid_overlap_pct
+            ),
+            burst_frame_count=_int_keyed(
+                data.get("burst_frame_count"), int, defaults.burst_frame_count
+            ),
+            jitter_burst_duration_s=float(
+                data.get("jitter_burst_duration_s", defaults.jitter_burst_duration_s)
+            ),
+            jitter_burst_fps=float(data.get("jitter_burst_fps", defaults.jitter_burst_fps)),
+            jitter_zoom_levels=_float_list(
+                data.get("jitter_zoom_levels"), defaults.jitter_zoom_levels
+            ),
+            jitter_pose_count=int(data.get("jitter_pose_count", defaults.jitter_pose_count)),
+            zoom_levels=_float_list(data.get("zoom_levels"), defaults.zoom_levels),
+            repeat_count=_int_keyed(data.get("repeat_count"), int, defaults.repeat_count),
+            holdout_fraction=float(data.get("holdout_fraction", defaults.holdout_fraction)),
+        )
+
+
+def _ranges_to_dict(
+    ranges: dict[int, tuple[float, float]],
+) -> dict[str, list[float]]:
+    """Serialise an int-keyed range dict to string keys and 2-element lists."""
+    return {str(k): [v[0], v[1]] for k, v in ranges.items()}
+
+
+def _ranges_from_dict(
+    raw: dict[Any, Any] | None,
+    default: dict[int, tuple[float, float]],
+) -> dict[int, tuple[float, float]]:
+    """Rebuild an int-keyed range dict from a serialised payload."""
+    if raw is None:
+        return dict(default)
+    return {int(k): (float(v[0]), float(v[1])) for k, v in raw.items()}
+
+
+def _int_keyed(
+    raw: dict[Any, Any] | None,
+    value_cast: Any,
+    default: dict[int, Any],
+) -> dict[int, Any]:
+    """Rebuild an int-keyed scalar dict, coercing values with ``value_cast``."""
+    if raw is None:
+        return dict(default)
+    return {int(k): value_cast(v) for k, v in raw.items()}
+
+
+def _float_list(raw: list[Any] | None, default: list[float]) -> list[float]:
+    """Rebuild a float list from a serialised payload."""
+    if raw is None:
+        return list(default)
+    return [float(v) for v in raw]

--- a/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.infrastructure.models.survey_run import SurveyRunModel
 from poc_homography.infrastructure.repositories.base import RepoPostgresSession
 
@@ -95,3 +96,31 @@ class RepoPostgresSurveyRun(RepoPostgresSession):
         except Exception:
             logger.exception("Failed to save SurveyRun %s", entity.id)
             return False
+
+    def save_plan_config(self, run_id: str, config: SurveyPlanConfig) -> bool:
+        """Persist ``config`` under the ``plan_config`` JSONB key of ``run_id``.
+
+        The run row must already exist; returns ``False`` if it does not.
+        Returns ``True`` on success, ``False`` (logged) on any failure.
+        """
+        try:
+            row = self._session.get(self._model_cls, run_id)
+            if row is None:
+                return False
+            row.data = {**row.data, "plan_config": config.to_dict()}  # type: ignore[attr-defined]
+            self._session.flush()
+            return True
+        except Exception:
+            logger.exception("Failed to save plan config for run %s", run_id)
+            return False
+
+    def load_plan_config(self, run_id: str) -> SurveyPlanConfig:
+        """Load the ``plan_config`` JSONB payload for ``run_id``.
+
+        Raises:
+            KeyError: If the run row is missing or has no ``plan_config`` key.
+        """
+        row = self._session.get(self._model_cls, run_id)
+        if row is None or "plan_config" not in row.data:  # type: ignore[attr-defined]
+            raise KeyError(run_id)
+        return SurveyPlanConfig.from_dict(row.data["plan_config"])  # type: ignore[attr-defined]

--- a/poc_homography/infrastructure/repositories/repo_yaml_survey_run.py
+++ b/poc_homography/infrastructure/repositories/repo_yaml_survey_run.py
@@ -12,8 +12,11 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 from poc_homography.domain.entities.survey.frame_record import FrameRecord
 from poc_homography.domain.entities.survey.survey_run import SurveyRun
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.infrastructure.repositories.base.repo_yaml import RepoYaml
 
 if TYPE_CHECKING:
@@ -86,3 +89,38 @@ class RepoYamlSurveyRun(RepoYaml[SurveyRun]):
     def get_frames_by_burst(self, burst_id: str) -> list[FrameRecord]:
         """Return all frames belonging to ``burst_id``."""
         return [f for f in self._all_frames() if f.capture.burst_id == burst_id]
+
+    # ------------------------------------------------------------------
+    # Plan-config sidecar
+    # ------------------------------------------------------------------
+
+    def _plan_config_path(self, run_id: str) -> Path:
+        return self._frames_dir / run_id / "plan_config.yaml"
+
+    def save_plan_config(self, run_id: str, config: SurveyPlanConfig) -> bool:
+        """Persist ``config`` as a ``plan_config.yaml`` sidecar for ``run_id``.
+
+        Returns ``True`` on success, ``False`` (logged) on any failure.
+        """
+        path = self._plan_config_path(run_id)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                yaml.dump(config.to_dict(), f, default_flow_style=False, sort_keys=False)
+        except Exception:
+            logger.exception("Failed to save plan config for run %s", run_id)
+            return False
+        return True
+
+    def load_plan_config(self, run_id: str) -> SurveyPlanConfig:
+        """Load the ``plan_config.yaml`` sidecar for ``run_id``.
+
+        Raises:
+            KeyError: If no sidecar exists for ``run_id``.
+        """
+        path = self._plan_config_path(run_id)
+        if not path.exists():
+            raise KeyError(run_id)
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return SurveyPlanConfig.from_dict(data)

--- a/poc_homography/survey/orchestrator_memory.py
+++ b/poc_homography/survey/orchestrator_memory.py
@@ -1,0 +1,163 @@
+"""In-memory placeholder orchestrator (camera-free) for the C5 operator surface.
+
+This is the C5 stand-in for the real C3 concurrent multi-camera orchestrator.
+It satisfies the ``ConcurrentSurveyOrchestrator`` protocol (see
+``poc_homography.domain.protocols.survey_orchestrator``)
+without touching a live camera: runs and per-camera progress are simulated
+deterministically in memory. The CLI, Django, and FastAPI layers wire this by
+default until C3 lands; tests inject deterministic ``id_factory`` / ``clock``
+callables for reproducible assertions.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
+from poc_homography.domain.protocols.survey_orchestrator import (
+    CameraStatus,
+    ProgressEvent,
+    RunHandle,
+    RunSummary,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+# Phase numbers (1..9) map to the nine-member SurveyPhase enum in declaration order.
+_PHASE_BY_NUMBER: dict[int, SurveyPhase] = dict(enumerate(SurveyPhase, start=1))
+
+DEFAULT_FRAMES_PER_PHASE = 2
+
+
+@dataclass
+class _CameraState:
+    """Mutable per-camera progress within a simulated run."""
+
+    session_id: str
+    phase: str
+    frame_count: int = 0
+    status: str = SurveyRunStatus.RUNNING.value
+
+
+@dataclass
+class _RunState:
+    """Mutable state for one simulated run."""
+
+    run_id: str
+    started_at: datetime
+    phases: tuple[SurveyPhase, ...]
+    cameras: dict[str, _CameraState] = field(default_factory=dict)
+    status: str = SurveyRunStatus.RUNNING.value
+
+
+class InMemorySurveyOrchestrator:
+    """Deterministic, camera-free orchestrator stub for the operator surface."""
+
+    def __init__(
+        self,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        clock: Callable[[], datetime] | None = None,
+        frames_per_phase: int = DEFAULT_FRAMES_PER_PHASE,
+    ) -> None:
+        self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
+        self._clock = clock or (lambda: datetime.now(tz=timezone.utc))
+        self._frames_per_phase = frames_per_phase
+        self._runs: dict[str, _RunState] = {}
+        self._lock = threading.Lock()
+
+    def start(self, plan_config: SurveyPlanConfig, camera_ids: Sequence[str]) -> RunHandle:
+        """Register a run with one session per camera; return its handle."""
+        phases = tuple(
+            _PHASE_BY_NUMBER[n] for n in sorted(plan_config.enabled_phases) if n in _PHASE_BY_NUMBER
+        )
+        with self._lock:
+            run_id = self._id_factory()
+            first_phase = phases[0].value if phases else SurveyPhase.CAMERA_INVENTORY.value
+            cameras = {
+                camera_id: _CameraState(session_id=self._id_factory(), phase=first_phase)
+                for camera_id in camera_ids
+            }
+            self._runs[run_id] = _RunState(
+                run_id=run_id,
+                started_at=self._clock(),
+                phases=phases,
+                cameras=cameras,
+            )
+            session_ids = {cid: state.session_id for cid, state in cameras.items()}
+        return RunHandle(run_id=run_id, session_ids=session_ids)
+
+    def status(self, run_id: str) -> dict[str, CameraStatus] | None:
+        """Return per-camera status keyed by ``camera_id``, or ``None`` if unknown."""
+        with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                return None
+            return {
+                cid: CameraStatus(
+                    session_id=cam.session_id,
+                    phase=cam.phase,
+                    frame_count=cam.frame_count,
+                    status=cam.status,
+                )
+                for cid, cam in run.cameras.items()
+            }
+
+    def abort(self, run_id: str) -> bool:
+        """Mark the run and all its cameras aborted; return whether it existed."""
+        with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                return False
+            run.status = SurveyRunStatus.ABORTED.value
+            for cam in run.cameras.values():
+                cam.status = SurveyRunStatus.ABORTED.value
+            return True
+
+    def iter_progress(self, run_id: str) -> Iterator[ProgressEvent]:
+        """Advance every camera through each enabled phase, yielding one event each."""
+        run = self._runs.get(run_id)
+        if run is None:
+            return
+        for phase in run.phases:
+            for camera_id, cam in run.cameras.items():
+                with self._lock:
+                    if run.status == SurveyRunStatus.ABORTED.value:
+                        return
+                    cam.phase = phase.value
+                    cam.frame_count += self._frames_per_phase
+                    event = ProgressEvent(
+                        camera_id=camera_id,
+                        phase=cam.phase,
+                        frame_count=cam.frame_count,
+                        status=cam.status,
+                    )
+                yield event
+        with self._lock:
+            if run.status != SurveyRunStatus.ABORTED.value:
+                run.status = SurveyRunStatus.COMPLETED.value
+                for cam in run.cameras.values():
+                    cam.status = SurveyRunStatus.COMPLETED.value
+
+    def list_runs(self, limit: int = 20) -> list[RunSummary]:
+        """Return up to ``limit`` run summaries, newest first."""
+        with self._lock:
+            runs = sorted(self._runs.values(), key=lambda r: r.started_at, reverse=True)
+            return [
+                RunSummary(
+                    run_id=run.run_id,
+                    start_time=run.started_at.isoformat(),
+                    camera_count=len(run.cameras),
+                    total_frame_count=sum(c.frame_count for c in run.cameras.values()),
+                    status=run.status,
+                )
+                for run in runs[:limit]
+            ]

--- a/poc_homography/survey/orchestrator_memory.py
+++ b/poc_homography/survey/orchestrator_memory.py
@@ -124,11 +124,17 @@ class InMemorySurveyOrchestrator:
 
     def iter_progress(self, run_id: str) -> Iterator[ProgressEvent]:
         """Advance every camera through each enabled phase, yielding one event each."""
-        run = self._runs.get(run_id)
+        with self._lock:
+            run = self._runs.get(run_id)
+            phases = run.phases if run is not None else ()
         if run is None:
             return
-        for phase in run.phases:
-            for camera_id, cam in run.cameras.items():
+        for phase in phases:
+            with self._lock:
+                if run.status == SurveyRunStatus.ABORTED.value:
+                    return
+                camera_items = list(run.cameras.items())
+            for camera_id, cam in camera_items:
                 with self._lock:
                     if run.status == SurveyRunStatus.ABORTED.value:
                         return

--- a/poc_homography/survey/run_service.py
+++ b/poc_homography/survey/run_service.py
@@ -41,7 +41,13 @@ class SurveyRunService:
         self._run_repo = run_repo
 
     def start_run(self, plan_config: SurveyPlanConfig, camera_ids: list[str]) -> dict[str, object]:
-        """Launch a run; return ``{"run_id", "session_ids"}``."""
+        """Launch a run; return ``{"run_id", "session_ids"}``.
+
+        Raises:
+            ValueError: If ``camera_ids`` is empty (a run needs at least one camera).
+        """
+        if not camera_ids:
+            raise ValueError("camera_ids must not be empty")
         handle = self._orchestrator.start(plan_config, camera_ids)
         return {"run_id": handle.run_id, "session_ids": dict(handle.session_ids)}
 
@@ -69,8 +75,15 @@ class SurveyRunService:
             return None
         return {"run_id": run_id, "message": "Run abort requested"}
 
-    def list_runs(self, limit: int = 20) -> list[dict[str, object]]:
-        """Return run summaries (newest first) as JSON-friendly dicts."""
+    def list_runs(self, limit: int = 20, offset: int = 0) -> list[dict[str, object]]:
+        """Return up to ``limit`` run summaries (newest first), skipping ``offset``.
+
+        The orchestrator only knows ``limit``, so fetch ``limit + offset`` newest
+        runs and drop the leading ``offset`` here — giving correct windowed
+        pagination across every transport from one place.
+        """
+        offset = max(offset, 0)
+        summaries = self._orchestrator.list_runs(limit + offset)[offset:]
         return [
             {
                 "run_id": summary.run_id,
@@ -79,7 +92,7 @@ class SurveyRunService:
                 "total_frame_count": summary.total_frame_count,
                 "status": summary.status,
             }
-            for summary in self._orchestrator.list_runs(limit)
+            for summary in summaries
         ]
 
     def iter_progress(self, run_id: str) -> Iterator[dict[str, object]]:
@@ -106,7 +119,12 @@ class SurveyRunService:
         Optional filters narrow the result: ``phase`` is a 1..9 phase number,
         ``camera`` a camera id, and ``zoom`` a reported zoom factor (matched to
         one decimal place). Returns an empty list when no run repository is wired.
+
+        Raises:
+            ValueError: If ``phase`` is not a valid 1..9 phase number.
         """
+        if phase is not None and phase not in _PHASE_BY_NUMBER:
+            raise ValueError(f"phase must be a 1..9 phase number, got {phase}")
         if self._run_repo is None:
             return []
         phase_value = _PHASE_BY_NUMBER[phase].value if phase is not None else None

--- a/poc_homography/survey/run_service.py
+++ b/poc_homography/survey/run_service.py
@@ -1,0 +1,138 @@
+"""Service facade for the multi-camera survey operator surface (C5, issue #262).
+
+A thin, transport-agnostic layer that the CLI (``hom survey ...``), the Django
+views, and the FastAPI endpoints all delegate to. It composes a
+:class:`~poc_homography.domain.protocols.survey_orchestrator.ConcurrentSurveyOrchestrator`
+(run lifecycle) with an optional
+:class:`~poc_homography.domain.protocols.survey_run_repository.SurveyRunRepository`
+(dataset browsing) and returns plain JSON-friendly dicts so every transport
+serialises results identically.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.survey.orchestrator_memory import InMemorySurveyOrchestrator
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from poc_homography.domain.protocols.survey_orchestrator import (
+        ConcurrentSurveyOrchestrator,
+    )
+    from poc_homography.domain.protocols.survey_run_repository import SurveyRunRepository
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+# Phase numbers (1..9) map to the nine-member SurveyPhase enum in declaration order.
+_PHASE_BY_NUMBER: dict[int, SurveyPhase] = dict(enumerate(SurveyPhase, start=1))
+
+
+class SurveyRunService:
+    """Transport-agnostic facade over the orchestrator and run repository."""
+
+    def __init__(
+        self,
+        orchestrator: ConcurrentSurveyOrchestrator,
+        run_repo: SurveyRunRepository | None = None,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._run_repo = run_repo
+
+    def start_run(self, plan_config: SurveyPlanConfig, camera_ids: list[str]) -> dict[str, object]:
+        """Launch a run; return ``{"run_id", "session_ids"}``."""
+        handle = self._orchestrator.start(plan_config, camera_ids)
+        return {"run_id": handle.run_id, "session_ids": dict(handle.session_ids)}
+
+    def get_status(self, run_id: str) -> dict[str, object] | None:
+        """Return ``{"run_id", "cameras": {...}}`` or ``None`` if the run is unknown."""
+        statuses = self._orchestrator.status(run_id)
+        if statuses is None:
+            return None
+        return {
+            "run_id": run_id,
+            "cameras": {
+                camera_id: {
+                    "session_id": cam.session_id,
+                    "phase": cam.phase,
+                    "frame_count": cam.frame_count,
+                    "status": cam.status,
+                }
+                for camera_id, cam in statuses.items()
+            },
+        }
+
+    def abort_run(self, run_id: str) -> dict[str, str] | None:
+        """Request graceful abort; return a message dict or ``None`` if unknown."""
+        if not self._orchestrator.abort(run_id):
+            return None
+        return {"run_id": run_id, "message": "Run abort requested"}
+
+    def list_runs(self, limit: int = 20) -> list[dict[str, object]]:
+        """Return run summaries (newest first) as JSON-friendly dicts."""
+        return [
+            {
+                "run_id": summary.run_id,
+                "start_time": summary.start_time,
+                "camera_count": summary.camera_count,
+                "total_frame_count": summary.total_frame_count,
+                "status": summary.status,
+            }
+            for summary in self._orchestrator.list_runs(limit)
+        ]
+
+    def iter_progress(self, run_id: str) -> Iterator[dict[str, object]]:
+        """Yield per-camera, per-phase progress dicts until the run terminates."""
+        for event in self._orchestrator.iter_progress(run_id):
+            yield {
+                "camera_id": event.camera_id,
+                "phase": event.phase,
+                "frame_count": event.frame_count,
+                "status": event.status,
+            }
+
+    def browse_groups(
+        self,
+        run_id: str,
+        *,
+        phase: int | None = None,
+        camera: str | None = None,
+        zoom: float | None = None,
+    ) -> list[dict[str, object]]:
+        """Return dataset grouping keys with frame counts for ``run_id``.
+
+        Frames are grouped by ``(phase, camera, reported_zoom)`` and counted.
+        Optional filters narrow the result: ``phase`` is a 1..9 phase number,
+        ``camera`` a camera id, and ``zoom`` a reported zoom factor (matched to
+        one decimal place). Returns an empty list when no run repository is wired.
+        """
+        if self._run_repo is None:
+            return []
+        phase_value = _PHASE_BY_NUMBER[phase].value if phase is not None else None
+        counts: dict[tuple[str, str, float], int] = {}
+        for frame in self._run_repo.get_frames_by_run(run_id):
+            frame_phase = frame.capture.phase.value
+            frame_camera = frame.camera.camera_id
+            frame_zoom = round(float(frame.reported.reported_zoom), 1)
+            if phase_value is not None and frame_phase != phase_value:
+                continue
+            if camera is not None and frame_camera != camera:
+                continue
+            if zoom is not None and frame_zoom != round(float(zoom), 1):
+                continue
+            key = (frame_phase, frame_camera, frame_zoom)
+            counts[key] = counts.get(key, 0) + 1
+        return [
+            {"phase": key[0], "camera": key[1], "zoom": key[2], "frame_count": count}
+            for key, count in sorted(counts.items())
+        ]
+
+
+def build_survey_run_service(run_repo: SurveyRunRepository | None = None) -> SurveyRunService:
+    """Build the default operator-surface service.
+
+    Wires the C5 in-memory orchestrator stub (camera-free) pending the real C3
+    orchestrator. ``run_repo`` enables dataset browsing when supplied.
+    """
+    return SurveyRunService(orchestrator=InMemorySurveyOrchestrator(), run_repo=run_repo)

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command tests."""

--- a/tests/cli/test_survey_cli.py
+++ b/tests/cli/test_survey_cli.py
@@ -1,0 +1,164 @@
+"""Tests for the ``hom survey`` CLI sub-app."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+import poc_homography.cli.survey as survey_cli
+from poc_homography.cli.main import app
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+
+runner = CliRunner()
+
+
+@pytest.mark.integration
+def test_survey_run_streams_progress(tmp_path):
+    """`survey run` against the real default service prints sessions + progress."""
+    plan = SurveyPlanConfig(enabled_phases=frozenset({1, 2}))
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan.to_dict()))
+
+    result = runner.invoke(
+        app,
+        ["survey", "run", "--plan", str(plan_path), "--cameras", "cam-a,cam-b"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "run_id:" in result.output
+    assert "cam-a" in result.output
+    assert "cam-b" in result.output
+    assert "phase=" in result.output
+
+
+def test_survey_run_bad_plan(tmp_path, monkeypatch):
+    """`survey run` exits 1 on an unsupported schema_version."""
+    plan_path = tmp_path / "bad.yaml"
+    plan_path.write_text(yaml.safe_dump({"schema_version": "999"}))
+
+    result = runner.invoke(
+        app,
+        ["survey", "run", "--plan", str(plan_path), "--cameras", "cam-a"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+
+def test_survey_status(monkeypatch):
+    """`survey status` prints per-camera phase/frame/status."""
+    fake = MagicMock()
+    fake.get_status.return_value = {
+        "run_id": "run-1",
+        "cameras": {
+            "cam-a": {
+                "session_id": "sess-a",
+                "phase": "camera_inventory",
+                "frame_count": 4,
+                "status": "running",
+            }
+        },
+    }
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "status", "--run-id", "run-1"])
+
+    assert result.exit_code == 0, result.output
+    assert "run-1" in result.output
+    assert "cam-a" in result.output
+    assert "phase=camera_inventory" in result.output
+    assert "frames=4" in result.output
+    assert "status=running" in result.output
+
+
+def test_survey_status_not_found(monkeypatch):
+    """`survey status` exits 1 when the run is unknown."""
+    fake = MagicMock()
+    fake.get_status.return_value = None
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "status", "--run-id", "nope"])
+
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+
+def test_survey_abort(monkeypatch):
+    """`survey abort` prints the returned message."""
+    fake = MagicMock()
+    fake.abort_run.return_value = {"run_id": "run-1", "message": "Run abort requested"}
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "abort", "--run-id", "run-1"])
+
+    assert result.exit_code == 0, result.output
+    assert "Run abort requested" in result.output
+
+
+def test_survey_abort_not_found(monkeypatch):
+    """`survey abort` exits 1 when the run is unknown."""
+    fake = MagicMock()
+    fake.abort_run.return_value = None
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "abort", "--run-id", "nope"])
+
+    assert result.exit_code == 1
+    assert "Error" in result.output
+
+
+def test_survey_list(monkeypatch):
+    """`survey list` prints a header and a row per run."""
+    fake = MagicMock()
+    fake.list_runs.return_value = [
+        {
+            "run_id": "run-1",
+            "start_time": "2026-06-05T00:00:00+00:00",
+            "camera_count": 2,
+            "total_frame_count": 8,
+            "status": "completed",
+        }
+    ]
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "list", "--limit", "5"])
+
+    assert result.exit_code == 0, result.output
+    assert "run_id" in result.output
+    assert "run-1" in result.output
+    assert "completed" in result.output
+    fake.list_runs.assert_called_once_with(5)
+
+
+def test_survey_browse(monkeypatch):
+    """`survey browse` prints grouping rows."""
+    fake = MagicMock()
+    fake.browse_groups.return_value = [
+        {"phase": "camera_inventory", "camera": "cam-a", "zoom": 1.0, "frame_count": 3},
+    ]
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(
+        app,
+        ["survey", "browse", "--run-id", "run-1", "--phase", "1", "--camera", "cam-a"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "camera_inventory" in result.output
+    assert "cam-a" in result.output
+    fake.browse_groups.assert_called_once_with("run-1", phase=1, camera="cam-a", zoom=None)
+
+
+def test_survey_browse_empty(monkeypatch):
+    """`survey browse` prints a no-groupings line and exits 0 when empty."""
+    fake = MagicMock()
+    fake.browse_groups.return_value = []
+    monkeypatch.setattr(survey_cli, "_survey_run_service", fake)
+
+    result = runner.invoke(app, ["survey", "browse", "--run-id", "run-1"])
+
+    assert result.exit_code == 0, result.output
+    assert "No groupings" in result.output

--- a/tests/domain/test_survey_plan_config.py
+++ b/tests/domain/test_survey_plan_config.py
@@ -1,0 +1,142 @@
+"""Tests for SurveyPlanConfig frozen VO: defaults, round-trip, schema, yaml sidecar."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from poc_homography.domain.vo.survey_plan_config import (
+    PLAN_CONFIG_SCHEMA_VERSION,
+    SurveyPlanConfig,
+)
+
+
+def _populated() -> SurveyPlanConfig:
+    """A non-default, fully-populated config exercising every field shape."""
+    return SurveyPlanConfig(
+        enabled_phases=frozenset({1, 2, 4, 8, 9}),
+        phase_pan_range={2: (-170.0, 170.0), 5: (-90.0, 90.0)},
+        phase_tilt_range={5: (-50.0, 60.0)},
+        phase_zoom_range={3: (1.0, 25.0), 6: (5.0, 12.0)},
+        grid_overlap_pct={4: 75.0, 5: 85.0},
+        burst_frame_count={2: 5, 3: 4, 7: 6},
+        jitter_burst_duration_s=45.0,
+        jitter_burst_fps=10.0,
+        jitter_zoom_levels=[2.0, 8.0, 20.0],
+        jitter_pose_count=3,
+        zoom_levels=[1.0, 10.0, 25.0],
+        repeat_count={2: 4, 7: 5},
+        holdout_fraction=0.2,
+    )
+
+
+class TestSurveyPlanConfigDefaults:
+    def test_constructs_with_no_args(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert cfg.schema_version == "1"
+
+    def test_enabled_phases_all_nine(self) -> None:
+        assert SurveyPlanConfig().enabled_phases == frozenset(range(1, 10))
+
+    def test_grid_overlap_defaults(self) -> None:
+        assert SurveyPlanConfig().grid_overlap_pct == {4: 80.0, 5: 80.0}
+
+    def test_holdout_fraction_default(self) -> None:
+        assert SurveyPlanConfig().holdout_fraction == 0.15
+
+    def test_jitter_defaults(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert cfg.jitter_burst_duration_s == 30.0
+        assert cfg.jitter_burst_fps == 0.0
+        assert cfg.jitter_zoom_levels == [1.0, 5.0, 12.0, 25.0]
+        assert cfg.jitter_pose_count == 1
+
+    def test_zoom_and_repeat_defaults(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert cfg.zoom_levels == [1.0, 5.0, 12.0, 25.0]
+        assert cfg.repeat_count == {2: 3, 7: 3}
+
+    def test_range_dicts_default_empty(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert cfg.phase_pan_range == {}
+        assert cfg.phase_tilt_range == {}
+        assert cfg.phase_zoom_range == {}
+        assert cfg.burst_frame_count == {}
+
+    def test_independent_default_instances(self) -> None:
+        a = SurveyPlanConfig()
+        b = SurveyPlanConfig()
+        assert a.grid_overlap_pct is not b.grid_overlap_pct
+
+
+class TestSurveyPlanConfigFrozen:
+    def test_mutate_holdout_raises(self) -> None:
+        cfg = SurveyPlanConfig()
+        with pytest.raises(AttributeError):
+            cfg.holdout_fraction = 0.5  # type: ignore[misc]
+
+    def test_mutate_enabled_phases_raises(self) -> None:
+        cfg = SurveyPlanConfig()
+        with pytest.raises(AttributeError):
+            cfg.enabled_phases = frozenset({1})  # type: ignore[misc]
+
+
+class TestSurveyPlanConfigRoundTrip:
+    def test_from_dict_to_dict_equals_original(self) -> None:
+        cfg = _populated()
+        assert SurveyPlanConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_to_dict_idempotent(self) -> None:
+        cfg = _populated()
+        restored = SurveyPlanConfig.from_dict(cfg.to_dict())
+        assert restored.to_dict() == cfg.to_dict()
+
+    def test_default_round_trip(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert SurveyPlanConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_to_dict_is_json_serialisable(self) -> None:
+        cfg = _populated()
+        encoded = json.dumps(cfg.to_dict())
+        decoded = json.loads(encoded)
+        _assert_all_dict_keys_are_strings(decoded)
+
+    def test_partial_dict_loads_with_defaults(self) -> None:
+        cfg = SurveyPlanConfig.from_dict({"schema_version": "1", "holdout_fraction": 0.3})
+        assert cfg.holdout_fraction == 0.3
+        assert cfg.enabled_phases == frozenset(range(1, 10))
+        assert cfg.grid_overlap_pct == {4: 80.0, 5: 80.0}
+
+
+class TestSurveyPlanConfigSchemaVersion:
+    def test_to_dict_schema_version_is_one(self) -> None:
+        assert SurveyPlanConfig().to_dict()["schema_version"] == "1"
+        assert PLAN_CONFIG_SCHEMA_VERSION == "1"
+
+    def test_unknown_version_raises(self) -> None:
+        data = SurveyPlanConfig().to_dict()
+        data["schema_version"] = "0.9"
+        with pytest.raises(ValueError, match="schema_version"):
+            SurveyPlanConfig.from_dict(data)
+
+
+class TestSurveyPlanConfigYamlReload:
+    def test_yaml_sidecar_round_trip(self, tmp_path) -> None:
+        cfg = _populated()
+        sidecar = tmp_path / "plan_config.yaml"
+        sidecar.write_text(yaml.safe_dump(cfg.to_dict()))
+        loaded = yaml.safe_load(sidecar.read_text())
+        assert SurveyPlanConfig.from_dict(loaded) == cfg
+
+
+def _assert_all_dict_keys_are_strings(obj: object) -> None:
+    """Recursively assert no dict in the decoded payload has non-str keys."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            assert isinstance(key, str)
+            _assert_all_dict_keys_are_strings(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _assert_all_dict_keys_are_strings(item)

--- a/tests/infrastructure/survey/test_repo_survey_run_plan_config.py
+++ b/tests/infrastructure/survey/test_repo_survey_run_plan_config.py
@@ -1,0 +1,99 @@
+"""Tests for plan_config persistence on the SurveyRun repos.
+
+The YAML test is a pure-filesystem unit test (no DB). The Postgres test is an
+``integration`` test gated on ``DATABASE_URL`` by the infra conftest; the
+``db_session`` fixture rolls back after each test.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poc_homography.domain.entities.survey.survey_run import SurveyRun
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.infrastructure.repositories.repo_postgres_survey_run import (
+    RepoPostgresSurveyRun,
+)
+from poc_homography.infrastructure.repositories.repo_yaml_survey_run import (
+    RepoYamlSurveyRun,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from sqlalchemy.orm import Session
+
+_TS = datetime(2026, 2, 3, 4, 5, 6, tzinfo=timezone.utc)
+
+
+def _make_config() -> SurveyPlanConfig:
+    return SurveyPlanConfig(
+        enabled_phases=frozenset({1, 4, 5, 9}),
+        phase_pan_range={4: (-30.0, 30.0), 5: (-90.0, 90.0)},
+        phase_zoom_range={6: (1.0, 12.0)},
+        grid_overlap_pct={4: 70.0, 5: 60.0},
+        burst_frame_count={2: 5, 7: 4},
+        jitter_burst_duration_s=15.0,
+        jitter_pose_count=3,
+        zoom_levels=[1.0, 2.0, 4.0],
+        repeat_count={2: 2, 7: 5},
+        holdout_fraction=0.25,
+    )
+
+
+def _make_run(run_id: str) -> SurveyRun:
+    return SurveyRun(
+        run_id=run_id,
+        camera_id="cam01",
+        phases=frozenset({SurveyPhase.MAIN_SURVEY, SurveyPhase.VALIDATION}),
+        started_at=_TS,
+        finished_at=None,
+        status=SurveyRunStatus.RUNNING,
+    )
+
+
+def test_yaml_plan_config_round_trip(tmp_path: Path) -> None:
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    cfg = _make_config()
+    run_id = "run-0001"
+
+    assert repo.save_plan_config(run_id, cfg) is True
+
+    sidecar = tmp_path / "survey" / run_id / "plan_config.yaml"
+    assert sidecar.exists()
+
+    assert repo.load_plan_config(run_id) == cfg
+
+
+def test_yaml_load_plan_config_unknown_raises_key_error(tmp_path: Path) -> None:
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    with pytest.raises(KeyError):
+        repo.load_plan_config("does-not-exist")
+
+
+@pytest.mark.integration
+class TestRepoPostgresSurveyRunPlanConfig:
+    def test_plan_config_round_trip(self, db_session: Session) -> None:
+        repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
+        run = _make_run("pg-plan-0001")
+        assert repo.save(run) is True
+
+        cfg = _make_config()
+        assert repo.save_plan_config(run.run_id, cfg) is True
+        assert repo.load_plan_config(run.run_id) == cfg
+
+    def test_load_plan_config_unknown_raises_key_error(self, db_session: Session) -> None:
+        repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
+        with pytest.raises(KeyError):
+            repo.load_plan_config("missing-run")

--- a/tests/survey/test_run_service.py
+++ b/tests/survey/test_run_service.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+import pytest
+
 from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.survey.orchestrator_memory import InMemorySurveyOrchestrator
 from poc_homography.survey.run_service import SurveyRunService, build_survey_run_service
@@ -117,6 +119,24 @@ class TestSurveyRunService:
         assert runs[0]["run_id"] == "id-0"
         assert runs[0]["camera_count"] == 1
 
+    def test_start_run_rejects_empty_camera_ids(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        with pytest.raises(ValueError, match="camera_ids"):
+            service.start_run(SurveyPlanConfig(), [])
+
+    def test_list_runs_offset_windows_results(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        # Three runs created newest-last; list_runs returns newest-first.
+        for _ in range(3):
+            service.start_run(SurveyPlanConfig(), ["cam-a"])
+        first_page = service.list_runs(limit=2, offset=0)
+        second_page = service.list_runs(limit=2, offset=2)
+        assert len(first_page) == 2
+        assert len(second_page) == 1
+        # No overlap between the windowed pages.
+        ids = {r["run_id"] for r in first_page} | {r["run_id"] for r in second_page}
+        assert len(ids) == 3
+
 
 class _FakeRunRepo:
     """Minimal SurveyRunRepository fake returning duck-typed frame records."""
@@ -171,6 +191,18 @@ class TestBrowseGroups:
         groups = service.browse_groups("run-1", phase=5)  # 5 -> main_survey
         assert len(groups) == 1
         assert groups[0]["phase"] == "main_survey"
+
+    @pytest.mark.parametrize("bad_phase", [0, 10, -1])
+    def test_out_of_range_phase_raises_valueerror(self, bad_phase: int) -> None:
+        service = SurveyRunService(_orchestrator(), run_repo=_FakeRunRepo([]))
+        with pytest.raises(ValueError, match="phase"):
+            service.browse_groups("run-1", phase=bad_phase)
+
+    def test_out_of_range_phase_raises_even_without_repo(self) -> None:
+        # The range guard runs before the no-repo short-circuit.
+        service = SurveyRunService(_orchestrator())
+        with pytest.raises(ValueError, match="phase"):
+            service.browse_groups("run-1", phase=99)
 
 
 def test_build_survey_run_service_default_wiring() -> None:

--- a/tests/survey/test_run_service.py
+++ b/tests/survey/test_run_service.py
@@ -1,0 +1,179 @@
+"""Unit tests for the C5 operator-surface service and in-memory orchestrator."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.survey.orchestrator_memory import InMemorySurveyOrchestrator
+from poc_homography.survey.run_service import SurveyRunService, build_survey_run_service
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+
+
+def _counting_ids() -> object:
+    """Return a deterministic id factory yielding id-0, id-1, ..."""
+    counter = {"n": -1}
+
+    def _next() -> str:
+        counter["n"] += 1
+        return f"id-{counter['n']}"
+
+    return _next
+
+
+def _fixed_clock(moment: datetime):
+    return lambda: moment
+
+
+def _orchestrator(**kwargs) -> InMemorySurveyOrchestrator:
+    return InMemorySurveyOrchestrator(
+        id_factory=_counting_ids(),
+        clock=_fixed_clock(datetime(2026, 1, 1, tzinfo=timezone.utc)),
+        frames_per_phase=2,
+        **kwargs,
+    )
+
+
+class TestInMemoryOrchestrator:
+    def test_start_assigns_run_and_sessions(self) -> None:
+        orch = _orchestrator()
+        handle = orch.start(SurveyPlanConfig(), ["cam-a", "cam-b"])
+        assert handle.run_id == "id-0"
+        assert set(handle.session_ids) == {"cam-a", "cam-b"}
+        assert handle.session_ids["cam-a"] != handle.session_ids["cam-b"]
+
+    def test_status_unknown_run_is_none(self) -> None:
+        assert _orchestrator().status("missing") is None
+
+    def test_iter_progress_completes_all_phases(self) -> None:
+        orch = _orchestrator()
+        handle = orch.start(SurveyPlanConfig(enabled_phases=frozenset({1, 2, 3})), ["cam-a"])
+        events = list(orch.iter_progress(handle.run_id))
+        # 3 phases x 1 camera
+        assert len(events) == 3
+        statuses = orch.status(handle.run_id)
+        assert statuses is not None
+        assert statuses["cam-a"].frame_count == 6  # 3 phases * 2 frames
+        assert statuses["cam-a"].status == "completed"
+
+    def test_abort_stops_progress(self) -> None:
+        orch = _orchestrator()
+        handle = orch.start(SurveyPlanConfig(), ["cam-a"])
+        assert orch.abort(handle.run_id) is True
+        assert list(orch.iter_progress(handle.run_id)) == []
+        statuses = orch.status(handle.run_id)
+        assert statuses is not None
+        assert statuses["cam-a"].status == "aborted"
+
+    def test_abort_unknown_run_is_false(self) -> None:
+        assert _orchestrator().abort("missing") is False
+
+    def test_list_runs_newest_first_and_limited(self) -> None:
+        orch = _orchestrator()
+        orch.start(SurveyPlanConfig(), ["cam-a"])
+        orch.start(SurveyPlanConfig(), ["cam-b"])
+        summaries = orch.list_runs(limit=1)
+        assert len(summaries) == 1
+        assert summaries[0].camera_count == 1
+
+
+class TestSurveyRunService:
+    def test_start_run_shape(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        result = service.start_run(SurveyPlanConfig(), ["cam-a"])
+        assert result["run_id"] == "id-0"
+        assert list(result["session_ids"]) == ["cam-a"]  # type: ignore[arg-type]
+
+    def test_get_status_unknown_is_none(self) -> None:
+        assert SurveyRunService(_orchestrator()).get_status("missing") is None
+
+    def test_get_status_reports_per_camera(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        run = service.start_run(SurveyPlanConfig(enabled_phases=frozenset({1})), ["cam-a"])
+        list(service.iter_progress(str(run["run_id"])))
+        status = service.get_status(str(run["run_id"]))
+        assert status is not None
+        cams = status["cameras"]
+        assert isinstance(cams, dict)
+        assert cams["cam-a"]["frame_count"] == 2
+
+    def test_abort_run_unknown_is_none(self) -> None:
+        assert SurveyRunService(_orchestrator()).abort_run("missing") is None
+
+    def test_abort_run_message(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        run = service.start_run(SurveyPlanConfig(), ["cam-a"])
+        result = service.abort_run(str(run["run_id"]))
+        assert result == {"run_id": "id-0", "message": "Run abort requested"}
+
+    def test_list_runs_dicts(self) -> None:
+        service = SurveyRunService(_orchestrator())
+        service.start_run(SurveyPlanConfig(), ["cam-a"])
+        runs = service.list_runs(limit=20)
+        assert runs[0]["run_id"] == "id-0"
+        assert runs[0]["camera_count"] == 1
+
+
+class _FakeRunRepo:
+    """Minimal SurveyRunRepository fake returning duck-typed frame records."""
+
+    def __init__(self, frames: list[object]) -> None:
+        self._frames = frames
+
+    def save_plan_config(self, run_id: str, config: SurveyPlanConfig) -> bool:
+        return True
+
+    def load_plan_config(self, run_id: str) -> SurveyPlanConfig:
+        return SurveyPlanConfig()
+
+    def get_frames_by_run(self, run_id: str) -> list[FrameRecord]:
+        return self._frames  # type: ignore[return-value]
+
+
+def _frame(phase_value: str, camera_id: str, zoom: float) -> object:
+    return SimpleNamespace(
+        capture=SimpleNamespace(phase=SimpleNamespace(value=phase_value)),
+        camera=SimpleNamespace(camera_id=camera_id),
+        reported=SimpleNamespace(reported_zoom=zoom),
+    )
+
+
+class TestBrowseGroups:
+    def test_no_repo_returns_empty(self) -> None:
+        assert SurveyRunService(_orchestrator()).browse_groups("run-1") == []
+
+    def test_groups_and_counts(self) -> None:
+        frames = [
+            _frame("main_survey", "cam-a", 1.0),
+            _frame("main_survey", "cam-a", 1.0),
+            _frame("main_survey", "cam-a", 5.0),
+            _frame("cross_zoom", "cam-b", 12.0),
+        ]
+        service = SurveyRunService(_orchestrator(), run_repo=_FakeRunRepo(frames))
+        groups = service.browse_groups("run-1")
+        assert {"phase": "main_survey", "camera": "cam-a", "zoom": 1.0, "frame_count": 2} in groups
+        assert len(groups) == 3
+
+    def test_filter_by_camera(self) -> None:
+        frames = [_frame("main_survey", "cam-a", 1.0), _frame("cross_zoom", "cam-b", 12.0)]
+        service = SurveyRunService(_orchestrator(), run_repo=_FakeRunRepo(frames))
+        groups = service.browse_groups("run-1", camera="cam-b")
+        assert len(groups) == 1
+        assert groups[0]["camera"] == "cam-b"
+
+    def test_filter_by_phase_number(self) -> None:
+        frames = [_frame("camera_inventory", "cam-a", 1.0), _frame("main_survey", "cam-a", 1.0)]
+        service = SurveyRunService(_orchestrator(), run_repo=_FakeRunRepo(frames))
+        groups = service.browse_groups("run-1", phase=5)  # 5 -> main_survey
+        assert len(groups) == 1
+        assert groups[0]["phase"] == "main_survey"
+
+
+def test_build_survey_run_service_default_wiring() -> None:
+    service = build_survey_run_service()
+    result = service.start_run(SurveyPlanConfig(), ["cam-a"])
+    assert "run_id" in result

--- a/tests/test_api/test_camera_evaluation_survey_run.py
+++ b/tests/test_api/test_camera_evaluation_survey_run.py
@@ -64,6 +64,17 @@ class TestSurveyRunStart:
 
         assert resp.status_code == 422
 
+    def test_empty_camera_ids_returns_400(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.start_run.side_effect = ValueError("camera_ids must not be empty")
+        body = {"plan_config": SurveyPlanConfig().to_dict(), "camera_ids": []}
+
+        with patch(_TARGET, mock_service):
+            resp = client.post("/camera-evaluation/survey/run/start/", json=body)
+
+        assert resp.status_code == 400
+        assert resp.json()["status"] == "error"
+
 
 # ---------------------------------------------------------------------------
 # GET /camera-evaluation/survey/run/{run_id}/status/
@@ -166,7 +177,7 @@ class TestSurveyRuns:
         assert data["limit"] == 5
         assert data["offset"] == 0
         assert data["runs"][0]["run_id"] == "run-1"
-        mock_service.list_runs.assert_called_once_with(limit=5)
+        mock_service.list_runs.assert_called_once_with(limit=5, offset=0)
 
 
 # ---------------------------------------------------------------------------
@@ -194,3 +205,16 @@ class TestSurveyRunGroups:
         mock_service.browse_groups.assert_called_once_with(
             "run-1", phase=5, camera="cam-a", zoom=1.0
         )
+
+    def test_out_of_range_phase_returns_400(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.browse_groups.side_effect = ValueError("phase must be a 1..9 phase number")
+
+        with patch(_TARGET, mock_service):
+            resp = client.get(
+                "/camera-evaluation/survey/runs/run-1/groups/",
+                params={"phase": 99},
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["status"] == "error"

--- a/tests/test_api/test_camera_evaluation_survey_run.py
+++ b/tests/test_api/test_camera_evaluation_survey_run.py
@@ -1,0 +1,196 @@
+"""Integration tests for the multi-camera survey-run endpoints (issue #262)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from poc_homography.domain.vo import SurveyPlanConfig
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+_TARGET = "api.routers.camera_evaluation._survey_run_service"
+
+
+# ---------------------------------------------------------------------------
+# POST /camera-evaluation/survey/run/start/
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyRunStart:
+    """Tests for ``POST /camera-evaluation/survey/run/start/``."""
+
+    def test_starts_run(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.start_run.return_value = {
+            "run_id": "run-1",
+            "session_ids": {"cam-a": "sess-a"},
+        }
+
+        body = {"plan_config": SurveyPlanConfig().to_dict(), "camera_ids": ["cam-a"]}
+
+        with patch(_TARGET, mock_service):
+            resp = client.post("/camera-evaluation/survey/run/start/", json=body)
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "success",
+            "data": {"run_id": "run-1", "session_ids": {"cam-a": "sess-a"}},
+        }
+        # SurveyPlanConfig.from_dict was applied: a config object was passed.
+        cfg_arg, ids_arg = mock_service.start_run.call_args.args
+        assert isinstance(cfg_arg, SurveyPlanConfig)
+        assert ids_arg == ["cam-a"]
+
+    def test_invalid_plan_config_returns_400(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        # Bad schema_version makes SurveyPlanConfig.from_dict raise ValueError.
+        body = {"plan_config": {"schema_version": "999"}, "camera_ids": ["cam-a"]}
+
+        with patch(_TARGET, mock_service):
+            resp = client.post("/camera-evaluation/survey/run/start/", json=body)
+
+        assert resp.status_code == 400
+        assert resp.json()["status"] == "error"
+        mock_service.start_run.assert_not_called()
+
+    def test_missing_field_returns_422(self, client: TestClient) -> None:
+        with patch(_TARGET, MagicMock()):
+            resp = client.post(
+                "/camera-evaluation/survey/run/start/",
+                json={"camera_ids": ["cam-a"]},
+            )
+
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /camera-evaluation/survey/run/{run_id}/status/
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyRunStatus:
+    """Tests for ``GET /camera-evaluation/survey/run/{run_id}/status/``."""
+
+    def test_returns_status(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.get_status.return_value = {
+            "run_id": "run-1",
+            "cameras": {
+                "cam-a": {
+                    "session_id": "sess-a",
+                    "phase": 5,
+                    "frame_count": 42,
+                    "status": "running",
+                }
+            },
+        }
+
+        with patch(_TARGET, mock_service):
+            resp = client.get("/camera-evaluation/survey/run/run-1/status/")
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["cameras"]["cam-a"]["phase"] == 5
+        assert data["cameras"]["cam-a"]["frame_count"] == 42
+
+    def test_unknown_run_returns_404(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.get_status.return_value = None
+
+        with patch(_TARGET, mock_service):
+            resp = client.get("/camera-evaluation/survey/run/nope/status/")
+
+        assert resp.status_code == 404
+        assert resp.json()["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# POST /camera-evaluation/survey/run/{run_id}/abort/
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyRunAbort:
+    """Tests for ``POST /camera-evaluation/survey/run/{run_id}/abort/``."""
+
+    def test_aborts_run(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.abort_run.return_value = {
+            "run_id": "run-1",
+            "message": "Run abort requested",
+        }
+
+        with patch(_TARGET, mock_service):
+            resp = client.post("/camera-evaluation/survey/run/run-1/abort/")
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["run_id"] == "run-1"
+
+    def test_unknown_run_returns_404(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.abort_run.return_value = None
+
+        with patch(_TARGET, mock_service):
+            resp = client.post("/camera-evaluation/survey/run/nope/abort/")
+
+        assert resp.status_code == 404
+        assert resp.json()["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# GET /camera-evaluation/survey/runs/
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyRuns:
+    """Tests for ``GET /camera-evaluation/survey/runs/``."""
+
+    def test_returns_runs(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.list_runs.return_value = [
+            {
+                "run_id": "run-1",
+                "start_time": "2026-06-05T00:00:00",
+                "camera_count": 2,
+                "total_frame_count": 100,
+                "status": "completed",
+            }
+        ]
+
+        with patch(_TARGET, mock_service):
+            resp = client.get("/camera-evaluation/survey/runs/", params={"limit": 5})
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["limit"] == 5
+        assert data["offset"] == 0
+        assert data["runs"][0]["run_id"] == "run-1"
+        mock_service.list_runs.assert_called_once_with(limit=5)
+
+
+# ---------------------------------------------------------------------------
+# GET /camera-evaluation/survey/runs/{run_id}/groups/
+# ---------------------------------------------------------------------------
+
+
+class TestSurveyRunGroups:
+    """Tests for ``GET /camera-evaluation/survey/runs/{run_id}/groups/``."""
+
+    def test_returns_groups_with_filters(self, client: TestClient) -> None:
+        mock_service = MagicMock()
+        mock_service.browse_groups.return_value = [
+            {"phase": "main_survey", "camera": "cam-a", "zoom": 1.0, "frame_count": 7}
+        ]
+
+        with patch(_TARGET, mock_service):
+            resp = client.get(
+                "/camera-evaluation/survey/runs/run-1/groups/",
+                params={"phase": 5, "camera": "cam-a", "zoom": 1.0},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["groups"][0]["frame_count"] == 7
+        mock_service.browse_groups.assert_called_once_with(
+            "run-1", phase=5, camera="cam-a", zoom=1.0
+        )

--- a/tests/test_camera_survey_run_views.py
+++ b/tests/test_camera_survey_run_views.py
@@ -126,6 +126,17 @@ def test_start_run_camera_ids_not_strings(client, mock_service) -> None:
     assert resp.status_code == 400
 
 
+def test_start_run_empty_camera_ids(client, mock_service) -> None:
+    """POST with an empty camera_ids list returns 400 (no run started)."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps({"plan_config": SurveyPlanConfig().to_dict(), "camera_ids": []}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    mock_service.start_run.assert_not_called()
+
+
 def test_start_run_bad_plan_config(client, mock_service) -> None:
     """POST with a plan_config that fails validation returns 400."""
     resp = client.post(
@@ -200,7 +211,7 @@ def test_runs_list_success(client, mock_service) -> None:
     assert data["runs"][0]["run_id"] == "run-1"
     assert data["limit"] == 20
     assert data["offset"] == 0
-    mock_service.list_runs.assert_called_once_with(limit=20)
+    mock_service.list_runs.assert_called_once_with(limit=20, offset=0)
 
 
 def test_runs_list_bad_limit(client, mock_service) -> None:
@@ -237,4 +248,11 @@ def test_groups_bad_phase(client, mock_service) -> None:
 def test_groups_bad_zoom(client, mock_service) -> None:
     """GET groups/ with a non-numeric zoom returns 400."""
     resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/?zoom=xyz")
+    assert resp.status_code == 400
+
+
+def test_groups_out_of_range_phase(client, mock_service) -> None:
+    """GET groups/ with an out-of-range phase maps the service ValueError to 400."""
+    mock_service.browse_groups.side_effect = ValueError("phase must be a 1..9 phase number")
+    resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/?phase=99")
     assert resp.status_code == 400

--- a/tests/test_camera_survey_run_views.py
+++ b/tests/test_camera_survey_run_views.py
@@ -1,0 +1,240 @@
+"""Tests for the concurrent multi-camera survey run Django views (issue #262).
+
+The views delegate to ``webapp.camera_survey.views._survey_run_service``; each test
+monkeypatches that singleton with a MagicMock returning canned dicts that match the
+locked service contract, so the views are exercised without any real cameras.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add webapp to path for Django imports
+PROJECT_ROOT = Path(__file__).parent.parent
+WEBAPP_DIR = PROJECT_ROOT / "webapp"
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+# Django test setup
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "homography_web.settings")
+
+import django
+
+django.setup()
+
+from django.test import Client
+
+from poc_homography.domain.vo import SurveyPlanConfig
+
+# URL prefix under which camera_survey.urls is mounted (homography_web/urls.py).
+PREFIX = "/camera-survey"
+
+
+@pytest.fixture
+def mock_service(monkeypatch):
+    """Replace the survey run service singleton with a MagicMock.
+
+    Django registers the app as ``camera_survey`` (webapp/ is on sys.path), so the
+    URLconf resolves views via the ``camera_survey.views`` module object. We patch
+    that exact module so the override reaches the running view; under this layout
+    ``webapp.camera_survey.views`` is a *separate* module object and patching it has
+    no effect on dispatched requests.
+    """
+    import camera_survey.views as views
+
+    service = MagicMock()
+    monkeypatch.setattr(views, "_survey_run_service", service)
+    return service
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def test_start_run_success(client, mock_service) -> None:
+    """POST survey/run/start/ with a valid body returns run_id + session_ids."""
+    mock_service.start_run.return_value = {
+        "run_id": "run-1",
+        "session_ids": {"cam-a": "sess-a"},
+    }
+    body = {
+        "plan_config": SurveyPlanConfig().to_dict(),
+        "camera_ids": ["cam-a"],
+    }
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "success"
+    assert payload["data"]["run_id"] == "run-1"
+    assert payload["data"]["session_ids"] == {"cam-a": "sess-a"}
+    # Service called with a SurveyPlanConfig and the camera_ids list.
+    cfg_arg, cams_arg = mock_service.start_run.call_args.args
+    assert isinstance(cfg_arg, SurveyPlanConfig)
+    assert cams_arg == ["cam-a"]
+
+
+def test_start_run_invalid_json(client, mock_service) -> None:
+    """POST with non-JSON body returns 400."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data="not json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_start_run_missing_plan_config(client, mock_service) -> None:
+    """POST without plan_config returns 400."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps({"camera_ids": ["cam-a"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    mock_service.start_run.assert_not_called()
+
+
+def test_start_run_missing_camera_ids(client, mock_service) -> None:
+    """POST without camera_ids returns 400."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps({"plan_config": SurveyPlanConfig().to_dict()}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    mock_service.start_run.assert_not_called()
+
+
+def test_start_run_camera_ids_not_strings(client, mock_service) -> None:
+    """POST with non-string camera_ids returns 400."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps({"plan_config": SurveyPlanConfig().to_dict(), "camera_ids": [1, 2]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+
+def test_start_run_bad_plan_config(client, mock_service) -> None:
+    """POST with a plan_config that fails validation returns 400."""
+    resp = client.post(
+        f"{PREFIX}/survey/run/start/",
+        data=json.dumps({"plan_config": {"schema_version": "999"}, "camera_ids": ["cam-a"]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    mock_service.start_run.assert_not_called()
+
+
+def test_status_success(client, mock_service) -> None:
+    """GET survey/run/<id>/status/ returns per-camera phase + frame_count."""
+    mock_service.get_status.return_value = {
+        "run_id": "run-1",
+        "cameras": {
+            "cam-a": {
+                "session_id": "sess-a",
+                "phase": 3,
+                "frame_count": 42,
+                "status": "running",
+            }
+        },
+    }
+    resp = client.get(f"{PREFIX}/survey/run/run-1/status/")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["run_id"] == "run-1"
+    cam = data["cameras"]["cam-a"]
+    assert cam["phase"] == 3
+    assert cam["frame_count"] == 42
+    mock_service.get_status.assert_called_once_with("run-1")
+
+
+def test_status_not_found(client, mock_service) -> None:
+    """GET status for an unknown run returns 404."""
+    mock_service.get_status.return_value = None
+    resp = client.get(f"{PREFIX}/survey/run/nope/status/")
+    assert resp.status_code == 404
+
+
+def test_abort_success(client, mock_service) -> None:
+    """POST survey/run/<id>/abort/ returns the abort message."""
+    mock_service.abort_run.return_value = {"run_id": "run-1", "message": "Run abort requested"}
+    resp = client.post(f"{PREFIX}/survey/run/run-1/abort/")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["run_id"] == "run-1"
+    mock_service.abort_run.assert_called_once_with("run-1")
+
+
+def test_abort_not_found(client, mock_service) -> None:
+    """POST abort for an unknown run returns 404."""
+    mock_service.abort_run.return_value = None
+    resp = client.post(f"{PREFIX}/survey/run/nope/abort/")
+    assert resp.status_code == 404
+
+
+def test_runs_list_success(client, mock_service) -> None:
+    """GET survey/runs/ returns the runs list and echoes limit/offset."""
+    mock_service.list_runs.return_value = [
+        {
+            "run_id": "run-1",
+            "start_time": "2026-06-05T00:00:00",
+            "camera_count": 1,
+            "total_frame_count": 10,
+            "status": "completed",
+        }
+    ]
+    resp = client.get(f"{PREFIX}/survey/runs/")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["runs"][0]["run_id"] == "run-1"
+    assert data["limit"] == 20
+    assert data["offset"] == 0
+    mock_service.list_runs.assert_called_once_with(limit=20)
+
+
+def test_runs_list_bad_limit(client, mock_service) -> None:
+    """GET survey/runs/ with a non-integer limit returns 400."""
+    resp = client.get(f"{PREFIX}/survey/runs/?limit=abc")
+    assert resp.status_code == 400
+
+
+def test_groups_success_forwards_filters(client, mock_service) -> None:
+    """GET survey/runs/<id>/groups/ forwards phase/camera/zoom to browse_groups."""
+    mock_service.browse_groups.return_value = [
+        {"phase": "p1", "camera": "cam-a", "zoom": 5.0, "frame_count": 7}
+    ]
+    resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/?phase=3&camera=cam-a&zoom=5.0")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["groups"][0]["frame_count"] == 7
+    mock_service.browse_groups.assert_called_once_with("run-1", phase=3, camera="cam-a", zoom=5.0)
+
+
+def test_groups_no_filters(client, mock_service) -> None:
+    """GET groups/ without query params forwards None filters."""
+    mock_service.browse_groups.return_value = []
+    resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/")
+    assert resp.status_code == 200
+    mock_service.browse_groups.assert_called_once_with("run-1", phase=None, camera=None, zoom=None)
+
+
+def test_groups_bad_phase(client, mock_service) -> None:
+    """GET groups/ with a non-integer phase returns 400."""
+    resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/?phase=abc")
+    assert resp.status_code == 400
+
+
+def test_groups_bad_zoom(client, mock_service) -> None:
+    """GET groups/ with a non-numeric zoom returns 400."""
+    resp = client.get(f"{PREFIX}/survey/runs/run-1/groups/?zoom=xyz")
+    assert resp.status_code == 400

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -336,3 +336,12 @@ _.header  # PlannedSurveyRun -> C1 SurveyRun persistence bridge (poc_homography/
 
 # -- Survey phases C4 (#261); consumed by C5 (CLI/endpoints) + tests (outside vulture scan paths) --
 YamlPhaseSink  # YAML PhaseSink adapter; wired by C5 + survey-phase tests (poc_homography/infrastructure/survey/yaml_phase_sink.py)
+
+# -- Survey operator surface C5 (#262); typer commands + plan-config repo contract --
+run_command  # typer survey command (poc_homography/cli/survey.py)
+status_command  # typer survey command (poc_homography/cli/survey.py)
+abort_command  # typer survey command (poc_homography/cli/survey.py)
+list_command  # typer survey command (poc_homography/cli/survey.py)
+browse_command  # typer survey command (poc_homography/cli/survey.py)
+_.save_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)
+_.load_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)

--- a/webapp/camera_survey/urls.py
+++ b/webapp/camera_survey/urls.py
@@ -39,4 +39,22 @@ urlpatterns = [
     ),
     # Presets
     path("api/survey/presets/", views.api_presets, name="api_presets"),
+    # Concurrent multi-camera survey runs (issue #262)
+    path("survey/run/start/", views.api_survey_run_start, name="api_survey_run_start"),
+    path(
+        "survey/run/<str:run_id>/status/",
+        views.api_survey_run_status,
+        name="api_survey_run_status",
+    ),
+    path(
+        "survey/run/<str:run_id>/abort/",
+        views.api_survey_run_abort,
+        name="api_survey_run_abort",
+    ),
+    path("survey/runs/", views.api_survey_runs_list, name="api_survey_runs_list"),
+    path(
+        "survey/runs/<str:run_id>/groups/",
+        views.api_survey_run_groups,
+        name="api_survey_run_groups",
+    ),
 ]

--- a/webapp/camera_survey/views.py
+++ b/webapp/camera_survey/views.py
@@ -18,6 +18,8 @@ from poc_homography.camera_config import (
     get_cameras_for_tenant,
     get_tenants,
 )
+from poc_homography.domain.vo import SurveyPlanConfig
+from poc_homography.survey.run_service import build_survey_run_service
 
 from .models import SurveyAxis, SurveyConfig
 from .ptz import create_ptz_camera
@@ -28,6 +30,10 @@ logger = logging.getLogger(__name__)
 
 # Singleton service instance
 _survey_service = CameraSurveyService()
+
+# Singleton concurrent multi-camera survey run orchestrator (issue #262).
+# Tests monkeypatch this with a fake/MagicMock to exercise views without cameras.
+_survey_run_service = build_survey_run_service()
 
 
 def _success_response(data: dict) -> JsonResponse:
@@ -454,3 +460,138 @@ def api_ptz_status(request: HttpRequest) -> JsonResponse:
     except Exception as e:
         logger.exception(f"Error getting PTZ status for {camera_id}")
         return _error_response(f"Failed to get camera position: {e}", 500)
+
+
+@require_POST
+def api_survey_run_start(request: HttpRequest) -> JsonResponse:
+    """Start a concurrent multi-camera survey run (issue #262).
+
+    Request body (JSON):
+        plan_config: SurveyPlanConfig dict (see SurveyPlanConfig.from_dict)
+        camera_ids: list of camera ID strings
+
+    Returns:
+        JSON response with run_id and per-camera session_ids.
+
+    # SPA: uses run_id + session_ids to poll /status/ and render per-camera progress.
+    """
+    try:
+        body = json.loads(request.body)
+    except json.JSONDecodeError:
+        return _error_response("Invalid JSON body")
+
+    plan_config = body.get("plan_config")
+    if not isinstance(plan_config, dict):
+        return _error_response("plan_config is required and must be an object")
+
+    camera_ids = body.get("camera_ids")
+    if not isinstance(camera_ids, list) or not all(isinstance(c, str) for c in camera_ids):
+        return _error_response("camera_ids is required and must be a list of strings")
+
+    try:
+        cfg = SurveyPlanConfig.from_dict(plan_config)
+    except ValueError as e:
+        return _error_response(f"Invalid plan_config: {e}")
+
+    result = _survey_run_service.start_run(cfg, camera_ids)
+    return _success_response({"run_id": result["run_id"], "session_ids": result["session_ids"]})
+
+
+@require_GET
+def api_survey_run_status(request: HttpRequest, run_id: str) -> JsonResponse:
+    """Get per-camera progress for a survey run (issue #262).
+
+    Args:
+        run_id: Survey run ID
+
+    Returns:
+        JSON response with run_id and a cameras map keyed by camera ID.
+
+    # SPA: renders each camera's phase + frame_count + status for live progress bars.
+    """
+    result = _survey_run_service.get_status(run_id)
+    if result is None:
+        return _error_response("Run not found", 404)
+    return _success_response(result)
+
+
+@require_POST
+def api_survey_run_abort(request: HttpRequest, run_id: str) -> JsonResponse:
+    """Request graceful abort of a survey run (issue #262).
+
+    Args:
+        run_id: Survey run ID
+
+    Returns:
+        JSON response with run_id and an abort message.
+
+    # SPA: calls this on the operator's "Abort run" button, then re-polls /status/.
+    """
+    result = _survey_run_service.abort_run(run_id)
+    if result is None:
+        return _error_response("Run not found", 404)
+    return _success_response(result)
+
+
+@require_GET
+def api_survey_runs_list(request: HttpRequest) -> JsonResponse:
+    """List survey runs, newest first (issue #262).
+
+    Query params:
+        limit: Maximum number to return (default 20)
+        offset: Number to skip (default 0)
+
+    Returns:
+        JSON response with runs list plus echoed limit/offset.
+
+    # SPA: renders the run history table and drives pagination via limit/offset.
+    """
+    try:
+        limit = int(request.GET.get("limit", 20))
+        offset = int(request.GET.get("offset", 0))
+    except ValueError:
+        return _error_response("limit and offset must be integers")
+
+    runs = _survey_run_service.list_runs(limit=limit)
+    runs = runs[offset:]
+    return _success_response({"runs": runs, "limit": limit, "offset": offset})
+
+
+@require_GET
+def api_survey_run_groups(request: HttpRequest, run_id: str) -> JsonResponse:
+    """Browse dataset grouping keys with frame counts for a run (issue #262).
+
+    Args:
+        run_id: Survey run ID
+
+    Query params:
+        phase: Optional 1..9 phase number filter
+        camera: Optional camera ID filter
+        zoom: Optional reported zoom factor filter
+
+    Returns:
+        JSON response with groups list, each carrying the (phase, camera, zoom)
+        grouping key and its frame_count.
+
+    # SPA: renders the dataset browser grouped by phase/camera/zoom with frame_count badges.
+    """
+    phase: int | None = None
+    phase_raw = request.GET.get("phase")
+    if phase_raw is not None:
+        try:
+            phase = int(phase_raw)
+        except ValueError:
+            return _error_response("phase must be an integer")
+
+    camera = request.GET.get("camera")
+
+    zoom: float | None = None
+    zoom_raw = request.GET.get("zoom")
+    if zoom_raw is not None:
+        try:
+            zoom = float(zoom_raw)
+        except ValueError:
+            return _error_response("zoom must be numeric")
+
+    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    return _success_response({"groups": groups})

--- a/webapp/camera_survey/views.py
+++ b/webapp/camera_survey/views.py
@@ -487,6 +487,8 @@ def api_survey_run_start(request: HttpRequest) -> JsonResponse:
     camera_ids = body.get("camera_ids")
     if not isinstance(camera_ids, list) or not all(isinstance(c, str) for c in camera_ids):
         return _error_response("camera_ids is required and must be a list of strings")
+    if not camera_ids:
+        return _error_response("camera_ids must not be empty")
 
     try:
         cfg = SurveyPlanConfig.from_dict(plan_config)
@@ -552,8 +554,7 @@ def api_survey_runs_list(request: HttpRequest) -> JsonResponse:
     except ValueError:
         return _error_response("limit and offset must be integers")
 
-    runs = _survey_run_service.list_runs(limit=limit)
-    runs = runs[offset:]
+    runs = _survey_run_service.list_runs(limit=limit, offset=offset)
     return _success_response({"runs": runs, "limit": limit, "offset": offset})
 
 
@@ -593,5 +594,8 @@ def api_survey_run_groups(request: HttpRequest, run_id: str) -> JsonResponse:
         except ValueError:
             return _error_response("zoom must be numeric")
 
-    groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    try:
+        groups = _survey_run_service.browse_groups(run_id, phase=phase, camera=camera, zoom=zoom)
+    except ValueError as e:
+        return _error_response(str(e))
     return _success_response({"groups": groups})


### PR DESCRIPTION
## Summary

Delivers the **C5 operator-facing surface** for the nine-phase, multi-camera survey epic (issue #262).

- **`SurveyPlanConfig`** frozen VO in `poc_homography/domain/vo/` — all nine-phase knobs (enabled phases, per-phase pan/tilt/zoom range overrides, grid overlap %, snapshot-burst counts, the phase-8 jitter spec, zoom levels, repeat counts, holdout fraction), a `schema_version`, and JSON/YAML-safe `to_dict()` / `from_dict()` (raises `ValueError` on unknown schema version).
- **Reproducible persistence** — `plan_config.yaml` sidecar written alongside the run frames, plus a top-level `plan_config` key in the Postgres `data` JSONB, via `save_plan_config` / `load_plan_config` on the C1 YAML and Postgres `SurveyRun` repos.
- **Boundary protocols** — `ConcurrentSurveyOrchestrator` (the C3 boundary) and `SurveyRunRepository`, with a deterministic, camera-free `InMemorySurveyOrchestrator` stub so the whole surface is exercisable today (and in tests) before C3 lands.
- **`SurveyRunService`** transport-agnostic facade (`start` / `status` / `abort` / `list` / `browse`) shared by every transport.
- **CLI** — `hom survey run|status|abort|list|browse` sub-app.
- **Django** — five views (`survey/run/start/`, `survey/run/<id>/status/`, `survey/run/<id>/abort/`, `survey/runs/`, `survey/runs/<id>/groups/`) + URLs, with SPA-hook docstrings.
- **FastAPI** — the same five operations mirrored under `/camera-evaluation/...` with `SurveyRunStartRequest` and identical response shapes, every endpoint behind `Depends(get_current_user)`.
- **Docs** — `survey_dataset_schema.md`, `survey_phase_catalog.md`, `survey_run_guide.md`, `survey_offline_reprocessing.md`, and a `docs/index.md` linking all docs.

Capture mechanics (C2), planner internals (C3), and phase logic (C4) are out of scope; this PR wires against their boundaries.

## Test plan

- `uv run pyright` (poc_homography + tests + webapp): **0 errors**.
- `uv run pylint poc_homography --fail-under=8.0`: **9.01/10**.
- `uv run vulture poc_homography webapp vulture_whitelist.py --min-confidence 60`: **clean**.
- `uv run ruff check` / `ruff format` on all changed files: **clean**.
- `uv run pytest tests/`: **1035 passed, 140 skipped** (integration/live_camera gated on `DATABASE_URL` / `ICO_CAMERA_IP`). The only two failures (`test_planar_synthetic` numerical, `test_camera_diagnostic` stress-test credentials) **pre-exist on `main`** and are unrelated to this change.

New tests: `SurveyPlanConfig` round-trip / yaml-reload; `SurveyRunService` + in-memory orchestrator; plan-config persistence (YAML unit + Postgres integration); CLI `run` (integration, camera-free) + `status`/`abort`/`list`/`browse` (mocked service); Django views; FastAPI endpoints.

## Definition of Done

- [x] `SurveyPlanConfig` frozen VO with `to_dict`/`from_dict`, `schema_version`, all fields; pyright clean
- [x] Round-trips through `to_dict()` → `from_dict()` (unit test)
- [x] Loads from a saved `plan_config.yaml` and equals the original (unit test, no camera)
- [x] `plan_config.yaml` written to the run dir + JSONB by the YAML/Postgres repos (integration test)
- [x] `poe validate` passes (ruff, format, pyright, pylint, vulture) with no new violations
- [x] `poe test` (offline) passes with no new failures
- [x] `hom survey run` starts a run, prints `run_id` + per-camera `session_id`, streams progress (integration test, stub orchestrator)
- [x] `hom survey status|abort|list|browse` return output without error (mocked-service unit tests)
- [x] `POST /camera-evaluation/survey/run/start/` returns `{"status":"success","data":{"run_id":...,"session_ids":{...}}}`
- [x] `GET /camera-evaluation/survey/run/<run_id>/status/` returns per-camera phase + frame count
- [x] `GET /camera-evaluation/survey/runs/<run_id>/groups/` returns grouping keys with counts, filterable by phase/camera/zoom
- [x] Same five endpoints on the Django side with identical response shapes
- [x] All four documentation pages exist with no placeholder sections
- [x] `docs/index.md` links all four new pages and all existing `docs/*.md`
- [ ] (manual) A real multi-camera run from a saved `plan_config.yaml` produces a schema-consistent dataset directory and reloading the config reproduces the same plan — requires live cameras + C2/C3

Closes #262
