### PR TITLE
feat(survey): Phase-0 horizon calibration → constrained 2-step survey (#275)

### DIFF
--- a/poc_homography/domain/vo/__init__.py
+++ b/poc_homography/domain/vo/__init__.py
@@ -26,6 +26,7 @@ from poc_homography.domain.vo.ptz_state import PTZState
 from poc_homography.domain.vo.rotation import Rotation
 from poc_homography.domain.vo.stream_profile import StreamProfile
 from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
 from poc_homography.domain.vo.vector3 import Vector3
 from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
 
@@ -54,6 +55,7 @@ __all__ = [
     "Rotation",
     "StreamProfile",
     "SurveyPlanConfig",
+    "TiltEnvelope",
     "Vector3",
     "WhiteBalanceState",
     "ZoomCalibrationEntry",

--- a/poc_homography/domain/vo/survey_plan_config.py
+++ b/poc_homography/domain/vo/survey_plan_config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
+
 PLAN_CONFIG_SCHEMA_VERSION = "1"
 """Schema version for :class:`SurveyPlanConfig`.
 
@@ -51,6 +53,10 @@ class SurveyPlanConfig:
         zoom_levels: Zoom factors swept by phases 3, 6 and 8.
         repeat_count: Per-phase repetition count (phases 2 and 7).
         holdout_fraction: Phase 9 validation holdout fraction.
+        tilt_envelope: Optional per-azimuth max-up-useful-tilt envelope from the
+            Phase-0 horizon calibration. ``None`` (the default) reproduces the
+            pre-horizon behaviour exactly; when present the C3 pose generators
+            skip sky tiles above the per-azimuth bound.
     """
 
     schema_version: str = PLAN_CONFIG_SCHEMA_VERSION
@@ -67,6 +73,7 @@ class SurveyPlanConfig:
     zoom_levels: list[float] = field(default_factory=lambda: [1.0, 5.0, 12.0, 25.0])
     repeat_count: dict[int, int] = field(default_factory=lambda: {2: 3, 7: 3})
     holdout_fraction: float = 0.15
+    tilt_envelope: TiltEnvelope | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-serialisable dictionary.
@@ -90,6 +97,9 @@ class SurveyPlanConfig:
             "zoom_levels": list(self.zoom_levels),
             "repeat_count": {str(k): v for k, v in self.repeat_count.items()},
             "holdout_fraction": self.holdout_fraction,
+            "tilt_envelope": (
+                self.tilt_envelope.to_dict() if self.tilt_envelope is not None else None
+            ),
         }
 
     @classmethod
@@ -142,6 +152,7 @@ class SurveyPlanConfig:
             zoom_levels=_float_list(data.get("zoom_levels"), defaults.zoom_levels),
             repeat_count=_int_keyed(data.get("repeat_count"), int, defaults.repeat_count),
             holdout_fraction=float(data.get("holdout_fraction", defaults.holdout_fraction)),
+            tilt_envelope=_tilt_envelope_from_dict(data.get("tilt_envelope")),
         )
 
 
@@ -171,6 +182,13 @@ def _int_keyed(
     if raw is None:
         return dict(default)
     return {int(k): value_cast(v) for k, v in raw.items()}
+
+
+def _tilt_envelope_from_dict(raw: dict[Any, Any] | None) -> TiltEnvelope | None:
+    """Rebuild the optional tilt envelope; ``None`` preserves legacy behaviour."""
+    if raw is None:
+        return None
+    return TiltEnvelope.from_dict(raw)
 
 
 def _float_list(raw: list[Any] | None, default: list[float]) -> list[float]:

--- a/poc_homography/domain/vo/tilt_envelope.py
+++ b/poc_homography/domain/vo/tilt_envelope.py
@@ -1,0 +1,159 @@
+"""Per-azimuth tilt envelope value object (horizon-aware survey constraint).
+
+A :class:`TiltEnvelope` records, for a coarse set of calibrated azimuths, the
+*maximum-up useful tilt* — the most-up the camera can point at that azimuth
+while the frame still contains ground rather than pure sky. Survey pose
+generators consume the envelope to skip sky tiles.
+
+Convention (matching :mod:`poc_homography.horizon.geometry` and
+:class:`poc_homography.camera.intrinsics.PTZStatus`): **positive tilt = down**.
+Pointing further up means a *smaller* (more negative) tilt. The per-azimuth
+``tilt_upper_bound`` is therefore a *lower numeric clamp*: a useful pose has
+``tilt >= upper_bound(pan)``; any pose with ``tilt < upper_bound(pan)`` points
+above the useful ground band and is sky. The name "upper bound" refers to the
+upper limit *in the scene* (toward the sky), not a numeric maximum.
+
+The envelope is a frozen, JSON-round-trippable VO following the project pattern
+(``schema_version`` discipline, ``to_dict``/``from_dict``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+TILT_ENVELOPE_SCHEMA_VERSION = "1"
+"""Schema version for :class:`TiltEnvelope`.
+
+Deliberately the literal ``"1"`` and independent of every other
+``*_SCHEMA_VERSION`` in the codebase; the envelope VO evolves on its own.
+"""
+
+# Tolerance for matching an exact calibrated azimuth (in degrees).
+_AZIMUTH_TOLERANCE = 1e-9
+
+
+@dataclass(frozen=True)
+class TiltEnvelope:
+    """A per-azimuth maximum-up-useful-tilt envelope.
+
+    Attributes:
+        bounds: ``azimuth_deg -> tilt_upper_bound_deg`` for each calibrated
+            azimuth. Azimuths are pan angles in degrees; bounds are reported
+            tilt in degrees (positive = down).
+        tilt_offset_deg: Confirmed reported tilt at which the optical axis is
+            horizontal (true elevation 0).
+        vfov_deg: Vertical field of view at ``zoom``, in degrees.
+        zoom: Zoom factor the calibration frames were captured at.
+        interpolation: Interpolation rule for pans between calibrated azimuths;
+            always ``"linear"`` (circular linear interpolation, see
+            :meth:`upper_bound`).
+        schema_version: VO schema version (always ``"1"``).
+    """
+
+    bounds: dict[float, float] = field(default_factory=dict)
+    tilt_offset_deg: float = 0.0
+    vfov_deg: float = 0.0
+    zoom: float = 1.0
+    interpolation: str = "linear"
+    schema_version: str = TILT_ENVELOPE_SCHEMA_VERSION
+
+    def upper_bound(self, pan_deg: float) -> float:
+        """Return the max-up useful tilt at ``pan_deg`` (positive = down).
+
+        The bound is **linearly interpolated** between the two nearest
+        calibrated azimuths, treating pan as circular (wrapping across the
+        360°/0° seam). Linear (rather than nearest-neighbour) interpolation is
+        chosen so the constraint varies smoothly around the pan circle and a
+        coarse calibration set does not produce abrupt per-tile jumps.
+
+        Args:
+            pan_deg: Pan angle in degrees (any value; reduced modulo 360).
+
+        Returns:
+            The interpolated ``tilt_upper_bound`` in degrees.
+
+        Raises:
+            ValueError: If the envelope has no calibrated azimuths.
+        """
+        if not self.bounds:
+            raise ValueError("empty TiltEnvelope has no bound to interpolate")
+
+        azimuths = sorted(self.bounds)
+        if len(azimuths) == 1:
+            return self.bounds[azimuths[0]]
+
+        pan = pan_deg % 360.0
+        for az in azimuths:
+            if abs(az - pan) <= _AZIMUTH_TOLERANCE:
+                return self.bounds[az]
+
+        lo_az: float | None = None
+        hi_az: float | None = None
+        for az in azimuths:
+            if az <= pan:
+                lo_az = az
+            if az >= pan and hi_az is None:
+                hi_az = az
+
+        if lo_az is not None and hi_az is not None:
+            return self._lerp(lo_az, hi_az, pan)
+
+        # Wrap-around seam: pan sits below the smallest or above the largest
+        # calibrated azimuth, so interpolate across the 360°/0° boundary.
+        lo_az = azimuths[-1]
+        hi_az = azimuths[0]
+        pan_eff = pan + 360.0 if pan < hi_az else pan
+        span = (hi_az + 360.0) - lo_az
+        frac = (pan_eff - lo_az) / span
+        return _interpolate(self.bounds[lo_az], self.bounds[hi_az], frac)
+
+    def _lerp(self, lo_az: float, hi_az: float, pan: float) -> float:
+        """Linearly interpolate the bound between two bracketing azimuths."""
+        span = hi_az - lo_az
+        if span <= _AZIMUTH_TOLERANCE:
+            return self.bounds[lo_az]
+        frac = (pan - lo_az) / span
+        return _interpolate(self.bounds[lo_az], self.bounds[hi_az], frac)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serialisable dictionary.
+
+        Bound keys (azimuth floats) are stringified so the result survives
+        ``json.dumps`` / ``yaml.safe_dump`` round-trips.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "bounds": {str(k): v for k, v in self.bounds.items()},
+            "tilt_offset_deg": self.tilt_offset_deg,
+            "vfov_deg": self.vfov_deg,
+            "zoom": self.zoom,
+            "interpolation": self.interpolation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TiltEnvelope:
+        """Reconstruct a :class:`TiltEnvelope` from :meth:`to_dict` output.
+
+        Raises:
+            ValueError: If ``schema_version`` is unsupported.
+        """
+        version = data.get("schema_version", TILT_ENVELOPE_SCHEMA_VERSION)
+        if version != TILT_ENVELOPE_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema_version {version!r}; expected {TILT_ENVELOPE_SCHEMA_VERSION!r}"
+            )
+        raw_bounds = data.get("bounds") or {}
+        return cls(
+            bounds={float(k): float(v) for k, v in raw_bounds.items()},
+            tilt_offset_deg=float(data.get("tilt_offset_deg", 0.0)),
+            vfov_deg=float(data.get("vfov_deg", 0.0)),
+            zoom=float(data.get("zoom", 1.0)),
+            interpolation=str(data.get("interpolation", "linear")),
+            schema_version=TILT_ENVELOPE_SCHEMA_VERSION,
+        )
+
+
+def _interpolate(lo_value: float, hi_value: float, frac: float) -> float:
+    """Linear blend ``lo_value -> hi_value`` by ``frac`` in ``[0, 1]``."""
+    return lo_value + (hi_value - lo_value) * frac

--- a/poc_homography/survey/calibration.py
+++ b/poc_homography/survey/calibration.py
@@ -92,6 +92,12 @@ def calibrate_horizon_envelope(
 
     bounds: dict[float, float] = {}
     for pan in pans:
+        azimuth = pan % 360.0
+        if azimuth in bounds:
+            raise ValueError(
+                f"duplicate calibration azimuth {azimuth} (pan {pan} aliases an "
+                f"earlier pan modulo 360); pass distinct azimuths"
+            )
         reported = camera.move_absolute(pan=pan, tilt=aim_tilt, zoom=zoom)
         camera.wait_for_stabilization(timeout_s=settle_timeout_s)
         reported_tilt = float(reported.tilt_deg)
@@ -108,9 +114,7 @@ def calibrate_horizon_envelope(
             base_focal_length_mm=spec.base_focal_length,
             tilt_offset_deg=Degrees(tilt_offset_deg),
         )
-        bounds[pan % 360.0] = _bound_from_estimate(
-            estimate, reported_tilt, zoom, spec, tilt_offset_deg
-        )
+        bounds[azimuth] = _bound_from_estimate(estimate, reported_tilt, zoom, spec, tilt_offset_deg)
 
     vfov = float(
         vertical_fov_degrees(
@@ -138,18 +142,19 @@ def _bound_from_estimate(
 ) -> float:
     """Derive the max-up useful tilt from one per-azimuth horizon estimate.
 
-    With the geometric horizon row at the capture tilt being
-    ``H(t0) = cy + f*tan(tilt_offset - t0)``, a detected boundary at row ``r``
-    sits ``d = r - H(t0)`` pixels off the flat horizon (terrain/structures push
-    the boundary above it, so ``d < 0``). The useful bound is the reported tilt
-    that brings that same boundary to the top edge (row 0)::
+    A feature at true elevation ``e`` projects to row
+    ``cy + f*tan((tilt_offset - t) - e)`` at reported tilt ``t``. Inverting that
+    for the detected boundary ``(t0, r)`` and solving for the tilt ``t_b`` that
+    brings the same boundary to the top edge (row 0) gives the exact closed
+    form (the ``e`` and ``t0`` terms cancel)::
 
-        tilt_bound = tilt_offset + degrees(atan((cy + d) / f))
+        t_b = t0 + degrees(atan((r - cy) / f)) + degrees(atan(cy / f))
 
-    which reduces to :func:`all_ground_tilt_threshold` (``tilt_offset + VFOV/2``)
-    when ``d == 0``. When the boundary is not in frame (all-ground or all-sky
-    detections give no row), the flat geometric threshold is used as a safe
-    fallback.
+    This is exact for any boundary row — not a small-angle approximation — and
+    reduces to :func:`all_ground_tilt_threshold` (``tilt_offset + VFOV/2``) when
+    the boundary coincides with the flat geometric horizon. When the boundary is
+    not in frame (all-ground or all-sky detections give no row), the flat
+    geometric threshold is used as a safe fallback.
     """
     if estimate.placement is not FramePlacement.IN_FRAME or estimate.row is None:
         return float(
@@ -172,12 +177,20 @@ def _bound_from_estimate(
     )
     f_px = float(intr.focal_length_px)
     cy = float(intr.cy)
-    horizon_row = cy + f_px * math.tan(math.radians(tilt_offset_deg - reported_tilt))
-    delta = float(estimate.row) - horizon_row
-    return tilt_offset_deg + math.degrees(math.atan((cy + delta) / f_px))
+    return (
+        reported_tilt
+        + math.degrees(math.atan((float(estimate.row) - cy) / f_px))
+        + math.degrees(math.atan(cy / f_px))
+    )
 
 
 def _decode_snapshot(data: bytes) -> np.ndarray:
-    """Decode JPEG snapshot bytes to an RGB ``numpy`` array for CV refinement."""
+    """Decode JPEG snapshot bytes to a **BGR** ``numpy`` array for CV refinement.
+
+    The horizon CV refiner (and the rest of the codebase, via ``cv2.imread`` /
+    ``cv2.VideoCapture``) assumes BGR channel order, so the PIL-decoded RGB
+    frame is reversed to BGR (contiguous) before hand-off.
+    """
     with Image.open(io.BytesIO(data)) as img:
-        return np.asarray(img.convert("RGB"))
+        rgb = np.asarray(img.convert("RGB"))
+    return np.ascontiguousarray(rgb[:, :, ::-1])

--- a/poc_homography/survey/calibration.py
+++ b/poc_homography/survey/calibration.py
@@ -1,0 +1,183 @@
+"""Phase-0 horizon calibration → per-azimuth tilt envelope.
+
+The first step of the horizon-aware 2-step survey. At a coarse set of pans
+(e.g. every 30-45°) and a wide zoom, the camera is aimed near the predicted
+horizon, a frame is captured, and :func:`poc_homography.horizon.estimate_horizon`
+(geometric prediction → optional CV refine → optional vision confirm) locates
+the ground/sky boundary. From each per-azimuth detection the *maximum-up useful
+tilt* is derived — the most-up reported tilt at which the detected boundary
+still sits at the top edge of frame. The result is a
+:class:`~poc_homography.domain.vo.tilt_envelope.TiltEnvelope` the C3 pose
+generators consume to skip sky tiles (step 2).
+
+Geometry (and intrinsics) are delegated entirely to the horizon and intrinsics
+modules; no focal-length or pixel arithmetic is reimplemented here.
+
+Convention: **positive tilt = down** (see
+:mod:`poc_homography.horizon.geometry`).
+"""
+
+from __future__ import annotations
+
+import io
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+from PIL import Image
+
+from poc_homography.camera.intrinsics import compute_intrinsics
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
+from poc_homography.horizon.estimate import estimate_horizon
+from poc_homography.horizon.geometry import (
+    DEFAULT_TILT_OFFSET_DEG,
+    all_ground_tilt_threshold,
+    vertical_fov_degrees,
+)
+from poc_homography.horizon.models import FramePlacement
+from poc_homography.types import Degrees, Unitless
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.horizon.models import HorizonEstimate
+    from poc_homography.horizon.validation import HorizonValidator
+
+
+def calibrate_horizon_envelope(
+    camera: CameraDevice,
+    *,
+    pans: Sequence[float],
+    zoom: float = 1.0,
+    spec: CameraSpec = CameraSpec.HIKVISION_DS_2DF8425IX,
+    validator: HorizonValidator | None = None,
+    tilt_offset_deg: float = float(DEFAULT_TILT_OFFSET_DEG),
+    settle_timeout_s: float = 5.0,
+) -> TiltEnvelope:
+    """Derive a per-azimuth tilt envelope from a coarse Phase-0 pan sweep.
+
+    For each pan the camera is aimed at the predicted horizon (reported tilt
+    ``tilt_offset_deg`` → true elevation 0, so the horizon sits near frame
+    centre), allowed to settle, and a snapshot is captured and analysed with
+    :func:`estimate_horizon`. The per-azimuth max-up useful tilt is then derived
+    from the detected boundary (see :func:`_bound_from_estimate`).
+
+    Args:
+        camera: The PTZ camera device to drive.
+        pans: Coarse pan angles in degrees (e.g. every 30-45°). At least one.
+        zoom: Wide zoom factor for the calibration frames (1.0 = wide).
+        spec: Camera specification supplying resolution and optics.
+        validator: Optional injected vision validator passed to
+            :func:`estimate_horizon`.
+        tilt_offset_deg: Reported tilt mapping to true elevation 0 (the aim
+            point and the geometric model's offset).
+        settle_timeout_s: Stabilisation timeout after each move, in seconds.
+
+    Returns:
+        A :class:`TiltEnvelope` whose ``bounds`` map each pan (reduced modulo
+        360) to its max-up useful tilt, with the confirmed ``tilt_offset_deg``
+        and the ``vfov_deg`` at ``zoom``.
+
+    Raises:
+        ValueError: If ``pans`` is empty.
+    """
+    if not pans:
+        raise ValueError("calibration needs >= 1 pan angle")
+
+    width = spec.image_width
+    height = spec.image_height
+    aim_tilt = tilt_offset_deg
+
+    bounds: dict[float, float] = {}
+    for pan in pans:
+        reported = camera.move_absolute(pan=pan, tilt=aim_tilt, zoom=zoom)
+        camera.wait_for_stabilization(timeout_s=settle_timeout_s)
+        reported_tilt = float(reported.tilt_deg)
+
+        image = _decode_snapshot(camera.capture_snapshot())
+        estimate = estimate_horizon(
+            Degrees(reported_tilt),
+            Unitless(zoom),
+            width,
+            height,
+            image=image,
+            validator=validator,
+            sensor_width_mm=spec.sensor_width,
+            base_focal_length_mm=spec.base_focal_length,
+            tilt_offset_deg=Degrees(tilt_offset_deg),
+        )
+        bounds[pan % 360.0] = _bound_from_estimate(
+            estimate, reported_tilt, zoom, spec, tilt_offset_deg
+        )
+
+    vfov = float(
+        vertical_fov_degrees(
+            Unitless(zoom),
+            width,
+            height,
+            spec.sensor_width,
+            spec.base_focal_length,
+        )
+    )
+    return TiltEnvelope(
+        bounds=bounds,
+        tilt_offset_deg=tilt_offset_deg,
+        vfov_deg=vfov,
+        zoom=zoom,
+    )
+
+
+def _bound_from_estimate(
+    estimate: HorizonEstimate,
+    reported_tilt: float,
+    zoom: float,
+    spec: CameraSpec,
+    tilt_offset_deg: float,
+) -> float:
+    """Derive the max-up useful tilt from one per-azimuth horizon estimate.
+
+    With the geometric horizon row at the capture tilt being
+    ``H(t0) = cy + f*tan(tilt_offset - t0)``, a detected boundary at row ``r``
+    sits ``d = r - H(t0)`` pixels off the flat horizon (terrain/structures push
+    the boundary above it, so ``d < 0``). The useful bound is the reported tilt
+    that brings that same boundary to the top edge (row 0)::
+
+        tilt_bound = tilt_offset + degrees(atan((cy + d) / f))
+
+    which reduces to :func:`all_ground_tilt_threshold` (``tilt_offset + VFOV/2``)
+    when ``d == 0``. When the boundary is not in frame (all-ground or all-sky
+    detections give no row), the flat geometric threshold is used as a safe
+    fallback.
+    """
+    if estimate.placement is not FramePlacement.IN_FRAME or estimate.row is None:
+        return float(
+            all_ground_tilt_threshold(
+                Unitless(zoom),
+                spec.image_width,
+                spec.image_height,
+                spec.sensor_width,
+                spec.base_focal_length,
+                Degrees(tilt_offset_deg),
+            )
+        )
+
+    intr = compute_intrinsics(
+        Unitless(zoom),
+        spec.image_width,
+        spec.image_height,
+        spec.sensor_width,
+        spec.base_focal_length,
+    )
+    f_px = float(intr.focal_length_px)
+    cy = float(intr.cy)
+    horizon_row = cy + f_px * math.tan(math.radians(tilt_offset_deg - reported_tilt))
+    delta = float(estimate.row) - horizon_row
+    return tilt_offset_deg + math.degrees(math.atan((cy + delta) / f_px))
+
+
+def _decode_snapshot(data: bytes) -> np.ndarray:
+    """Decode JPEG snapshot bytes to an RGB ``numpy`` array for CV refinement."""
+    with Image.open(io.BytesIO(data)) as img:
+        return np.asarray(img.convert("RGB"))

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
     from poc_homography.domain.entities.survey.frame_record import CommandedState
     from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
     from poc_homography.survey.phases.common import PhaseResult, PhaseSink
     from poc_homography.survey.planner.poses import Pose
 
@@ -107,6 +108,11 @@ class SurveyPlan:
     # Phase 9 — validation holdout partition.
     holdout_fraction: float = 0.25
     holdout_seed: int = 261
+
+    # Phase-0 horizon calibration (#275). When set, the main-survey FOV grid
+    # skips sky tiles above the per-azimuth bound; ``None`` reproduces the
+    # pre-horizon behaviour exactly.
+    tilt_envelope: TiltEnvelope | None = None
 
 
 @dataclass(frozen=True)
@@ -305,13 +311,18 @@ def _phase_dir(base: Path, phase: SurveyPhase) -> Path:
 
 
 def _partition_main_grid(spec: CameraSpec, plan: SurveyPlan) -> tuple[list[Pose], list[Pose]]:
-    """Build the main FOV grid and split it into training and holdout sets."""
+    """Build the main FOV grid and split it into training and holdout sets.
+
+    When ``plan.tilt_envelope`` is set (Phase-0 calibration ran), sky tiles
+    above the per-azimuth bound are skipped; otherwise the grid is unchanged.
+    """
     grid = fov_grid(
         spec,
         plan.main_pan_range,
         plan.main_tilt_range,
         plan.main_zoom_levels,
         plan.main_overlap_fraction,
+        tilt_envelope=plan.tilt_envelope,
     )
     training, holdout = partition_holdout(grid, plan.holdout_fraction, plan.holdout_seed)
     return training, holdout

--- a/poc_homography/survey/planner/generators.py
+++ b/poc_homography/survey/planner/generators.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from poc_homography.domain.enums.camera_spec import CameraSpec
+    from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
 
 # Tolerance (in axis units) for including the inclusive endpoint of a range.
 _ENDPOINT_TOLERANCE = 1e-9
@@ -174,6 +175,7 @@ def fov_grid(
     overlap_fraction: float,
     *,
     phase: SurveyPhase = SurveyPhase.MAIN_SURVEY,
+    tilt_envelope: TiltEnvelope | None = None,
 ) -> list[Pose]:
     """Generate a FOV-overlapping pan x tilt grid for each zoom level.
 
@@ -182,6 +184,12 @@ def fov_grid(
     ``overlap_fraction``. Both range endpoints are always covered, and no gap
     between consecutive pan (or tilt) values exceeds one step.
 
+    When a ``tilt_envelope`` is supplied, tiles that point above the per-azimuth
+    max-up useful tilt are skipped (sky tiles): a pose is kept only when its
+    ``tilt >= upper_bound(pan)`` (positive tilt = down, so a smaller tilt points
+    further up). With ``tilt_envelope=None`` the output is byte-for-byte
+    identical to the unconstrained grid.
+
     Args:
         spec: Camera specification.
         pan_range: ``(pan_min, pan_max)`` inclusive bounds.
@@ -189,6 +197,8 @@ def fov_grid(
         zoom_levels: Zoom levels to cover, in order.
         overlap_fraction: Desired fractional overlap in ``[0.0, 1.0)``.
         phase: Phase identity (unused for tagging; documents intent).
+        tilt_envelope: Optional per-azimuth tilt envelope; when present, sky
+            tiles above the per-azimuth bound are omitted.
 
     Returns:
         Flat pose list ordered zoom, then tilt rows, then pan columns.
@@ -201,8 +211,22 @@ def fov_grid(
         tilt_values = _inclusive_values(tilt_range[0], tilt_range[1], float(tilt_step))
         for tilt in tilt_values:
             for pan in pan_values:
+                if _is_sky_tile(tilt, pan, tilt_envelope):
+                    continue
                 poses.append(Pose(pan=Degrees(pan), tilt=Degrees(tilt), zoom=Unitless(zoom)))
     return poses
+
+
+def _is_sky_tile(tilt: float, pan: float, tilt_envelope: TiltEnvelope | None) -> bool:
+    """Return whether ``(pan, tilt)`` points above the per-azimuth useful band.
+
+    With no envelope nothing is sky (preserving unconstrained behaviour). With
+    an envelope, a tile is sky when its tilt is strictly above (numerically
+    below, since positive tilt = down) the interpolated per-azimuth bound.
+    """
+    if tilt_envelope is None:
+        return False
+    return tilt < tilt_envelope.upper_bound(pan) - _ENDPOINT_TOLERANCE
 
 
 def nadir_region(

--- a/tests/domain/test_survey_plan_config.py
+++ b/tests/domain/test_survey_plan_config.py
@@ -11,6 +11,7 @@ from poc_homography.domain.vo.survey_plan_config import (
     PLAN_CONFIG_SCHEMA_VERSION,
     SurveyPlanConfig,
 )
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
 
 
 def _populated() -> SurveyPlanConfig:
@@ -120,6 +121,33 @@ class TestSurveyPlanConfigSchemaVersion:
         data["schema_version"] = "0.9"
         with pytest.raises(ValueError, match="schema_version"):
             SurveyPlanConfig.from_dict(data)
+
+
+class TestSurveyPlanConfigTiltEnvelope:
+    def test_default_envelope_is_none(self) -> None:
+        assert SurveyPlanConfig().tilt_envelope is None
+
+    def test_absent_envelope_round_trips_to_none(self) -> None:
+        cfg = SurveyPlanConfig()
+        assert SurveyPlanConfig.from_dict(cfg.to_dict()).tilt_envelope is None
+
+    def test_legacy_payload_without_key_loads_none(self) -> None:
+        # A pre-#275 payload has no "tilt_envelope" key at all.
+        data = SurveyPlanConfig().to_dict()
+        del data["tilt_envelope"]
+        assert SurveyPlanConfig.from_dict(data).tilt_envelope is None
+
+    def test_populated_envelope_round_trips(self) -> None:
+        env = TiltEnvelope(
+            bounds={0.0: -13.0, 180.0: -16.0}, tilt_offset_deg=-31.0, vfov_deg=36.0, zoom=1.0
+        )
+        cfg = SurveyPlanConfig(tilt_envelope=env)
+        assert SurveyPlanConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_populated_envelope_json_serialisable(self) -> None:
+        env = TiltEnvelope(bounds={0.0: -13.0}, tilt_offset_deg=-31.0, vfov_deg=36.0, zoom=1.0)
+        decoded = json.loads(json.dumps(SurveyPlanConfig(tilt_envelope=env).to_dict()))
+        _assert_all_dict_keys_are_strings(decoded)
 
 
 class TestSurveyPlanConfigYamlReload:

--- a/tests/domain/test_tilt_envelope.py
+++ b/tests/domain/test_tilt_envelope.py
@@ -1,0 +1,106 @@
+"""Tests for the TiltEnvelope VO: defaults, round-trip, schema, interpolation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from poc_homography.domain.vo.tilt_envelope import (
+    TILT_ENVELOPE_SCHEMA_VERSION,
+    TiltEnvelope,
+)
+
+
+def _populated() -> TiltEnvelope:
+    """A non-default envelope with several calibrated azimuths."""
+    return TiltEnvelope(
+        bounds={0.0: -13.0, 90.0: -10.0, 180.0: -16.0, 270.0: -12.0},
+        tilt_offset_deg=-31.0,
+        vfov_deg=36.0,
+        zoom=1.0,
+    )
+
+
+class TestTiltEnvelopeDefaults:
+    def test_constructs_with_no_args(self) -> None:
+        env = TiltEnvelope()
+        assert env.schema_version == "1"
+        assert env.bounds == {}
+        assert env.interpolation == "linear"
+
+    def test_independent_default_bounds(self) -> None:
+        assert TiltEnvelope().bounds is not TiltEnvelope().bounds
+
+
+class TestTiltEnvelopeFrozen:
+    def test_mutate_raises(self) -> None:
+        env = TiltEnvelope()
+        with pytest.raises(AttributeError):
+            env.zoom = 5.0  # type: ignore[misc]
+
+
+class TestTiltEnvelopeRoundTrip:
+    def test_from_dict_to_dict_equals_original(self) -> None:
+        env = _populated()
+        assert TiltEnvelope.from_dict(env.to_dict()) == env
+
+    def test_to_dict_idempotent(self) -> None:
+        env = _populated()
+        restored = TiltEnvelope.from_dict(env.to_dict())
+        assert restored.to_dict() == env.to_dict()
+
+    def test_to_dict_is_json_serialisable_with_string_keys(self) -> None:
+        decoded = json.loads(json.dumps(_populated().to_dict()))
+        assert all(isinstance(k, str) for k in decoded["bounds"])
+
+    def test_yaml_sidecar_round_trip(self, tmp_path) -> None:
+        env = _populated()
+        sidecar = tmp_path / "envelope.yaml"
+        sidecar.write_text(yaml.safe_dump(env.to_dict()))
+        loaded = yaml.safe_load(sidecar.read_text())
+        assert TiltEnvelope.from_dict(loaded) == env
+
+
+class TestTiltEnvelopeSchemaVersion:
+    def test_to_dict_schema_version_is_one(self) -> None:
+        assert _populated().to_dict()["schema_version"] == "1"
+        assert TILT_ENVELOPE_SCHEMA_VERSION == "1"
+
+    def test_unknown_version_raises(self) -> None:
+        data = _populated().to_dict()
+        data["schema_version"] = "0.9"
+        with pytest.raises(ValueError, match="schema_version"):
+            TiltEnvelope.from_dict(data)
+
+
+class TestTiltEnvelopeInterpolation:
+    def test_exact_azimuth_returns_exact_bound(self) -> None:
+        env = _populated()
+        assert env.upper_bound(90.0) == -10.0
+        assert env.upper_bound(180.0) == -16.0
+
+    def test_pan_reduced_modulo_360(self) -> None:
+        env = _populated()
+        assert env.upper_bound(360.0) == env.upper_bound(0.0)
+        assert env.upper_bound(450.0) == env.upper_bound(90.0)
+
+    def test_linear_midpoint_between_two_azimuths(self) -> None:
+        env = _populated()
+        # Halfway between 90° (-10) and 180° (-16) → -13.
+        assert env.upper_bound(135.0) == pytest.approx(-13.0)
+
+    def test_wrap_around_seam_interpolates(self) -> None:
+        env = _populated()
+        # Halfway between 270° (-12) and 0°/360° (-13) → -12.5.
+        assert env.upper_bound(315.0) == pytest.approx(-12.5)
+
+    def test_single_azimuth_is_constant(self) -> None:
+        env = TiltEnvelope(bounds={42.0: -9.0})
+        assert env.upper_bound(0.0) == -9.0
+        assert env.upper_bound(200.0) == -9.0
+
+    def test_empty_envelope_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            TiltEnvelope().upper_bound(0.0)

--- a/tests/survey/test_calibration.py
+++ b/tests/survey/test_calibration.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import io
+import math
 
 import pytest
 from PIL import Image
 
+from poc_homography.camera.intrinsics import compute_intrinsics
 from poc_homography.domain.enums.camera_spec import CameraSpec
 from poc_homography.domain.vo.ptz_state import PTZState
 from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
@@ -14,7 +16,8 @@ from poc_homography.horizon.geometry import (
     DEFAULT_TILT_OFFSET_DEG,
     all_ground_tilt_threshold,
 )
-from poc_homography.survey.calibration import calibrate_horizon_envelope
+from poc_homography.horizon.models import FramePlacement, HorizonEstimate
+from poc_homography.survey.calibration import _bound_from_estimate, calibrate_horizon_envelope
 from poc_homography.types import Degrees, Unitless
 
 SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
@@ -101,3 +104,87 @@ class TestCalibrateHorizonEnvelope:
     def test_pan_reduced_modulo_360(self) -> None:
         env = calibrate_horizon_envelope(_EchoCamera(), pans=[370.0])
         assert set(env.bounds) == {10.0}
+
+    def test_aliasing_azimuths_raise(self) -> None:
+        # 10.0 and 370.0 both reduce to azimuth 10.0 → silent overwrite guarded.
+        with pytest.raises(ValueError, match="duplicate calibration azimuth"):
+            calibrate_horizon_envelope(_EchoCamera(), pans=[10.0, 370.0])
+
+
+class TestBoundFromEstimate:
+    def test_off_center_boundary_is_exact_top_edge_tilt(self) -> None:
+        # The derived bound must place an off-centre detected boundary exactly at
+        # the top edge (row 0), not approximately — exercises the closed form
+        # away from frame centre where a small-angle approximation would drift.
+        zoom = 1.0
+        offset = float(DEFAULT_TILT_OFFSET_DEG)
+        intr = compute_intrinsics(
+            Unitless(zoom),
+            SPEC.image_width,
+            SPEC.image_height,
+            SPEC.sensor_width,
+            SPEC.base_focal_length,
+        )
+        f_px = float(intr.focal_length_px)
+        cy = float(intr.cy)
+        reported_tilt = offset  # aimed at the horizon
+        row = cy - 200.0  # boundary well above centre (terrain/structure)
+        estimate = HorizonEstimate(
+            placement=FramePlacement.IN_FRAME,
+            image_height=int(SPEC.image_height),
+            row=row,
+        )
+
+        bound = _bound_from_estimate(estimate, reported_tilt, zoom, SPEC, offset)
+
+        # The same world boundary's elevation, then its row at the derived tilt.
+        e_feat = (offset - reported_tilt) - math.degrees(math.atan((row - cy) / f_px))
+        row_at_bound = cy + f_px * math.tan(math.radians((offset - bound) - e_feat))
+        assert row_at_bound == pytest.approx(0.0, abs=1e-6)
+
+    def test_centered_boundary_matches_flat_threshold(self) -> None:
+        zoom = 1.0
+        offset = float(DEFAULT_TILT_OFFSET_DEG)
+        intr = compute_intrinsics(
+            Unitless(zoom),
+            SPEC.image_width,
+            SPEC.image_height,
+            SPEC.sensor_width,
+            SPEC.base_focal_length,
+        )
+        cy = float(intr.cy)
+        # Boundary on the flat geometric horizon at the aimed tilt → row == cy.
+        estimate = HorizonEstimate(
+            placement=FramePlacement.IN_FRAME, image_height=int(SPEC.image_height), row=cy
+        )
+        bound = _bound_from_estimate(estimate, offset, zoom, SPEC, offset)
+        flat = float(
+            all_ground_tilt_threshold(
+                Unitless(zoom),
+                SPEC.image_width,
+                SPEC.image_height,
+                SPEC.sensor_width,
+                SPEC.base_focal_length,
+                DEFAULT_TILT_OFFSET_DEG,
+            )
+        )
+        assert bound == pytest.approx(flat, abs=1e-9)
+
+    def test_not_in_frame_falls_back_to_flat_threshold(self) -> None:
+        zoom = 1.0
+        offset = float(DEFAULT_TILT_OFFSET_DEG)
+        estimate = HorizonEstimate(
+            placement=FramePlacement.ABOVE_FRAME, image_height=int(SPEC.image_height), row=None
+        )
+        bound = _bound_from_estimate(estimate, offset, zoom, SPEC, offset)
+        flat = float(
+            all_ground_tilt_threshold(
+                Unitless(zoom),
+                SPEC.image_width,
+                SPEC.image_height,
+                SPEC.sensor_width,
+                SPEC.base_focal_length,
+                DEFAULT_TILT_OFFSET_DEG,
+            )
+        )
+        assert bound == pytest.approx(flat, abs=1e-9)

--- a/tests/survey/test_calibration.py
+++ b/tests/survey/test_calibration.py
@@ -1,0 +1,103 @@
+"""Phase-0 horizon-calibration tests (offline, with a recording FakeCamera)."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.vo.ptz_state import PTZState
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
+from poc_homography.horizon.geometry import (
+    DEFAULT_TILT_OFFSET_DEG,
+    all_ground_tilt_threshold,
+)
+from poc_homography.survey.calibration import calibrate_horizon_envelope
+from poc_homography.types import Degrees, Unitless
+
+SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
+
+
+def _jpeg(width: int, height: int) -> bytes:
+    """Solid JPEG of the given size (CV refinement falls back to geometry)."""
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color=(20, 40, 60)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+class _EchoCamera:
+    """A CameraDevice double that echoes the commanded tilt and records pans."""
+
+    def __init__(self) -> None:
+        self.commanded_pans: list[float] = []
+        self._tilt = 0.0
+
+    def move_absolute(
+        self, pan: float | None = None, tilt: float | None = None, zoom: float | None = None
+    ) -> PTZState:
+        if pan is not None:
+            self.commanded_pans.append(pan)
+        if tilt is not None:
+            self._tilt = tilt
+        return PTZState(
+            pan_raw=Degrees(pan or 0.0),
+            tilt_deg=Degrees(self._tilt),
+            zoom=Unitless(zoom or 1.0),
+            focus=100,
+        )
+
+    def wait_for_stabilization(self, timeout_s: float = 5.0, threshold: float = 0.1) -> PTZState:
+        return PTZState(
+            pan_raw=Degrees(0.0), tilt_deg=Degrees(self._tilt), zoom=Unitless(1.0), focus=100
+        )
+
+    def capture_snapshot(self) -> bytes:
+        return _jpeg(int(SPEC.image_width), int(SPEC.image_height))
+
+
+class TestCalibrateHorizonEnvelope:
+    def test_empty_pans_raises(self) -> None:
+        with pytest.raises(ValueError, match="pan"):
+            calibrate_horizon_envelope(_EchoCamera(), pans=[])
+
+    def test_one_bound_per_pan(self) -> None:
+        camera = _EchoCamera()
+        env = calibrate_horizon_envelope(camera, pans=[0.0, 90.0, 180.0, 270.0])
+        assert isinstance(env, TiltEnvelope)
+        assert set(env.bounds) == {0.0, 90.0, 180.0, 270.0}
+
+    def test_pans_are_commanded(self) -> None:
+        camera = _EchoCamera()
+        calibrate_horizon_envelope(camera, pans=[0.0, 120.0, 240.0])
+        assert camera.commanded_pans == [0.0, 120.0, 240.0]
+
+    def test_envelope_metadata_recorded(self) -> None:
+        env = calibrate_horizon_envelope(_EchoCamera(), pans=[0.0], zoom=1.0)
+        assert env.tilt_offset_deg == float(DEFAULT_TILT_OFFSET_DEG)
+        assert env.vfov_deg > 0.0
+        assert env.zoom == 1.0
+
+    def test_bound_is_sane(self) -> None:
+        # Aimed at the horizon (reported tilt == offset), the detected boundary
+        # sits near frame centre, so the bound lands near the flat all-ground
+        # threshold (tilt_offset + VFOV/2).
+        env = calibrate_horizon_envelope(_EchoCamera(), pans=[0.0], zoom=1.0)
+        flat_threshold = float(
+            all_ground_tilt_threshold(
+                Unitless(1.0),
+                SPEC.image_width,
+                SPEC.image_height,
+                SPEC.sensor_width,
+                SPEC.base_focal_length,
+                DEFAULT_TILT_OFFSET_DEG,
+            )
+        )
+        assert env.bounds[0.0] == pytest.approx(flat_threshold, abs=1.0)
+        # The bound must be a valid, useful (down-ward) tilt above the offset.
+        assert env.tilt_offset_deg < env.bounds[0.0] < env.tilt_offset_deg + env.vfov_deg
+
+    def test_pan_reduced_modulo_360(self) -> None:
+        env = calibrate_horizon_envelope(_EchoCamera(), pans=[370.0])
+        assert set(env.bounds) == {10.0}

--- a/tests/test_planner_grid_envelope.py
+++ b/tests/test_planner_grid_envelope.py
@@ -1,0 +1,60 @@
+"""Horizon-envelope constraint tests for the FOV grid generator."""
+
+from __future__ import annotations
+
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
+from poc_homography.survey.planner import fov_grid
+
+SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
+PAN_RANGE = (0.0, 90.0)
+# Tilt range spans well above and below the bound (positive tilt = down, so the
+# low (negative) end points up at the sky).
+TILT_RANGE = (-30.0, 0.0)
+ZOOM_LEVELS = [2.0, 5.0]
+OVERLAP = 0.2
+
+
+def _envelope() -> TiltEnvelope:
+    """A bound near -13° across the swept pan range (sky below it)."""
+    return TiltEnvelope(
+        bounds={0.0: -13.0, 90.0: -13.0},
+        tilt_offset_deg=-31.0,
+        vfov_deg=36.0,
+        zoom=1.0,
+    )
+
+
+class TestEnvelopeConstrainedGrid:
+    def test_none_envelope_is_byte_for_byte_identical(self) -> None:
+        baseline = fov_grid(SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP)
+        explicit_none = fov_grid(
+            SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP, tilt_envelope=None
+        )
+        assert [p.to_dict() for p in explicit_none] == [p.to_dict() for p in baseline]
+
+    def test_constrained_generates_strictly_fewer_poses(self) -> None:
+        unconstrained = fov_grid(SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP)
+        constrained = fov_grid(
+            SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP, tilt_envelope=_envelope()
+        )
+        assert 0 < len(constrained) < len(unconstrained)
+
+    def test_no_pose_points_above_the_bound(self) -> None:
+        env = _envelope()
+        constrained = fov_grid(SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP, tilt_envelope=env)
+        for pose in constrained:
+            assert pose.tilt >= env.upper_bound(pose.pan) - 1e-6
+
+    def test_constrained_is_subset_of_unconstrained(self) -> None:
+        unconstrained = {
+            (p.pan, p.tilt, p.zoom)
+            for p in fov_grid(SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP)
+        }
+        constrained = {
+            (p.pan, p.tilt, p.zoom)
+            for p in fov_grid(
+                SPEC, PAN_RANGE, TILT_RANGE, ZOOM_LEVELS, OVERLAP, tilt_envelope=_envelope()
+            )
+        }
+        assert constrained.issubset(unconstrained)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -346,3 +346,6 @@ browse_command  # typer survey command (poc_homography/cli/survey.py)
 _.save_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)
 _.load_plan_config  # SurveyRunRepository plan-config contract; consumed by tests + future C3 (poc_homography/domain/protocols/survey_run_repository.py)
 _.detail  # ValidationOutcome human-readable note; injectable-hook contract (poc_homography/horizon/validation.py)
+
+# -- Phase-0 horizon calibration C3 (#275); step-1 entry point consumed by C5/CLI + tests --
+calibrate_horizon_envelope  # Phase-0 calibration step; invoked by operator/CLI + tests (poc_homography/survey/calibration.py)


### PR DESCRIPTION
## Summary

Makes the survey horizon-aware via a 2-step process.

- **Step 1 — Phase-0 calibration** (`calibrate_horizon_envelope`): drives a coarse pan sweep at wide zoom, aims near the predicted horizon, captures a frame, detects the horizon (geometric prediction → optional CV refine → optional vision confirm from child #1), and derives a per-azimuth **max-up useful tilt** envelope plus the confirmed tilt→elevation offset and VFOV(zoom).
- **Step 2 — constrained generation**: `fov_grid` consumes the envelope and emits tiles only within `[upper_bound(pan) … max_down]`, skipping sky tiles. The bound is **linearly interpolated (circular)** between calibrated azimuths.

The envelope is a frozen, JSON-round-trippable `TiltEnvelope` sibling VO. `SurveyPlanConfig` carries it optionally with unchanged `schema_version` semantics; an **absent envelope reproduces current behaviour exactly**. `execute_survey` threads an optional `plan.tilt_envelope` into the main-survey grid so the two steps compose (one invocation, or separate runs sharing the envelope).

Convention throughout: **positive tilt = down** (matching the horizon module). The per-azimuth `tilt_upper_bound` is the upward (sky-ward) limit, i.e. a lower numeric clamp — a useful pose has `tilt >= upper_bound(pan)`.

## Test plan

`poe validate` (lint, format-check, pyright, pylint ≥ 8, vulture) and offline `poe test` both pass (**1113 passed, 148 skipped** — DB/DVC/live gated).

New tests:
- `TiltEnvelope` round-trip + circular linear interpolation (exact, midpoint, wrap-around seam, single-azimuth, modulo-360).
- `SurveyPlanConfig` envelope round-trip + absent-default + legacy-payload-without-key.
- `fov_grid` constrained generates **strictly fewer** poses; `tilt_envelope=None` is **byte-for-byte** identical (regression guard); subset + no-pose-above-bound.
- `calibrate_horizon_envelope` produces a sane envelope with a recording `FakeCamera`.

## Definition of Done

- [x] A horizon-calibration step exists and yields a per-azimuth `tilt_upper_bound` envelope from a coarse pan set.
- [x] `SurveyPlanConfig` (or a documented sibling VO) carries the envelope with round-tripping `to_dict`/`from_dict` and unchanged `schema_version` semantics; absent envelope ⇒ unchanged behavior.
- [x] Pose generators in `generators.py` skip tiles above the per-azimuth bound; a unit test shows a constrained run generates strictly fewer poses (no sky tiles) than the unconstrained run on the same ranges.
- [x] A regression test confirms that with no envelope the generated pose sets are byte-for-byte unchanged.
- [x] `poe validate` and offline `poe test` pass.

Closes #275
