### PR TITLE
feat(survey): clean-plate capture — stable pose catalog + per-pose bursts + per-frame metadata (#276)

### DIFF
--- a/poc_homography/domain/entities/survey/__init__.py
+++ b/poc_homography/domain/entities/survey/__init__.py
@@ -12,30 +12,45 @@ constant can be imported by those submodules without a circular import.
 
 from __future__ import annotations
 
-SURVEY_SCHEMA_VERSION: str = "1.0"
+SURVEY_SCHEMA_VERSION: str = "1.1"
 """Current survey schema version, stamped on FrameRecord and SurveyRun."""
+
+SUPPORTED_SURVEY_SCHEMA_VERSIONS: frozenset[str] = frozenset({"1.0", "1.1"})
+"""All schema versions this code can load.
+
+``"1.0"`` records pre-date the #276 clean-plate additive fields; they load with
+the new optional fields defaulting to ``None``. ``"1.1"`` is the current
+version stamped on freshly serialised records.
+"""
 
 
 def check_schema_version(version: str) -> str:
-    """Validate a serialised ``schema_version`` against the current constant.
+    """Validate a serialised ``schema_version`` against the supported set.
 
     Args:
         version: The ``schema_version`` value read from a serialised dict.
 
     Returns:
-        The validated version string (always equal to
-        :data:`SURVEY_SCHEMA_VERSION`).
+        The validated version string (one of
+        :data:`SUPPORTED_SURVEY_SCHEMA_VERSIONS`). The string is returned
+        unchanged so callers may stamp the loaded record with its original
+        version.
 
     Raises:
-        ValueError: If ``version`` does not match the current schema version,
+        ValueError: If ``version`` is not a known/compatible schema version,
             signalling that a migration hook is required before the record can
             be loaded.
     """
-    if version != SURVEY_SCHEMA_VERSION:
+    if version not in SUPPORTED_SURVEY_SCHEMA_VERSIONS:
+        supported = ", ".join(sorted(SUPPORTED_SURVEY_SCHEMA_VERSIONS))
         raise ValueError(
-            f"Unrecognised survey schema_version {version!r}; expected {SURVEY_SCHEMA_VERSION!r}"
+            f"Unrecognised survey schema_version {version!r}; supported versions: {supported}"
         )
     return version
 
 
-__all__ = ["SURVEY_SCHEMA_VERSION", "check_schema_version"]
+__all__ = [
+    "SUPPORTED_SURVEY_SCHEMA_VERSIONS",
+    "SURVEY_SCHEMA_VERSION",
+    "check_schema_version",
+]

--- a/poc_homography/domain/entities/survey/frame_record.py
+++ b/poc_homography/domain/entities/survey/frame_record.py
@@ -23,11 +23,15 @@ from poc_homography.domain.enums.survey_phase import SurveyPhase
 from poc_homography.types import (
     FPS,
     Degrees,
+    Meters,
     Millimeters,
     Pixels,
     Seconds,
     Unitless,
 )
+
+Matrix3x3List = list[list[float]]
+"""A 3x3 matrix serialised as a nested list of floats (row-major)."""
 
 PanDirection = Literal["cw", "ccw", "none"]
 TiltDirection = Literal["up", "down", "none"]
@@ -344,6 +348,173 @@ class ImageData:
         )
 
 
+def _matrix_from_list(data: Any) -> Matrix3x3List | None:
+    """Coerce a serialised 3x3 nested list into a list-of-lists of floats."""
+    if data is None:
+        return None
+    return [[float(value) for value in row] for row in data]
+
+
+@dataclass(frozen=True)
+class Intrinsics:
+    """Intrinsic matrix K plus the parameters to recompute it deterministically.
+
+    ``k_matrix`` is an optional cached 3x3 matrix (row-major nested list). When
+    absent it can be recomputed from ``zoom``, the image dimensions, the sensor
+    width and the base focal length, so the matrix is never load-bearing.
+    """
+
+    zoom: Unitless
+    image_width: Pixels
+    image_height: Pixels
+    sensor_width_mm: Millimeters
+    base_focal_length_mm: Millimeters
+    k_matrix: Matrix3x3List | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "zoom": float(self.zoom),
+            "image_width": int(self.image_width),
+            "image_height": int(self.image_height),
+            "sensor_width_mm": float(self.sensor_width_mm),
+            "base_focal_length_mm": float(self.base_focal_length_mm),
+            "k_matrix": self.k_matrix,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Intrinsics:
+        """Create :class:`Intrinsics` from a dictionary."""
+        return cls(
+            zoom=Unitless(float(data["zoom"])),
+            image_width=Pixels(int(data["image_width"])),
+            image_height=Pixels(int(data["image_height"])),
+            sensor_width_mm=Millimeters(float(data["sensor_width_mm"])),
+            base_focal_length_mm=Millimeters(float(data["base_focal_length_mm"])),
+            k_matrix=_matrix_from_list(data.get("k_matrix")),
+        )
+
+
+@dataclass(frozen=True)
+class GroundHomography:
+    """Extrinsic inputs that make the ground homography H recomputable.
+
+    Survey stores the geometry (camera height, pan/tilt/roll, ground scale and
+    the map origin) plus an OPTIONAL cached ``h_matrix`` (row-major nested
+    list). The matrix is never load-bearing — it can be recomputed from inputs.
+    """
+
+    camera_height_m: Meters
+    pan_deg: Degrees
+    tilt_deg: Degrees
+    roll_deg: Degrees
+    pixels_per_meter: float
+    map_origin: tuple[float, float]
+    h_matrix: Matrix3x3List | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "camera_height_m": float(self.camera_height_m),
+            "pan_deg": float(self.pan_deg),
+            "tilt_deg": float(self.tilt_deg),
+            "roll_deg": float(self.roll_deg),
+            "pixels_per_meter": float(self.pixels_per_meter),
+            "map_origin": [float(self.map_origin[0]), float(self.map_origin[1])],
+            "h_matrix": self.h_matrix,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GroundHomography:
+        """Create :class:`GroundHomography` from a dictionary."""
+        origin = data["map_origin"]
+        return cls(
+            camera_height_m=Meters(float(data["camera_height_m"])),
+            pan_deg=Degrees(float(data["pan_deg"])),
+            tilt_deg=Degrees(float(data["tilt_deg"])),
+            roll_deg=Degrees(float(data["roll_deg"])),
+            pixels_per_meter=float(data["pixels_per_meter"]),
+            map_origin=(float(origin[0]), float(origin[1])),
+            h_matrix=_matrix_from_list(data.get("h_matrix")),
+        )
+
+
+@dataclass(frozen=True)
+class FullOptics:
+    """Per-frame optics snapshot (exposure, gain, iris, white balance, focus).
+
+    Field naming aligns with
+    :mod:`poc_homography.domain.vo.image_optics` (``exposure_type``,
+    ``white_balance`` style, iris level, focus). All fields are optional so a
+    frame captured without an optics probe round-trips with ``None`` values.
+    """
+
+    exposure_type: str | None = None
+    shutter: str | None = None
+    gain: float | None = None
+    iris: int | None = None
+    white_balance: str | None = None
+    focus: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "exposure_type": self.exposure_type,
+            "shutter": self.shutter,
+            "gain": self.gain,
+            "iris": self.iris,
+            "white_balance": self.white_balance,
+            "focus": self.focus,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FullOptics:
+        """Create :class:`FullOptics` from a dictionary."""
+        exposure_type = data.get("exposure_type")
+        shutter = data.get("shutter")
+        gain = data.get("gain")
+        iris = data.get("iris")
+        white_balance = data.get("white_balance")
+        focus = data.get("focus")
+        return cls(
+            exposure_type=str(exposure_type) if exposure_type is not None else None,
+            shutter=str(shutter) if shutter is not None else None,
+            gain=float(gain) if gain is not None else None,
+            iris=int(iris) if iris is not None else None,
+            white_balance=str(white_balance) if white_balance is not None else None,
+            focus=int(focus) if focus is not None else None,
+        )
+
+
+@dataclass(frozen=True)
+class FloorMaskReference:
+    """Reference to an externally-produced floor mask.
+
+    Survey only stores the reference (a path/key the external masker fills) and
+    an optional integrity ``checksum`` — never pixel data.
+    """
+
+    mask_ref: str | None = None
+    checksum: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "mask_ref": self.mask_ref,
+            "checksum": self.checksum,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FloorMaskReference:
+        """Create :class:`FloorMaskReference` from a dictionary."""
+        mask_ref = data.get("mask_ref")
+        checksum = data.get("checksum")
+        return cls(
+            mask_ref=str(mask_ref) if mask_ref is not None else None,
+            checksum=str(checksum) if checksum is not None else None,
+        )
+
+
 @dataclass(frozen=True)
 class SurveyContext:
     """Planner-derived survey context attached to a frame by the phase layer.
@@ -360,6 +531,7 @@ class SurveyContext:
     region_id: str | None = None
     approach_direction: str | None = None
     sequence_index: int | None = None
+    pose_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -367,6 +539,7 @@ class SurveyContext:
             "region_id": self.region_id,
             "approach_direction": self.approach_direction,
             "sequence_index": self.sequence_index,
+            "pose_id": self.pose_id,
         }
 
     @classmethod
@@ -375,12 +548,14 @@ class SurveyContext:
         region_id = data.get("region_id")
         approach_direction = data.get("approach_direction")
         sequence_index = data.get("sequence_index")
+        pose_id = data.get("pose_id")
         return cls(
             region_id=str(region_id) if region_id is not None else None,
             approach_direction=(
                 str(approach_direction) if approach_direction is not None else None
             ),
             sequence_index=int(sequence_index) if sequence_index is not None else None,
+            pose_id=str(pose_id) if pose_id is not None else None,
         )
 
 
@@ -401,6 +576,10 @@ class FrameRecord:
     pipeline: ImagePipelineState
     image_data: ImageData
     survey_context: SurveyContext = field(default_factory=SurveyContext)
+    intrinsics: Intrinsics | None = None
+    ground_homography: GroundHomography | None = None
+    full_optics: FullOptics | None = None
+    floor_mask_reference: FloorMaskReference | None = None
     schema_version: str = field(default=SURVEY_SCHEMA_VERSION)
 
     @property
@@ -428,6 +607,16 @@ class FrameRecord:
             "pipeline": self.pipeline.to_dict(),
             "image_data": self.image_data.to_dict(),
             "survey_context": self.survey_context.to_dict(),
+            "intrinsics": self.intrinsics.to_dict() if self.intrinsics is not None else None,
+            "ground_homography": (
+                self.ground_homography.to_dict() if self.ground_homography is not None else None
+            ),
+            "full_optics": self.full_optics.to_dict() if self.full_optics is not None else None,
+            "floor_mask_reference": (
+                self.floor_mask_reference.to_dict()
+                if self.floor_mask_reference is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -438,6 +627,10 @@ class FrameRecord:
             ValueError: If ``schema_version`` is unrecognised.
         """
         version = check_schema_version(str(data["schema_version"]))
+        intrinsics = data.get("intrinsics")
+        ground_homography = data.get("ground_homography")
+        full_optics = data.get("full_optics")
+        floor_mask_reference = data.get("floor_mask_reference")
         return cls(
             camera=CameraIdentity.from_dict(data["camera"]),
             capture=CaptureIdentity.from_dict(data["capture"]),
@@ -447,5 +640,17 @@ class FrameRecord:
             pipeline=ImagePipelineState.from_dict(data["pipeline"]),
             image_data=ImageData.from_dict(data["image_data"]),
             survey_context=SurveyContext.from_dict(data.get("survey_context") or {}),
+            intrinsics=Intrinsics.from_dict(intrinsics) if intrinsics is not None else None,
+            ground_homography=(
+                GroundHomography.from_dict(ground_homography)
+                if ground_homography is not None
+                else None
+            ),
+            full_optics=FullOptics.from_dict(full_optics) if full_optics is not None else None,
+            floor_mask_reference=(
+                FloorMaskReference.from_dict(floor_mask_reference)
+                if floor_mask_reference is not None
+                else None
+            ),
             schema_version=version,
         )

--- a/poc_homography/domain/entities/survey/pose_catalog.py
+++ b/poc_homography/domain/entities/survey/pose_catalog.py
@@ -1,0 +1,134 @@
+"""Per-camera catalog of stable pose ids across survey runs.
+
+A :class:`PoseCatalog` maps a deterministic ``pose_id`` (from
+:func:`~poc_homography.survey.planner.poses.canonical_pose_key`) to the
+physical ``(pan, tilt, zoom)`` geometry. Because the id is derived purely from
+quantised geometry, the same physical pose maps to the same ``pose_id`` across
+runs and catalog instances — enabling multi-visit grouping by
+``(camera_id, pose_id)``.
+
+The entity is frozen; mutation helpers (:meth:`PoseCatalog.with_pose`) return a
+new catalog. ``to_dict`` emits entries with deterministically-sorted keys.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from poc_homography.domain.entities.survey import (
+    SURVEY_SCHEMA_VERSION,
+    check_schema_version,
+)
+from poc_homography.survey.planner.poses import canonical_pose_key
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from poc_homography.survey.planner.poses import Pose
+
+CatalogEntry = tuple[float, float, float]
+"""A cataloged pose as ``(pan, tilt, zoom)``."""
+
+
+@dataclass(frozen=True, eq=False)
+class PoseCatalog:
+    """Catalog of stable pose ids for one camera.
+
+    The ``id`` property is the ``catalog_id``, satisfying the ``Entity``
+    protocol. ``entries`` maps ``pose_id -> (pan, tilt, zoom)``.
+    """
+
+    catalog_id: str
+    camera_id: str
+    entries: dict[str, CatalogEntry] = field(default_factory=dict)
+    schema_version: str = field(default=SURVEY_SCHEMA_VERSION)
+
+    @property
+    def id(self) -> str:
+        """Unique identifier — the catalog id."""
+        return self.catalog_id
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    @staticmethod
+    def assign(pan: float, tilt: float, zoom: float) -> str:
+        """Return the deterministic ``pose_id`` for a physical pose.
+
+        Purely derived from geometry, so the same physical pose maps to the
+        same id across catalog instances and runs. Does not mutate the catalog;
+        use :meth:`with_pose` to record the entry.
+        """
+        return canonical_pose_key(pan, tilt, zoom)
+
+    def with_pose(self, pan: float, tilt: float, zoom: float) -> PoseCatalog:
+        """Return a new catalog that additionally contains this pose."""
+        pose_id = self.assign(pan, tilt, zoom)
+        new_entries = dict(self.entries)
+        new_entries[pose_id] = (float(pan), float(tilt), float(zoom))
+        return PoseCatalog(
+            catalog_id=self.catalog_id,
+            camera_id=self.camera_id,
+            entries=new_entries,
+            schema_version=self.schema_version,
+        )
+
+    @classmethod
+    def from_poses(
+        cls,
+        catalog_id: str,
+        camera_id: str,
+        poses: Iterable[Pose],
+    ) -> PoseCatalog:
+        """Build a catalog deterministically from a sequence of poses.
+
+        Insertion order does not affect the result: a given physical pose
+        always maps to the same ``pose_id``, and ``to_dict`` sorts keys.
+        """
+        entries: dict[str, CatalogEntry] = {}
+        for pose in poses:
+            pose_id = canonical_pose_key(float(pose.pan), float(pose.tilt), float(pose.zoom))
+            entries[pose_id] = (float(pose.pan), float(pose.tilt), float(pose.zoom))
+        return cls(catalog_id=catalog_id, camera_id=camera_id, entries=entries)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization with sorted entry keys."""
+        return {
+            "schema_version": self.schema_version,
+            "catalog_id": self.catalog_id,
+            "camera_id": self.camera_id,
+            "entries": {
+                pose_id: [
+                    float(self.entries[pose_id][0]),
+                    float(self.entries[pose_id][1]),
+                    float(self.entries[pose_id][2]),
+                ]
+                for pose_id in sorted(self.entries)
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PoseCatalog:
+        """Create :class:`PoseCatalog` from a dictionary.
+
+        Raises:
+            ValueError: If ``schema_version`` is unrecognised.
+        """
+        version = check_schema_version(str(data["schema_version"]))
+        raw_entries = data.get("entries") or {}
+        entries: dict[str, CatalogEntry] = {
+            str(pose_id): (float(values[0]), float(values[1]), float(values[2]))
+            for pose_id, values in raw_entries.items()
+        }
+        return cls(
+            catalog_id=str(data["catalog_id"]),
+            camera_id=str(data["camera_id"]),
+            entries=entries,
+            schema_version=version,
+        )

--- a/poc_homography/domain/entities/survey/survey_run.py
+++ b/poc_homography/domain/entities/survey/survey_run.py
@@ -32,6 +32,7 @@ class SurveyRun:
     started_at: datetime
     finished_at: datetime | None = None
     status: SurveyRunStatus = SurveyRunStatus.PENDING
+    pose_catalog_id: str | None = None
     schema_version: str = field(default=SURVEY_SCHEMA_VERSION)
 
     @property
@@ -61,6 +62,7 @@ class SurveyRun:
             "started_at": self.started_at.isoformat(),
             "finished_at": self.finished_at.isoformat() if self.finished_at else None,
             "status": self.status.value,
+            "pose_catalog_id": self.pose_catalog_id,
         }
 
     @classmethod
@@ -72,6 +74,7 @@ class SurveyRun:
         """
         version = check_schema_version(str(data["schema_version"]))
         finished_raw = data.get("finished_at")
+        pose_catalog_id = data.get("pose_catalog_id")
         return cls(
             run_id=str(data["run_id"]),
             camera_id=str(data["camera_id"]),
@@ -79,5 +82,6 @@ class SurveyRun:
             started_at=datetime.fromisoformat(data["started_at"]),
             finished_at=datetime.fromisoformat(finished_raw) if finished_raw else None,
             status=SurveyRunStatus(data["status"]),
+            pose_catalog_id=str(pose_catalog_id) if pose_catalog_id is not None else None,
             schema_version=version,
         )

--- a/poc_homography/domain/protocols/survey_run_repository.py
+++ b/poc_homography/domain/protocols/survey_run_repository.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from poc_homography.domain.entities.survey.frame_record import FrameRecord
+    from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
+    from poc_homography.domain.entities.survey.survey_run import SurveyRun
     from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 
 
@@ -36,4 +38,25 @@ class SurveyRunRepository(Protocol):
 
     def get_frames_by_run(self, run_id: str) -> list[FrameRecord]:
         """Return every frame captured in ``run_id``."""
+        ...
+
+    def save_pose_catalog(self, run_id: str, catalog: PoseCatalog) -> bool:
+        """Persist ``catalog`` for ``run_id``; return ``True`` on success."""
+        ...
+
+    def load_pose_catalog(self, run_id: str) -> PoseCatalog:
+        """Load the persisted pose catalog for ``run_id``.
+
+        Raises:
+            KeyError: If no pose catalog is stored for ``run_id``.
+        """
+        ...
+
+    def get_runs_by_camera_and_pose(self, camera_id: str, pose_id: str) -> list[SurveyRun]:
+        """Return every run for ``camera_id`` whose pose catalog holds ``pose_id``.
+
+        Because pose ids are deterministic across runs, multiple multi-visit
+        runs for one camera that visited the same physical pose are returned
+        together — the ``(camera_id, pose_id)`` grouping linkage.
+        """
         ...

--- a/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
+
+from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
 from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.infrastructure.models.survey_run import SurveyRunModel
 from poc_homography.infrastructure.repositories.base import RepoPostgresSession
@@ -124,3 +127,50 @@ class RepoPostgresSurveyRun(RepoPostgresSession):
         if row is None or "plan_config" not in row.data:  # type: ignore[attr-defined]
             raise KeyError(run_id)
         return SurveyPlanConfig.from_dict(row.data["plan_config"])  # type: ignore[attr-defined]
+
+    def save_pose_catalog(self, run_id: str, catalog: PoseCatalog) -> bool:
+        """Persist ``catalog`` under the ``pose_catalog`` JSONB key of ``run_id``.
+
+        The run row must already exist; returns ``False`` if it does not.
+        Returns ``True`` on success, ``False`` (logged) on any failure.
+        """
+        try:
+            row = self._session.get(self._model_cls, run_id)
+            if row is None:
+                return False
+            row.data = {**row.data, "pose_catalog": catalog.to_dict()}  # type: ignore[attr-defined]
+            self._session.flush()
+            return True
+        except Exception:
+            logger.exception("Failed to save pose catalog for run %s", run_id)
+            return False
+
+    def load_pose_catalog(self, run_id: str) -> PoseCatalog:
+        """Load the ``pose_catalog`` JSONB payload for ``run_id``.
+
+        Raises:
+            KeyError: If the run row is missing or has no ``pose_catalog`` key.
+        """
+        row = self._session.get(self._model_cls, run_id)
+        if row is None or "pose_catalog" not in row.data:  # type: ignore[attr-defined]
+            raise KeyError(run_id)
+        return PoseCatalog.from_dict(row.data["pose_catalog"])  # type: ignore[attr-defined]
+
+    def get_runs_by_camera_and_pose(self, camera_id: str, pose_id: str) -> list[Any]:
+        """Return every run for ``camera_id`` whose pose catalog holds ``pose_id``.
+
+        The ``camera_id`` filter runs in SQL over the indexed column; the
+        ``pose_id`` membership is checked in Python against each row's
+        ``data["pose_catalog"]["entries"]``. Runs without a pose catalog are
+        skipped. Returns rebuilt :class:`SurveyRun` aggregates.
+        """
+        stmt = select(self._model_cls).where(
+            self._model_cls.camera_id == camera_id  # type: ignore[attr-defined]
+        )
+        rows = self._session.execute(stmt).scalars().all()
+        matches: list[Any] = []
+        for row in rows:
+            entries = row.data.get("pose_catalog", {}).get("entries", {})  # type: ignore[attr-defined]
+            if pose_id in entries:
+                matches.append(self._row_to_entity(row))
+        return matches

--- a/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_survey_run.py
@@ -170,7 +170,8 @@ class RepoPostgresSurveyRun(RepoPostgresSession):
         rows = self._session.execute(stmt).scalars().all()
         matches: list[Any] = []
         for row in rows:
-            entries = row.data.get("pose_catalog", {}).get("entries", {})  # type: ignore[attr-defined]
+            catalog = row.data.get("pose_catalog") or {}  # type: ignore[attr-defined]
+            entries = catalog.get("entries", {})
             if pose_id in entries:
                 matches.append(self._row_to_entity(row))
         return matches

--- a/poc_homography/infrastructure/repositories/repo_yaml_survey_run.py
+++ b/poc_homography/infrastructure/repositories/repo_yaml_survey_run.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from poc_homography.domain.entities.survey.frame_record import FrameRecord
+from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
 from poc_homography.domain.entities.survey.survey_run import SurveyRun
 from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
 from poc_homography.infrastructure.repositories.base.repo_yaml import RepoYaml
@@ -124,3 +125,62 @@ class RepoYamlSurveyRun(RepoYaml[SurveyRun]):
         with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         return SurveyPlanConfig.from_dict(data)
+
+    # ------------------------------------------------------------------
+    # Pose-catalog sidecar
+    # ------------------------------------------------------------------
+
+    def _pose_catalog_path(self, run_id: str) -> Path:
+        return self._frames_dir / run_id / "pose_catalog.yaml"
+
+    def save_pose_catalog(self, run_id: str, catalog: PoseCatalog) -> bool:
+        """Persist ``catalog`` as a ``pose_catalog.yaml`` sidecar for ``run_id``.
+
+        Returns ``True`` on success, ``False`` (logged) on any failure.
+        """
+        path = self._pose_catalog_path(run_id)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                yaml.dump(catalog.to_dict(), f, default_flow_style=False, sort_keys=False)
+        except Exception:
+            logger.exception("Failed to save pose catalog for run %s", run_id)
+            return False
+        return True
+
+    def load_pose_catalog(self, run_id: str) -> PoseCatalog:
+        """Load the ``pose_catalog.yaml`` sidecar for ``run_id``.
+
+        Raises:
+            KeyError: If no sidecar exists for ``run_id``.
+        """
+        path = self._pose_catalog_path(run_id)
+        if not path.exists():
+            raise KeyError(run_id)
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return PoseCatalog.from_dict(data)
+
+    # ------------------------------------------------------------------
+    # Multi-visit grouping
+    # ------------------------------------------------------------------
+
+    def get_runs_by_camera_and_pose(self, camera_id: str, pose_id: str) -> list[SurveyRun]:
+        """Return every run for ``camera_id`` whose pose catalog holds ``pose_id``.
+
+        Runs are read from the manifest store; a run is included only when its
+        ``pose_catalog.yaml`` sidecar exists and its ``entries`` contain
+        ``pose_id``. Multiple runs for the same camera that visited the same
+        physical pose are returned together.
+        """
+        matches: list[SurveyRun] = []
+        for run in self.get_all():
+            if run.camera_id != camera_id:
+                continue
+            try:
+                catalog = self.load_pose_catalog(run.id)
+            except KeyError:
+                continue
+            if pose_id in catalog.entries:
+                matches.append(run)
+        return matches

--- a/poc_homography/infrastructure/survey/capture_engine.py
+++ b/poc_homography/infrastructure/survey/capture_engine.py
@@ -47,13 +47,20 @@ from typing import TYPE_CHECKING, Any
 import cv2
 from PIL import Image
 
+from poc_homography.camera.intrinsics import compute_intrinsics
+from poc_homography.camera_config import (
+    DEFAULT_BASE_FOCAL_LENGTH_MM,
+    DEFAULT_SENSOR_WIDTH_MM,
+)
 from poc_homography.domain.entities.survey.frame_record import (
     CameraIdentity,
     CaptureIdentity,
     CommandedState,
     FrameRecord,
+    FullOptics,
     ImageData,
     ImagePipelineState,
+    Intrinsics,
     MovementContext,
     PanDirection,
     ReportedState,
@@ -64,7 +71,7 @@ from poc_homography.domain.entities.survey.video_burst_record import (
     FrameRef,
     VideoBurstRecord,
 )
-from poc_homography.types import FPS, Degrees, Pixels, Seconds, Unitless
+from poc_homography.types import FPS, Degrees, Millimeters, Pixels, Seconds, Unitless
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -149,6 +156,7 @@ class _BurstScaffold:
     movement: MovementContext
     pipeline: ImagePipelineState
     primary_profile: StreamProfile
+    optics: ImageOptics
     timestamp_before_move: datetime
     timestamp_after_move: datetime
 
@@ -225,6 +233,8 @@ class SurveyCaptureEngine:
         camera: CameraDevice,
         *,
         settle_timeout_s: float = 5.0,
+        sensor_width_mm: float = DEFAULT_SENSOR_WIDTH_MM,
+        base_focal_length_mm: float = DEFAULT_BASE_FOCAL_LENGTH_MM,
         clock: Callable[[], datetime] | None = None,
         uuid_factory: Callable[[], str] | None = None,
     ) -> None:
@@ -233,6 +243,10 @@ class SurveyCaptureEngine:
         Args:
             camera: The device to drive, satisfying :class:`CameraDevice`.
             settle_timeout_s: Max seconds to wait for PTZ stabilisation.
+            sensor_width_mm: Sensor width used to compute per-frame intrinsics;
+                defaults to the DS-2DF8425IX constant.
+            base_focal_length_mm: Base (1x-zoom) focal length used to compute
+                per-frame intrinsics; defaults to the DS-2DF8425IX constant.
             clock: Returns timezone-aware UTC ``datetime``; injectable for
                 deterministic tests. Defaults to :func:`_utcnow`.
             uuid_factory: Returns a fresh id string for ``burst_id``;
@@ -241,6 +255,8 @@ class SurveyCaptureEngine:
         """
         self._camera = camera
         self._settle_timeout_s = settle_timeout_s
+        self._sensor_width_mm = Millimeters(float(sensor_width_mm))
+        self._base_focal_length_mm = Millimeters(float(base_focal_length_mm))
         self._clock = clock or _utcnow
         self._new_id = uuid_factory or _new_uuid
 
@@ -497,6 +513,7 @@ class SurveyCaptureEngine:
             movement=movement,
             pipeline=_build_pipeline_state(primary, optics),
             primary_profile=primary,
+            optics=optics,
             timestamp_before_move=move.timestamp_before_move,
             timestamp_after_move=move.timestamp_after_move,
         )
@@ -566,6 +583,12 @@ class SurveyCaptureEngine:
             timestamp_after_move=scaffold.timestamp_after_move,
             timestamp_at_capture=timestamp_at_capture,
         )
+        intrinsics = self._build_intrinsics(commanded, image_data)
+        # ``ground_homography`` and ``floor_mask_reference`` are deliberately
+        # left ``None`` at survey-capture time: the ground homography needs
+        # deployment-specific extrinsics (camera height, pixels-per-meter, map
+        # origin) a bare survey does not possess, and the floor mask is filled
+        # by an external masker. Both are populated downstream, not here.
         return FrameRecord(
             camera=scaffold.camera_identity,
             capture=capture,
@@ -574,6 +597,34 @@ class SurveyCaptureEngine:
             movement=scaffold.movement,
             pipeline=scaffold.pipeline,
             image_data=image_data,
+            intrinsics=intrinsics,
+            full_optics=_build_full_optics(scaffold.optics),
+        )
+
+    def _build_intrinsics(
+        self,
+        commanded: CommandedState,
+        image_data: ImageData,
+    ) -> Intrinsics:
+        """Compute per-frame intrinsics from commanded zoom + frame dimensions.
+
+        Stores both the recompute inputs and the cached ``k_matrix`` (the matrix
+        is never load-bearing — it can be recomputed from the inputs).
+        """
+        computed = compute_intrinsics(
+            commanded.commanded_zoom,
+            image_data.width,
+            image_data.height,
+            self._sensor_width_mm,
+            self._base_focal_length_mm,
+        )
+        return Intrinsics(
+            zoom=commanded.commanded_zoom,
+            image_width=image_data.width,
+            image_height=image_data.height,
+            sensor_width_mm=self._sensor_width_mm,
+            base_focal_length_mm=self._base_focal_length_mm,
+            k_matrix=[[float(value) for value in row] for row in computed.K.tolist()],
         )
 
 
@@ -610,6 +661,23 @@ def _build_reported_state(reported: PTZState) -> ReportedState:
         reported_focal_length_mm=None,
         reported_focus=int(reported.focus) if reported.focus is not None else None,
         ptz_settled=True,
+    )
+
+
+def _build_full_optics(optics: ImageOptics) -> FullOptics:
+    """Map the per-burst :class:`ImageOptics` onto a per-frame :class:`FullOptics`.
+
+    Only the fields the #256 adapter's ``ImageOptics`` surfaces are mapped
+    (exposure type, iris level, white-balance style, focus limit); the optics
+    fields with no adapter source (``shutter``, ``gain``) are left ``None``.
+    """
+    return FullOptics(
+        exposure_type=optics.exposure.exposure_type or None,
+        shutter=None,
+        gain=None,
+        iris=optics.iris.level,
+        white_balance=optics.white_balance.style or None,
+        focus=optics.focus.focus_limited,
     )
 
 

--- a/poc_homography/survey/phases/common.py
+++ b/poc_homography/survey/phases/common.py
@@ -158,12 +158,16 @@ def capture_pose_sequence(
 def _stamp_pose_id(base: SurveyContext | None, pose: Pose) -> SurveyContext:
     """Return ``base`` (or a fresh context) with a stable ``pose_id`` stamped.
 
-    The id is derived purely from the pose geometry via
-    :func:`~poc_homography.survey.planner.poses.canonical_pose_key`, so the same
-    physical ``(pan, tilt, zoom)`` yields the same id on every run regardless of
-    insertion order, randomness, or time.
+    Honours a planner-assigned ``pose.pose_id`` when present (keeping the
+    planner the single source of truth), otherwise derives the id purely from
+    the pose geometry via
+    :func:`~poc_homography.survey.planner.poses.canonical_pose_key`. Either way
+    the same physical ``(pan, tilt, zoom)`` yields the same id on every run
+    regardless of insertion order, randomness, or time.
     """
-    pose_id = canonical_pose_key(float(pose.pan), float(pose.tilt), float(pose.zoom))
+    pose_id = pose.pose_id or canonical_pose_key(
+        float(pose.pan), float(pose.tilt), float(pose.zoom)
+    )
     if base is None:
         return SurveyContext(pose_id=pose_id)
     return replace(base, pose_id=pose_id)

--- a/poc_homography/survey/phases/common.py
+++ b/poc_homography/survey/phases/common.py
@@ -18,6 +18,7 @@ from poc_homography.domain.entities.survey.frame_record import (
     SurveyContext,
 )
 from poc_homography.infrastructure.survey.capture_engine import CaptureContext
+from poc_homography.survey.planner.poses import canonical_pose_key
 from poc_homography.types import Degrees, Unitless
 
 if TYPE_CHECKING:
@@ -106,7 +107,10 @@ def capture_pose_sequence(
     :class:`CaptureContext` so the engine can compute per-axis movement
     directions; threading starts fresh (no previous pose) at the first pose so a
     phase's sweep is self-contained and not contaminated by a prior phase. Every
-    frame is tagged with ``phase`` (via the engine) and, when
+    frame is tagged with ``phase`` (via the engine), with a stable
+    ``pose_id`` derived from the pose geometry via
+    :func:`~poc_homography.survey.planner.poses.canonical_pose_key` (so the same
+    physical pose yields the same id across runs), and, when
     ``survey_context_for`` is supplied, enriched with the C3-derived
     :class:`SurveyContext` (region id / approach direction / sequence index).
 
@@ -143,9 +147,23 @@ def capture_pose_sequence(
             burst_count=burst_count,
             output_dir=output_dir,
         )
-        if survey_context_for is not None:
-            survey_context = survey_context_for(pose, index)
-            frames = [replace(frame, survey_context=survey_context) for frame in frames]
+        base_context = survey_context_for(pose, index) if survey_context_for is not None else None
+        survey_context = _stamp_pose_id(base_context, pose)
+        frames = [replace(frame, survey_context=survey_context) for frame in frames]
         records.extend(frames)
         previous = commanded
     return records
+
+
+def _stamp_pose_id(base: SurveyContext | None, pose: Pose) -> SurveyContext:
+    """Return ``base`` (or a fresh context) with a stable ``pose_id`` stamped.
+
+    The id is derived purely from the pose geometry via
+    :func:`~poc_homography.survey.planner.poses.canonical_pose_key`, so the same
+    physical ``(pan, tilt, zoom)`` yields the same id on every run regardless of
+    insertion order, randomness, or time.
+    """
+    pose_id = canonical_pose_key(float(pose.pan), float(pose.tilt), float(pose.zoom))
+    if base is None:
+        return SurveyContext(pose_id=pose_id)
+    return replace(base, pose_id=pose_id)

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -29,9 +29,22 @@ if TYPE_CHECKING:
 
     from poc_homography.domain.entities.survey.frame_record import CommandedState
     from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
     from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
     from poc_homography.survey.phases.common import PhaseResult, PhaseSink
     from poc_homography.survey.planner.poses import Pose
+
+# Clean-plate default snapshot-burst frame count (#276): a stable clean plate
+# needs at least two frames per pose; five is a sensible default. Phases absent
+# from a plan-config's ``burst_frame_count`` fall back to this.
+DEFAULT_BURST_FRAME_COUNT = 5
+
+# Minimum frames per pose for a usable clean-plate burst (#276).
+MIN_BURST_FRAME_COUNT = 2
+
+# Pose-based phases that capture a snapshot burst per pose (phase 8 uses video
+# bursts; phase 1 is inventory and captures no frames).
+_POSE_BURST_PHASES = (2, 3, 4, 5, 6, 7, 9)
 
 
 @dataclass(frozen=True)
@@ -45,6 +58,11 @@ class SurveyPlan:
     """
 
     burst_count: int = 1
+
+    # Optional per-phase override of ``burst_count`` (phase number -> frames),
+    # sourced from :class:`SurveyPlanConfig` via :meth:`from_plan_config`. A
+    # phase absent here falls back to :attr:`burst_count`.
+    phase_burst_counts: dict[int, int] = field(default_factory=dict)
 
     # Phase 2 — PTZ characterization.
     ptz_pan_range: tuple[float, float] = (0.0, 20.0)
@@ -113,6 +131,46 @@ class SurveyPlan:
     # skips sky tiles above the per-azimuth bound; ``None`` reproduces the
     # pre-horizon behaviour exactly.
     tilt_envelope: TiltEnvelope | None = None
+
+    def burst_for(self, phase_number: int) -> int:
+        """Return the per-pose snapshot-burst frame count for ``phase_number``.
+
+        Falls back to :attr:`burst_count` when the phase is not in
+        :attr:`phase_burst_counts`.
+        """
+        return self.phase_burst_counts.get(phase_number, self.burst_count)
+
+    @classmethod
+    def from_plan_config(
+        cls,
+        config: SurveyPlanConfig,
+        *,
+        default_burst_frame_count: int = DEFAULT_BURST_FRAME_COUNT,
+    ) -> SurveyPlan:
+        """Build a :class:`SurveyPlan` whose burst counts come from ``config``.
+
+        Bridges the camera-free :class:`SurveyPlanConfig` sidecar onto the
+        runner's in-memory plan. Each pose-based phase's per-pose snapshot-burst
+        frame count is taken from ``config.burst_frame_count[phase]`` (falling
+        back to ``default_burst_frame_count``) and clamped to at least
+        :data:`MIN_BURST_FRAME_COUNT`, so every clean-plate capture emits two or
+        more frames per pose. Only the burst counts are bridged here; the other
+        plan knobs keep their DoD-satisfying defaults.
+
+        Args:
+            config: The reproducible plan-config sidecar.
+            default_burst_frame_count: Burst frame count for pose-based phases
+                absent from ``config.burst_frame_count``.
+
+        Returns:
+            A :class:`SurveyPlan` with per-phase burst counts populated.
+        """
+        default = max(MIN_BURST_FRAME_COUNT, int(default_burst_frame_count))
+        phase_burst_counts = {
+            phase: max(MIN_BURST_FRAME_COUNT, int(config.burst_frame_count.get(phase, default)))
+            for phase in _POSE_BURST_PHASES
+        }
+        return cls(burst_count=default, phase_burst_counts=phase_burst_counts)
 
 
 @dataclass(frozen=True)
@@ -184,7 +242,7 @@ def execute_survey(
             fixed_pan=plan.ptz_fixed_pan,
             fixed_zoom=plan.ptz_fixed_zoom,
             repeat_count=plan.ptz_repeat_count,
-            burst_count=plan.burst_count,
+            burst_count=plan.burst_for(2),
         )
     )
 
@@ -199,7 +257,7 @@ def execute_survey(
             zoom_step=plan.zoom_step,
             fixed_pan=plan.zoom_fixed_pan,
             fixed_tilt=plan.zoom_fixed_tilt,
-            burst_count=plan.burst_count,
+            burst_count=plan.burst_for(3),
         )
     )
 
@@ -215,7 +273,7 @@ def execute_survey(
         zoom=plan.nadir_zoom,
         overlap_fraction=plan.nadir_overlap_fraction,
         region_id=plan.nadir_region_id,
-        burst_count=plan.burst_count,
+        burst_count=plan.burst_for(4),
     )
     results.append(nadir)
     captured_4_to_7.extend(nadir.commanded_states)
@@ -226,7 +284,7 @@ def execute_survey(
         run_id=run_id,
         camera_id=camera_id,
         output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
-        burst_count=plan.burst_count,
+        burst_count=plan.burst_for(5),
     )
     results.append(main)
     captured_4_to_7.extend(main.commanded_states)
@@ -238,7 +296,7 @@ def execute_survey(
         output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
         anchors=plan.cross_zoom_anchors,
         zoom_levels=plan.cross_zoom_levels,
-        burst_count=plan.burst_count,
+        burst_count=plan.burst_for(6),
     )
     results.append(cross)
     captured_4_to_7.extend(cross.commanded_states)
@@ -252,7 +310,7 @@ def execute_survey(
         target_tilt=plan.repeat_target_tilt,
         target_zoom=plan.repeat_target_zoom,
         approach_deltas=plan.repeat_approach_deltas,
-        burst_count=plan.burst_count,
+        burst_count=plan.burst_for(7),
     )
     results.append(repeat)
     captured_4_to_7.extend(repeat.commanded_states)
@@ -279,7 +337,7 @@ def execute_survey(
             run_id=run_id,
             camera_id=camera_id,
             output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
-            burst_count=plan.burst_count,
+            burst_count=plan.burst_for(9),
         )
     )
 

--- a/poc_homography/survey/planner/poses.py
+++ b/poc_homography/survey/planner/poses.py
@@ -15,6 +15,29 @@ from typing import Any
 from poc_homography.types import Degrees, Unitless
 
 
+def canonical_pose_key(pan: float, tilt: float, zoom: float) -> str:
+    """Return a stable, deterministic pose id for a physical PTZ pose.
+
+    Pan and tilt are quantised to 0.1 degrees and zoom to 0.01 before
+    formatting, so two physically-equal poses yield the SAME id on every run
+    regardless of insertion order, randomness, or time. The result is a
+    human-readable fixed-width string, e.g. ``"p+0120.1_t-0015.0_z004.00"``.
+
+    Args:
+        pan: Pan angle in degrees.
+        tilt: Tilt angle in degrees.
+        zoom: Zoom factor (dimensionless).
+
+    Returns:
+        A stable string id derived purely from the quantised geometry.
+    """
+    pan_q = round(float(pan), 1)
+    tilt_q = round(float(tilt), 1)
+    zoom_q = round(float(zoom), 2)
+    # ``+ 0.0`` normalises a possible ``-0.0`` to ``0.0`` for a stable sign.
+    return f"p{pan_q + 0.0:+07.1f}_t{tilt_q + 0.0:+07.1f}_z{zoom_q + 0.0:06.2f}"
+
+
 class ApproachDirection(str, Enum):
     """Direction from which a pose is approached along a sweep axis.
 
@@ -49,6 +72,7 @@ class Pose:
     approach_direction: ApproachDirection | None = None
     is_holdout: bool = False
     region_id: str | None = None
+    pose_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -61,6 +85,7 @@ class Pose:
             ),
             "is_holdout": self.is_holdout,
             "region_id": self.region_id,
+            "pose_id": self.pose_id,
         }
 
     @classmethod
@@ -68,6 +93,7 @@ class Pose:
         """Create :class:`Pose` from a dictionary."""
         approach = data.get("approach_direction")
         region_id = data.get("region_id")
+        pose_id = data.get("pose_id")
         return cls(
             pan=Degrees(float(data["pan"])),
             tilt=Degrees(float(data["tilt"])),
@@ -75,4 +101,5 @@ class Pose:
             approach_direction=(ApproachDirection(approach) if approach is not None else None),
             is_holdout=bool(data["is_holdout"]),
             region_id=str(region_id) if region_id is not None else None,
+            pose_id=str(pose_id) if pose_id is not None else None,
         )

--- a/tests/domain/survey/builders.py
+++ b/tests/domain/survey/builders.py
@@ -9,12 +9,18 @@ from poc_homography.domain.entities.survey.frame_record import (
     CameraIdentity,
     CaptureIdentity,
     CommandedState,
+    FloorMaskReference,
     FrameRecord,
+    FullOptics,
+    GroundHomography,
     ImageData,
     ImagePipelineState,
+    Intrinsics,
     MovementContext,
     ReportedState,
+    SurveyContext,
 )
+from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
 from poc_homography.domain.entities.survey.survey_run import SurveyRun
 from poc_homography.domain.entities.survey.video_burst_record import (
     FrameRef,
@@ -22,9 +28,11 @@ from poc_homography.domain.entities.survey.video_burst_record import (
 )
 from poc_homography.domain.enums.survey_phase import SurveyPhase
 from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
+from poc_homography.survey.planner.poses import Pose
 from poc_homography.types import (
     FPS,
     Degrees,
+    Meters,
     Millimeters,
     Pixels,
     Seconds,
@@ -148,6 +156,48 @@ def make_image_data(image_path: str = "frames/cap-0001.jpg") -> ImageData:
     )
 
 
+def make_intrinsics() -> Intrinsics:
+    """Build an :class:`Intrinsics` with a cached K matrix."""
+    return Intrinsics(
+        zoom=Unitless(4.0),
+        image_width=Pixels(2560),
+        image_height=Pixels(1440),
+        sensor_width_mm=Millimeters(6.78),
+        base_focal_length_mm=Millimeters(5.9),
+        k_matrix=[[2200.0, 0.0, 1280.0], [0.0, 2200.0, 720.0], [0.0, 0.0, 1.0]],
+    )
+
+
+def make_ground_homography() -> GroundHomography:
+    """Build a :class:`GroundHomography` with a cached H matrix."""
+    return GroundHomography(
+        camera_height_m=Meters(8.5),
+        pan_deg=Degrees(120.0),
+        tilt_deg=Degrees(-15.0),
+        roll_deg=Degrees(0.0),
+        pixels_per_meter=12.5,
+        map_origin=(100.0, 200.0),
+        h_matrix=[[1.0, 0.0, 3.0], [0.0, 1.0, 4.0], [0.0, 0.0, 1.0]],
+    )
+
+
+def make_full_optics() -> FullOptics:
+    """Build a :class:`FullOptics`."""
+    return FullOptics(
+        exposure_type="auto",
+        shutter="1/1000",
+        gain=6.0,
+        iris=42,
+        white_balance="auto",
+        focus=510,
+    )
+
+
+def make_floor_mask_reference() -> FloorMaskReference:
+    """Build a :class:`FloorMaskReference`."""
+    return FloorMaskReference(mask_ref="masks/cap-0001.png", checksum="b" * 64)
+
+
 def make_frame_record(
     *,
     capture_id: str = "cap-0001",
@@ -158,8 +208,13 @@ def make_frame_record(
     frame_index: int = 0,
     reported_zoom: float = 4.0,
     image_path: str = "frames/cap-0001.jpg",
+    with_clean_plate: bool = False,
 ) -> FrameRecord:
-    """Build a fully-populated :class:`FrameRecord`."""
+    """Build a fully-populated :class:`FrameRecord`.
+
+    When ``with_clean_plate`` is set, the four #276 optional sub-VOs plus
+    ``survey_context.pose_id`` are populated.
+    """
     return FrameRecord(
         camera=make_camera_identity(camera_id=camera_id),
         capture=make_capture_identity(
@@ -174,6 +229,37 @@ def make_frame_record(
         movement=make_movement_context(),
         pipeline=make_pipeline_state(),
         image_data=make_image_data(image_path=image_path),
+        survey_context=(
+            SurveyContext(pose_id="p+0120.0_t-0015.0_z004.00")
+            if with_clean_plate
+            else SurveyContext()
+        ),
+        intrinsics=make_intrinsics() if with_clean_plate else None,
+        ground_homography=make_ground_homography() if with_clean_plate else None,
+        full_optics=make_full_optics() if with_clean_plate else None,
+        floor_mask_reference=make_floor_mask_reference() if with_clean_plate else None,
+    )
+
+
+def make_pose(
+    *,
+    pan: float = 120.0,
+    tilt: float = -15.0,
+    zoom: float = 4.0,
+) -> Pose:
+    """Build a :class:`Pose`."""
+    return Pose(pan=Degrees(pan), tilt=Degrees(tilt), zoom=Unitless(zoom))
+
+
+def make_pose_catalog(catalog_id: str = "cat-0001", camera_id: str = "cam01") -> PoseCatalog:
+    """Build a :class:`PoseCatalog` from a few poses."""
+    return PoseCatalog.from_poses(
+        catalog_id,
+        camera_id,
+        [
+            make_pose(pan=120.0, tilt=-15.0, zoom=4.0),
+            make_pose(pan=90.0, tilt=-10.0, zoom=2.0),
+        ],
     )
 
 
@@ -209,6 +295,7 @@ def make_survey_run(
     camera_id: str = "cam01",
     status: SurveyRunStatus = SurveyRunStatus.RUNNING,
     finished: bool = False,
+    pose_catalog_id: str | None = None,
 ) -> SurveyRun:
     """Build a :class:`SurveyRun`."""
     return SurveyRun(
@@ -218,4 +305,5 @@ def make_survey_run(
         started_at=_TS,
         finished_at=_TS if finished else None,
         status=status,
+        pose_catalog_id=pose_catalog_id,
     )

--- a/tests/domain/survey/test_clean_plate.py
+++ b/tests/domain/survey/test_clean_plate.py
@@ -1,0 +1,185 @@
+"""Tests for the #276 clean-plate additive domain layer.
+
+Covers the new FrameRecord sub-VOs, legacy 1.0 load tolerance, stable pose ids,
+PoseCatalog round-trip, and SurveyRun.pose_catalog_id.
+"""
+
+from __future__ import annotations
+
+from tests.domain.survey.builders import (
+    make_frame_record,
+    make_pose,
+    make_pose_catalog,
+    make_survey_run,
+)
+
+from poc_homography.domain.entities.survey import (
+    SUPPORTED_SURVEY_SCHEMA_VERSIONS,
+    SURVEY_SCHEMA_VERSION,
+)
+from poc_homography.domain.entities.survey.frame_record import FrameRecord
+from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
+from poc_homography.domain.entities.survey.survey_run import SurveyRun
+from poc_homography.survey.planner.poses import Pose, canonical_pose_key
+
+
+class TestSchemaVersion:
+    def test_current_is_one_one(self) -> None:
+        assert SURVEY_SCHEMA_VERSION == "1.1"
+
+    def test_supported_set(self) -> None:
+        assert frozenset({"1.0", "1.1"}) == SUPPORTED_SURVEY_SCHEMA_VERSIONS
+
+
+class TestFrameRecordCleanPlateRoundTrip:
+    def test_round_trip_with_all_new_sub_vos(self) -> None:
+        record = make_frame_record(with_clean_plate=True)
+        restored = FrameRecord.from_dict(record.to_dict())
+        assert restored == record
+        assert restored.to_dict() == record.to_dict()
+
+    def test_new_sub_vos_populated(self) -> None:
+        record = make_frame_record(with_clean_plate=True)
+        restored = FrameRecord.from_dict(record.to_dict())
+        assert restored.intrinsics == record.intrinsics
+        assert restored.ground_homography == record.ground_homography
+        assert restored.full_optics == record.full_optics
+        assert restored.floor_mask_reference == record.floor_mask_reference
+        assert restored.survey_context.pose_id == "p+0120.0_t-0015.0_z004.00"
+
+    def test_optional_fields_default_none(self) -> None:
+        record = make_frame_record(with_clean_plate=False)
+        assert record.intrinsics is None
+        assert record.ground_homography is None
+        assert record.full_optics is None
+        assert record.floor_mask_reference is None
+        assert record.survey_context.pose_id is None
+        restored = FrameRecord.from_dict(record.to_dict())
+        assert restored == record
+        assert restored.to_dict() == record.to_dict()
+
+
+class TestFrameRecordLegacyLoad:
+    def test_legacy_1_0_without_new_keys_loads(self) -> None:
+        record = make_frame_record(with_clean_plate=True)
+        payload = record.to_dict()
+        # Simulate an old 1.0 record: bump version down and strip the new keys.
+        payload["schema_version"] = "1.0"
+        del payload["intrinsics"]
+        del payload["ground_homography"]
+        del payload["full_optics"]
+        del payload["floor_mask_reference"]
+        del payload["survey_context"]["pose_id"]
+
+        restored = FrameRecord.from_dict(payload)
+
+        assert restored.schema_version == "1.0"
+        assert restored.intrinsics is None
+        assert restored.ground_homography is None
+        assert restored.full_optics is None
+        assert restored.floor_mask_reference is None
+        assert restored.survey_context.pose_id is None
+
+
+class TestStablePoseId:
+    def test_same_pose_same_id_across_runs(self) -> None:
+        # Two independent computations simulate two runs.
+        first = canonical_pose_key(120.0, -15.0, 4.0)
+        second = canonical_pose_key(120.0, -15.0, 4.0)
+        assert first == second
+
+    def test_quantisation_collapses_tiny_differences(self) -> None:
+        base = canonical_pose_key(120.0, -15.0, 4.0)
+        within = canonical_pose_key(120.04, -14.96, 4.004)
+        assert within == base
+
+    def test_distinct_poses_differ(self) -> None:
+        base = canonical_pose_key(120.0, -15.0, 4.0)
+        other = canonical_pose_key(120.5, -15.0, 4.0)
+        assert other != base
+
+    def test_negative_zero_normalised(self) -> None:
+        assert canonical_pose_key(-0.0, 0.0, 1.0) == canonical_pose_key(0.0, 0.0, 1.0)
+
+    def test_catalog_assign_matches_canonical_key(self) -> None:
+        catalog = make_pose_catalog()
+        assert catalog.assign(120.0, -15.0, 4.0) == canonical_pose_key(120.0, -15.0, 4.0)
+
+
+class TestPoseCatalog:
+    def test_round_trip(self) -> None:
+        catalog = make_pose_catalog()
+        restored = PoseCatalog.from_dict(catalog.to_dict())
+        assert restored == catalog
+        assert restored.entries == catalog.entries
+        assert restored.to_dict() == catalog.to_dict()
+
+    def test_deterministic_key_ordering(self) -> None:
+        catalog = make_pose_catalog()
+        keys = list(catalog.to_dict()["entries"].keys())
+        assert keys == sorted(keys)
+
+    def test_id_is_catalog_id(self) -> None:
+        catalog = make_pose_catalog(catalog_id="cat-xyz")
+        assert catalog.id == "cat-xyz"
+
+    def test_with_pose_is_immutable(self) -> None:
+        catalog = PoseCatalog(catalog_id="c1", camera_id="cam01")
+        updated = catalog.with_pose(10.0, 5.0, 1.0)
+        assert catalog.entries == {}
+        pose_id = canonical_pose_key(10.0, 5.0, 1.0)
+        assert updated.entries[pose_id] == (10.0, 5.0, 1.0)
+
+    def test_from_poses_order_independent(self) -> None:
+        poses_a = [make_pose(pan=10.0), make_pose(pan=20.0)]
+        poses_b = [make_pose(pan=20.0), make_pose(pan=10.0)]
+        cat_a = PoseCatalog.from_poses("c", "cam01", poses_a)
+        cat_b = PoseCatalog.from_poses("c", "cam01", poses_b)
+        assert cat_a.to_dict() == cat_b.to_dict()
+
+    def test_schema_version_stamped(self) -> None:
+        catalog = make_pose_catalog()
+        assert catalog.schema_version == SURVEY_SCHEMA_VERSION
+        assert catalog.to_dict()["schema_version"] == SURVEY_SCHEMA_VERSION
+
+
+class TestPosePoseId:
+    def test_pose_round_trip_with_pose_id(self) -> None:
+        pose = make_pose()
+        with_id = Pose(
+            pan=pose.pan,
+            tilt=pose.tilt,
+            zoom=pose.zoom,
+            pose_id="p+0120.0_t-0015.0_z004.00",
+        )
+        restored = Pose.from_dict(with_id.to_dict())
+        assert restored == with_id
+
+    def test_pose_legacy_without_pose_id(self) -> None:
+        payload = make_pose().to_dict()
+        del payload["pose_id"]
+        restored = Pose.from_dict(payload)
+        assert restored.pose_id is None
+
+
+class TestSurveyRunPoseCatalogId:
+    def test_round_trip_with_pose_catalog_id(self) -> None:
+        run = make_survey_run(pose_catalog_id="cat-0001")
+        restored = SurveyRun.from_dict(run.to_dict())
+        assert restored.pose_catalog_id == "cat-0001"
+        assert restored == run
+        assert restored.to_dict() == run.to_dict()
+
+    def test_round_trip_without_pose_catalog_id(self) -> None:
+        run = make_survey_run(pose_catalog_id=None)
+        assert run.to_dict()["pose_catalog_id"] is None
+        restored = SurveyRun.from_dict(run.to_dict())
+        assert restored.pose_catalog_id is None
+
+    def test_legacy_without_key_loads(self) -> None:
+        payload = make_survey_run().to_dict()
+        payload["schema_version"] = "1.0"
+        del payload["pose_catalog_id"]
+        restored = SurveyRun.from_dict(payload)
+        assert restored.pose_catalog_id is None
+        assert restored.schema_version == "1.0"

--- a/tests/infrastructure/survey/test_repo_survey_run_plan_config.py
+++ b/tests/infrastructure/survey/test_repo_survey_run_plan_config.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poc_homography.domain.entities.survey.pose_catalog import PoseCatalog
 from poc_homography.domain.entities.survey.survey_run import SurveyRun
 from poc_homography.domain.enums.survey_phase import SurveyPhase
 from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
@@ -46,14 +47,22 @@ def _make_config() -> SurveyPlanConfig:
     )
 
 
-def _make_run(run_id: str) -> SurveyRun:
+def _make_run(run_id: str, camera_id: str = "cam01") -> SurveyRun:
     return SurveyRun(
         run_id=run_id,
-        camera_id="cam01",
+        camera_id=camera_id,
         phases=frozenset({SurveyPhase.MAIN_SURVEY, SurveyPhase.VALIDATION}),
         started_at=_TS,
         finished_at=None,
         status=SurveyRunStatus.RUNNING,
+    )
+
+
+def _make_catalog(camera_id: str = "cam01") -> PoseCatalog:
+    return (
+        PoseCatalog(catalog_id="cat-01", camera_id=camera_id)
+        .with_pose(10.0, -5.0, 2.0)
+        .with_pose(-20.0, 15.0, 4.0)
     )
 
 
@@ -82,6 +91,73 @@ def test_yaml_load_plan_config_unknown_raises_key_error(tmp_path: Path) -> None:
         repo.load_plan_config("does-not-exist")
 
 
+def test_yaml_pose_catalog_round_trip(tmp_path: Path) -> None:
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    catalog = _make_catalog()
+    run_id = "run-0001"
+
+    assert repo.save_pose_catalog(run_id, catalog) is True
+
+    sidecar = tmp_path / "survey" / run_id / "pose_catalog.yaml"
+    assert sidecar.exists()
+
+    assert repo.load_pose_catalog(run_id).to_dict() == catalog.to_dict()
+
+
+def test_yaml_load_pose_catalog_unknown_raises_key_error(tmp_path: Path) -> None:
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    with pytest.raises(KeyError):
+        repo.load_pose_catalog("does-not-exist")
+
+
+def test_yaml_legacy_run_without_pose_catalog_still_loads(tmp_path: Path) -> None:
+    """A run persisted before pose-catalog sidecars existed still round-trips."""
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    run = _make_run("legacy-run")
+    repo.save(run)
+
+    loaded = repo.get("legacy-run")
+    assert loaded is not None
+    assert loaded == run
+    with pytest.raises(KeyError):
+        repo.load_pose_catalog("legacy-run")
+
+
+def test_yaml_get_runs_by_camera_and_pose_groups_multi_visit(tmp_path: Path) -> None:
+    repo = RepoYamlSurveyRun(
+        data_dir=tmp_path / "survey_runs",
+        frames_dir=tmp_path / "survey",
+    )
+    catalog = _make_catalog(camera_id="cam01")
+    pose_id = PoseCatalog.assign(10.0, -5.0, 2.0)
+
+    # Two runs for cam01 sharing the same physical pose.
+    for run_id in ("visit-1", "visit-2"):
+        run = _make_run(run_id, camera_id="cam01")
+        repo.save(run)
+        assert repo.save_pose_catalog(run_id, catalog) is True
+
+    # A different camera visiting the same pose must NOT be grouped under cam01.
+    other = _make_run("other-cam", camera_id="cam02")
+    repo.save(other)
+    repo.save_pose_catalog("other-cam", _make_catalog(camera_id="cam02"))
+
+    matches = repo.get_runs_by_camera_and_pose("cam01", pose_id)
+    assert {r.id for r in matches} == {"visit-1", "visit-2"}
+
+    # Absent pose returns nothing.
+    assert repo.get_runs_by_camera_and_pose("cam01", "no-such-pose") == []
+
+
 @pytest.mark.integration
 class TestRepoPostgresSurveyRunPlanConfig:
     def test_plan_config_round_trip(self, db_session: Session) -> None:
@@ -97,3 +173,34 @@ class TestRepoPostgresSurveyRunPlanConfig:
         repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
         with pytest.raises(KeyError):
             repo.load_plan_config("missing-run")
+
+    def test_pose_catalog_round_trip(self, db_session: Session) -> None:
+        repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
+        run = _make_run("pg-pose-0001")
+        assert repo.save(run) is True
+
+        catalog = _make_catalog()
+        assert repo.save_pose_catalog(run.run_id, catalog) is True
+        assert repo.load_pose_catalog(run.run_id).to_dict() == catalog.to_dict()
+
+    def test_load_pose_catalog_unknown_raises_key_error(self, db_session: Session) -> None:
+        repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
+        with pytest.raises(KeyError):
+            repo.load_pose_catalog("missing-run")
+
+    def test_get_runs_by_camera_and_pose_groups_multi_visit(self, db_session: Session) -> None:
+        repo = RepoPostgresSurveyRun(db_session, SurveyRun.from_dict)
+        catalog = _make_catalog(camera_id="cam01")
+        pose_id = PoseCatalog.assign(10.0, -5.0, 2.0)
+
+        for run_id in ("pg-visit-1", "pg-visit-2"):
+            assert repo.save(_make_run(run_id, camera_id="cam01")) is True
+            assert repo.save_pose_catalog(run_id, catalog) is True
+
+        assert repo.save(_make_run("pg-other-cam", camera_id="cam02")) is True
+        repo.save_pose_catalog("pg-other-cam", _make_catalog(camera_id="cam02"))
+
+        matches = repo.get_runs_by_camera_and_pose("cam01", pose_id)
+        assert {r.id for r in matches} == {"pg-visit-1", "pg-visit-2"}
+
+        assert repo.get_runs_by_camera_and_pose("cam01", "no-such-pose") == []

--- a/tests/survey/test_clean_plate_capture.py
+++ b/tests/survey/test_clean_plate_capture.py
@@ -1,0 +1,261 @@
+"""Capture/phase-wiring tests for #276 clean-plate capture.
+
+Covers the per-pose burst-count bridge from :class:`SurveyPlanConfig`, the
+additive per-frame metadata stamped by the capture engine (intrinsics,
+full_optics) and the phase layer (stable pose_id), and the deliberate
+``None`` of the downstream-only fields.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poc_homography.camera_config import (
+    DEFAULT_BASE_FOCAL_LENGTH_MM,
+    DEFAULT_SENSOR_WIDTH_MM,
+)
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.infrastructure.survey.capture_engine import SurveyCaptureEngine
+from poc_homography.survey.phases import executors
+from poc_homography.survey.phases.runner import (
+    MIN_BURST_FRAME_COUNT,
+    SurveyPlan,
+)
+from poc_homography.survey.planner.poses import canonical_pose_key
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.survey.conftest import CountingUuid, FakeCamera, IncrementingClock
+
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+
+_SPEC_PAN = 90.0
+_SPEC_TILT = -20.0
+_SPEC_ZOOM = 4.0
+
+
+def _engine(
+    camera: FakeCamera, clock: IncrementingClock, uuid_factory: CountingUuid
+) -> SurveyCaptureEngine:
+    return SurveyCaptureEngine(camera, clock=clock, uuid_factory=uuid_factory)
+
+
+def _cross_zoom_frames(
+    camera: FakeCamera,
+    clock: IncrementingClock,
+    uuid_factory: CountingUuid,
+    out: Path,
+    *,
+    burst_count: int = 1,
+    run_id: str = "run-1",
+) -> list[FrameRecord]:
+    """Drive a small pose-based phase (cross-zoom) and return its frames."""
+    result = executors.run_cross_zoom(
+        _engine(camera, clock, uuid_factory),
+        run_id=run_id,
+        camera_id="cam01",
+        output_dir=out,
+        anchors=((_SPEC_PAN, _SPEC_TILT),),
+        zoom_levels=(_SPEC_ZOOM,),
+        burst_count=burst_count,
+    )
+    return list(result.frames)
+
+
+class TestPerPoseBursts:
+    def test_pose_phase_emits_n_frames_per_pose_sharing_one_burst_id(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        frames = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path, burst_count=3)
+        # One pose (single anchor x single zoom) -> exactly N frames.
+        assert len(frames) == 3
+        assert len({f.capture.burst_id for f in frames}) == 1
+        assert [f.capture.frame_index for f in frames] == [0, 1, 2]
+
+
+class TestStablePoseId:
+    def test_same_pose_yields_same_pose_id_across_runs(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        run_a = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path / "a", run_id="run-a")
+        # A second, independent run with fresh factories and a distinct run id.
+        from tests.survey.conftest import (
+            CountingUuid as _Uuid,
+        )
+        from tests.survey.conftest import (
+            FakeCamera as _Cam,
+        )
+        from tests.survey.conftest import (
+            IncrementingClock as _Clock,
+        )
+
+        run_b = _cross_zoom_frames(_Cam(), _Clock(), _Uuid(), tmp_path / "b", run_id="run-b")
+
+        expected = canonical_pose_key(_SPEC_PAN, _SPEC_TILT, _SPEC_ZOOM)
+        # Distinct runs (different run ids) yield the SAME stable pose id.
+        assert run_a[0].capture.run_id != run_b[0].capture.run_id
+        assert {f.survey_context.pose_id for f in run_a} == {expected}
+        assert {f.survey_context.pose_id for f in run_b} == {expected}
+
+    def test_pose_id_preserves_other_survey_context_fields(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        frames = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path)
+        # Cross-zoom stamps region_id; pose_id must be added, not replace it.
+        assert all(f.survey_context.region_id == "region_0" for f in frames)
+        assert all(f.survey_context.pose_id is not None for f in frames)
+
+
+class TestIntrinsicsStamped:
+    def test_every_frame_has_intrinsics_with_k_matrix(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        frames = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path)
+        assert frames
+        for frame in frames:
+            intrinsics = frame.intrinsics
+            assert intrinsics is not None
+            assert float(intrinsics.zoom) == _SPEC_ZOOM
+            assert float(intrinsics.sensor_width_mm) == DEFAULT_SENSOR_WIDTH_MM
+            assert float(intrinsics.base_focal_length_mm) == DEFAULT_BASE_FOCAL_LENGTH_MM
+            assert intrinsics.k_matrix is not None
+            assert len(intrinsics.k_matrix) == 3
+            assert all(len(row) == 3 for row in intrinsics.k_matrix)
+            # Principal point is the image centre; fx == fy on the diagonal.
+            assert intrinsics.k_matrix[0][2] == float(frame.image_data.width) / 2.0
+            assert intrinsics.k_matrix[0][0] == intrinsics.k_matrix[1][1]
+
+
+class TestFullOpticsStamped:
+    def test_every_frame_has_full_optics_from_camera(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        frames = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path)
+        assert frames
+        for frame in frames:
+            optics = frame.full_optics
+            assert optics is not None
+            # Mapped from the FakeCamera's ImageOptics (see conftest.make_optics).
+            assert optics.exposure_type == "auto"
+            assert optics.iris == 50
+            assert optics.white_balance == "auto"
+            assert optics.focus == 150
+            # Unmapped (no adapter source) fields stay None.
+            assert optics.shutter is None
+            assert optics.gain is None
+
+
+class TestDownstreamFieldsLeftNone:
+    def test_ground_homography_and_floor_mask_are_none_at_capture(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+    ) -> None:
+        frames = _cross_zoom_frames(camera, clock, uuid_factory, tmp_path)
+        assert frames
+        # These require deployment extrinsics / an external masker; the survey
+        # leaves them None and they are populated downstream.
+        assert all(f.ground_homography is None for f in frames)
+        assert all(f.floor_mask_reference is None for f in frames)
+
+
+class TestFromPlanConfigBridge:
+    def test_maps_burst_frame_count_per_phase(self) -> None:
+        config = SurveyPlanConfig(burst_frame_count={5: 8, 2: 4})
+        plan = SurveyPlan.from_plan_config(config)
+        assert plan.burst_for(5) == 8
+        assert plan.burst_for(2) == 4
+
+    def test_default_applies_to_unconfigured_phases(self) -> None:
+        config = SurveyPlanConfig(burst_frame_count={})
+        plan = SurveyPlan.from_plan_config(config, default_burst_frame_count=7)
+        # Every pose-based phase falls back to the default.
+        for phase in (2, 3, 4, 5, 6, 7, 9):
+            assert plan.burst_for(phase) == 7
+
+    def test_clamps_below_minimum_to_two(self) -> None:
+        config = SurveyPlanConfig(burst_frame_count={5: 1})
+        plan = SurveyPlan.from_plan_config(config, default_burst_frame_count=1)
+        assert plan.burst_for(5) == MIN_BURST_FRAME_COUNT
+        assert plan.burst_for(3) == MIN_BURST_FRAME_COUNT
+
+    def test_default_is_at_least_two(self) -> None:
+        plan = SurveyPlan.from_plan_config(SurveyPlanConfig())
+        assert plan.burst_for(5) >= MIN_BURST_FRAME_COUNT
+
+
+class TestRunnerHonoursPlanBursts:
+    def test_runner_emits_configured_burst_per_pose(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        from poc_homography.survey.phases.runner import execute_survey
+
+        patch_rtsp(20)
+
+        class _Sink:
+            def __init__(self) -> None:
+                self.frames: list[FrameRecord] = []
+
+            def save_inventory(self, record: object) -> None:
+                return None
+
+            def save_frame(self, record: FrameRecord) -> None:
+                self.frames.append(record)
+
+            def save_burst(self, record: object) -> None:
+                return None
+
+        sink = _Sink()
+        plan = SurveyPlan.from_plan_config(SurveyPlanConfig(), default_burst_frame_count=2)
+        execute_survey(
+            camera,
+            run_id="run-1",
+            camera_id="cam01",
+            sink=sink,  # type: ignore[arg-type]
+            base_output_dir=tmp_path,
+            plan=plan,
+            clock=clock,
+            uuid_factory=uuid_factory,
+        )
+
+        # Every snapshot-burst (non-jitter) pose emits >= 2 frames sharing a
+        # burst id; group the pose-based frames by burst id and assert size.
+        pose_frames = [f for f in sink.frames if f.capture.phase is not SurveyPhase.STATIC_JITTER]
+        assert pose_frames
+        by_burst: dict[str | None, list[FrameRecord]] = {}
+        for frame in pose_frames:
+            by_burst.setdefault(frame.capture.burst_id, []).append(frame)
+        assert all(len(group) == 2 for group in by_burst.values())
+        # And every emitted frame carries the additive clean-plate metadata.
+        assert all(f.intrinsics is not None for f in pose_frames)
+        assert all(f.full_optics is not None for f in pose_frames)
+        assert all(f.survey_context.pose_id is not None for f in pose_frames)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -349,3 +349,7 @@ _.detail  # ValidationOutcome human-readable note; injectable-hook contract (poc
 
 # -- Phase-0 horizon calibration C3 (#275); step-1 entry point consumed by C5/CLI + tests --
 calibrate_horizon_envelope  # Phase-0 calibration step; invoked by operator/CLI + tests (poc_homography/survey/calibration.py)
+
+# -- Clean-plate capture domain (#276); PoseCatalog public API consumed by C2/C4 + tests --
+_.with_pose  # PoseCatalog immutable pose-record builder (poc_homography/domain/entities/survey/pose_catalog.py)
+_.from_poses  # PoseCatalog deterministic builder from a pose sequence (poc_homography/domain/entities/survey/pose_catalog.py)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -353,3 +353,4 @@ calibrate_horizon_envelope  # Phase-0 calibration step; invoked by operator/CLI 
 # -- Clean-plate capture domain (#276); PoseCatalog public API consumed by C2/C4 + tests --
 _.with_pose  # PoseCatalog immutable pose-record builder (poc_homography/domain/entities/survey/pose_catalog.py)
 _.from_poses  # PoseCatalog deterministic builder from a pose sequence (poc_homography/domain/entities/survey/pose_catalog.py)
+_.from_plan_config  # SurveyPlanConfig->SurveyPlan burst-count bridge; consumed by C5 + tests (poc_homography/survey/phases/runner.py)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -346,6 +346,8 @@ browse_command  # typer survey command (poc_homography/cli/survey.py)
 _.save_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)
 _.load_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)
 _.detail  # ValidationOutcome human-readable note; injectable-hook contract (poc_homography/horizon/validation.py)
+_.save_pose_catalog  # SurveyRunRepository pose-catalog contract (#276); consumed by tests + future C2/C4 (poc_homography/domain/protocols/survey_run_repository.py)
+_.get_runs_by_camera_and_pose  # SurveyRunRepository multi-visit grouping query (#276); consumed by tests (poc_homography/domain/protocols/survey_run_repository.py)
 
 # -- Phase-0 horizon calibration C3 (#275); step-1 entry point consumed by C5/CLI + tests --
 calibrate_horizon_envelope  # Phase-0 calibration step; invoked by operator/CLI + tests (poc_homography/survey/calibration.py)


### PR DESCRIPTION
## Summary

Makes the survey capture everything the offline clean-plate reconstruction (epic #273, child #4) needs. Part of epic #273. Closes #276.

- **Stable cross-run pose catalog** — new `PoseCatalog` entity maps `pose_id → (pan, tilt, zoom)`; `pose_id` is derived deterministically from quantized geometry (`canonical_pose_key`), so the same physical pose carries the same id on every visit. Persisted as a YAML sidecar (`pose_catalog.yaml`) and Postgres JSONB (`data["pose_catalog"]`). `SurveyRun` gained `pose_catalog_id`.
- **Per-pose bursts everywhere** — `SurveyPlan.from_plan_config` bridges `SurveyPlanConfig.burst_frame_count` to per-phase burst counts (clamped to ≥2, default 5); every pose-based phase (2–7, 9) now captures a multi-frame burst per pose sharing a `burst_id` with 0-based `frame_index`.
- **Additive per-frame metadata** — `FrameRecord` gained optional `intrinsics` (K + recompute inputs), `ground_homography` (extrinsic-input slot), `full_optics` (exposure/shutter/gain/iris/white-balance/focus), and `floor_mask_reference` (path/key + checksum) sub-VOs, plus `SurveyContext.pose_id`. The capture engine stamps `intrinsics` (from commanded zoom + image dims + sensor params) and `full_optics` (from per-burst `ImageOptics`) on every frame; the phase layer stamps the stable `pose_id`. `ground_homography`/`floor_mask_reference` are intentionally left `None` at capture — they require deployment-specific extrinsics / an external masker and are filled downstream (out of scope per the issue).
- **Schema discipline** — `SURVEY_SCHEMA_VERSION` bumped `1.0 → 1.1` with a tolerant `check_schema_version` (accepts `{1.0, 1.1}`); all new fields default to `None`/empty so legacy records still load.
- **Multi-visit linkage** — `get_runs_by_camera_and_pose(camera_id, pose_id)` on both repos groups runs that visited the same physical pose for a camera.
- Additive only: no destructive migration, no new column/table (pose catalog rides the existing `data` JSONB).

## Test plan

- `poe validate` → exit 0 (ruff, format, pyright, pylint 9.03/10, vulture).
- Offline `poe test` → **1076 passed, 151 skipped** (DB-gated Postgres tests skip without `DATABASE_URL`).
- New tests cover: legacy-1.0-record load, `pose_id` stability across two runs, N-frames-per-pose bursts, K/optics stamping, `from_plan_config` clamp-to-≥2, pose-catalog round-trip in both repos, and the multi-visit grouping query.

## Definition of Done

- [x] A persistent pose catalog exists; the same physical pose yields a stable `pose_id` across runs, persisted in YAML and JSONB.
- [x] Every survey pose captures a configurable burst of N≥2 frames sharing a `burst_id`, controlled via `SurveyPlanConfig`.
- [x] `FrameRecord` carries additive K, ground-homography, full optics, and floor-mask-reference fields; round-trips through both YAML and Postgres repos; legacy records without these fields still load.
- [x] Multi-visit runs are groupable by `(camera_id, pose_id)` via a repository query.
- [x] `poe validate` and offline `poe test` pass.


## Closes DoD bullets

- [x] A persistent pose catalog exists; the same physical pose yields a stable `pose_id` across runs, persisted in YAML and JSONB.
- [x] Every survey pose captures a configurable burst of N≥2 frames sharing a `burst_id`, controlled via `SurveyPlanConfig`.
- [x] `FrameRecord` carries additive K, ground-homography, full optics, and floor-mask-reference fields; round-trips through both YAML and Postgres repos; legacy records without these fields still load (regression test).
- [x] Multi-visit runs are groupable by `(camera_id, pose_id)` via a repository query.
- [x] `poe validate` and offline `poe test` pass.
