### PR TITLE
feat(survey): MinIO frame uploader + PostgresPhaseSink [#284]

### DIFF
--- a/poc_homography/infrastructure/clients/minio_frame_store.py
+++ b/poc_homography/infrastructure/clients/minio_frame_store.py
@@ -1,0 +1,138 @@
+"""S3 / MinIO object store for survey frame images.
+
+The clean-plate capture writes frame *images* to a MinIO bucket (on maglar's
+k8s-lab MinIO) and frame *metadata* to Postgres (Neon). This module owns the
+image side: a thin S3 client (MinIO speaks the S3 API) that uploads JPEG bytes
+under a deterministic object key and, for the gallery, mints presigned GET URLs.
+
+Config comes from the environment so the same code runs on maglor (capture) and
+in the API (gallery):
+
+- ``MINIO_ENDPOINT``      e.g. ``http://s3.10-121-15-59.sslip.io:9000``
+- ``MINIO_ACCESS_KEY``    MinIO access key
+- ``MINIO_SECRET_KEY``    MinIO secret key
+- ``MINIO_BUCKET``        bucket name (default ``cleanplate-frames``)
+- ``MINIO_REGION``        S3 region label (default ``us-east-1``; MinIO ignores it)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+DEFAULT_BUCKET = "cleanplate-frames"
+DEFAULT_REGION = "us-east-1"
+
+
+@dataclass(frozen=True)
+class PutResult:
+    """Where an uploaded object landed, plus its content hash."""
+
+    bucket: str
+    key: str
+    sha256: str
+
+
+class MinioFrameStore:
+    """Uploads (and presigns) survey frame images in an S3/MinIO bucket."""
+
+    def __init__(
+        self,
+        *,
+        endpoint_url: str,
+        access_key: str,
+        secret_key: str,
+        bucket: str = DEFAULT_BUCKET,
+        region: str = DEFAULT_REGION,
+        client: Any | None = None,
+    ) -> None:
+        """Build the store.
+
+        Args:
+            endpoint_url: MinIO S3 endpoint (scheme + host + port).
+            access_key: MinIO access key.
+            secret_key: MinIO secret key.
+            bucket: Target bucket name.
+            region: S3 region label (MinIO ignores it but boto3 requires one).
+            client: Optional pre-built boto3 S3 client (dependency injection for
+                tests); when given, the credential/endpoint args are unused.
+        """
+        self.bucket = bucket
+        self._client = client or boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=region,
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+        )
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> MinioFrameStore:
+        """Build a store from ``MINIO_*`` environment variables.
+
+        Raises:
+            RuntimeError: If a required variable is missing.
+        """
+        src = env if env is not None else os.environ
+        endpoint = src.get("MINIO_ENDPOINT", "")
+        access = src.get("MINIO_ACCESS_KEY", "")
+        secret = src.get("MINIO_SECRET_KEY", "")
+        missing = [
+            name
+            for name, value in (
+                ("MINIO_ENDPOINT", endpoint),
+                ("MINIO_ACCESS_KEY", access),
+                ("MINIO_SECRET_KEY", secret),
+            )
+            if not value
+        ]
+        if missing:
+            msg = f"MinIO config missing: {', '.join(missing)}"
+            raise RuntimeError(msg)
+        return cls(
+            endpoint_url=endpoint,
+            access_key=access,
+            secret_key=secret,
+            bucket=src.get("MINIO_BUCKET", DEFAULT_BUCKET),
+            region=src.get("MINIO_REGION", DEFAULT_REGION),
+        )
+
+    def ensure_bucket(self) -> None:
+        """Create the bucket if it does not already exist (idempotent)."""
+        try:
+            self._client.head_bucket(Bucket=self.bucket)
+        except ClientError:
+            self._client.create_bucket(Bucket=self.bucket)
+
+    def put_frame(self, data: bytes, key: str, content_type: str = "image/jpeg") -> PutResult:
+        """Upload ``data`` under ``key`` and return its location + sha256."""
+        sha256 = hashlib.sha256(data).hexdigest()
+        self._client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+            Metadata={"sha256": sha256},
+        )
+        return PutResult(bucket=self.bucket, key=key, sha256=sha256)
+
+    def presign_get(self, key: str, expires_in: int = 3600) -> str:
+        """Return a presigned GET URL for ``key`` (used by the gallery)."""
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires_in,
+        )
+
+
+__all__ = ["DEFAULT_BUCKET", "MinioFrameStore", "PutResult"]

--- a/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
@@ -1,0 +1,77 @@
+"""PostgreSQL-backed repository for clean-plate survey frames."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from poc_homography.infrastructure.models.clean_plate_frame import CleanPlateFrameModel
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+class RepoPostgresCleanPlateFrame:
+    """Upsert + read clean-plate frame rows in the ``clean_plate_frames`` table.
+
+    One row per captured ``FrameRecord``: the full record as JSONB plus
+    denormalised indexed projection columns and the MinIO object location of the
+    frame image. ``upsert`` is keyed on the frame id (the per-frame capture id),
+    so re-running a survey is idempotent.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    # Projection columns are denormalised by design (one kwarg per indexed column).
+    def upsert(  # pylint: disable=too-many-arguments,too-many-locals
+        self,
+        *,
+        frame_id: str,
+        run_id: str,
+        camera_id: str,
+        phase: str,
+        pose_id: str,
+        commanded_pan: float,
+        commanded_tilt: float,
+        commanded_zoom: float,
+        burst_id: str | None,
+        frame_index: int,
+        captured_at: datetime,
+        minio_bucket: str,
+        minio_object_key: str,
+        checksum_sha256: str | None,
+        record: dict[str, Any],
+    ) -> bool:
+        """Insert or update one frame row by ``frame_id``. Returns success."""
+        try:
+            row = self._session.get(CleanPlateFrameModel, frame_id)
+            if row is None:
+                row = CleanPlateFrameModel(id=frame_id)
+                self._session.add(row)
+            row.run_id = run_id
+            row.camera_id = camera_id
+            row.phase = phase
+            row.pose_id = pose_id
+            row.commanded_pan = commanded_pan
+            row.commanded_tilt = commanded_tilt
+            row.commanded_zoom = commanded_zoom
+            row.burst_id = burst_id
+            row.frame_index = frame_index
+            row.captured_at = captured_at
+            row.minio_bucket = minio_bucket
+            row.minio_object_key = minio_object_key
+            row.checksum_sha256 = checksum_sha256
+            row.record = record
+            self._session.flush()
+            return True
+        except Exception:
+            logger.exception("Failed to upsert clean-plate frame %s", frame_id)
+            return False
+
+
+__all__ = ["RepoPostgresCleanPlateFrame"]

--- a/poc_homography/infrastructure/survey/postgres_phase_sink.py
+++ b/poc_homography/infrastructure/survey/postgres_phase_sink.py
@@ -1,0 +1,137 @@
+"""Postgres + MinIO :class:`PhaseSink`: frames to MinIO + Neon, lossless.
+
+For every survey frame this sink uploads the image bytes to a MinIO bucket and
+upserts a ``clean_plate_frames`` row (indexed projection columns + the full
+``FrameRecord.to_dict()`` as JSONB + the MinIO object location). The result is
+an always-on, queryable metadata index a gallery reads even while the MinIO host
+(maglor) sleeps.
+
+Inventory and video-burst records (Phase 1 / Phase 8) are not part of the
+clean-plate frame model; they are forwarded to an optional ``fallback`` sink
+(e.g. a :class:`YamlPhaseSink`) when one is supplied, and otherwise logged and
+skipped (never silently dropped).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_clean_plate_frame import (
+    RepoPostgresCleanPlateFrame,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractContextManager
+
+    from sqlalchemy.orm import Session
+
+    from poc_homography.domain.entities.survey.frame_record import FrameRecord
+    from poc_homography.domain.entities.survey.inventory_record import (
+        CameraInventoryRecord,
+    )
+    from poc_homography.domain.entities.survey.video_burst_record import (
+        VideoBurstRecord,
+    )
+    from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
+    from poc_homography.survey.phases.common import PhaseSink
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresPhaseSink:
+    """Persist frames to MinIO (image) + Postgres (metadata).
+
+    Implements the :class:`~poc_homography.survey.phases.common.PhaseSink`
+    protocol structurally.
+    """
+
+    def __init__(
+        self,
+        frame_store: MinioFrameStore,
+        *,
+        session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+        fallback: PhaseSink | None = None,
+    ) -> None:
+        """Build the sink.
+
+        Args:
+            frame_store: MinIO/S3 store the frame images are uploaded to.
+            session_factory: Callable returning a context-managed SQLAlchemy
+                session that commits on exit. Defaults to the app
+                :func:`~poc_homography.infrastructure.database.get_session`.
+                Injectable for tests.
+            fallback: Optional sink that receives inventory/burst records this
+                sink does not model.
+        """
+        self._store = frame_store
+        self._session_factory = session_factory or get_session
+        self._fallback = fallback
+        self._bucket_ready = False
+
+    def save_inventory(self, record: CameraInventoryRecord) -> None:
+        """Forward the Phase 1 inventory record to the fallback sink, or skip."""
+        if self._fallback is not None:
+            self._fallback.save_inventory(record)
+        else:
+            logger.warning(
+                "PostgresPhaseSink does not persist inventory; skipping %s (no fallback)",
+                record.id,
+            )
+
+    def save_frame(self, record: FrameRecord) -> None:
+        """Upload the frame image to MinIO and upsert its metadata row."""
+        if not self._bucket_ready:
+            self._store.ensure_bucket()
+            self._bucket_ready = True
+
+        image_bytes = Path(record.image_data.image_path).read_bytes()
+        key = self._object_key(record)
+        put = self._store.put_frame(image_bytes, key)
+
+        with self._session_factory() as session:
+            repo = RepoPostgresCleanPlateFrame(session)
+            repo.upsert(
+                frame_id=record.id,
+                run_id=record.capture.run_id,
+                camera_id=record.camera.camera_id,
+                phase=record.capture.phase.value,
+                pose_id=record.survey_context.pose_id or "",
+                commanded_pan=float(record.commanded.commanded_pan),
+                commanded_tilt=float(record.commanded.commanded_tilt),
+                commanded_zoom=float(record.commanded.commanded_zoom),
+                burst_id=record.capture.burst_id,
+                frame_index=record.capture.frame_index,
+                captured_at=record.capture.timestamp_at_capture,
+                minio_bucket=put.bucket,
+                minio_object_key=put.key,
+                checksum_sha256=put.sha256,
+                record=record.to_dict(),
+            )
+
+    def save_burst(self, record: VideoBurstRecord) -> None:
+        """Forward the Phase 8 burst record to the fallback sink, or skip."""
+        if self._fallback is not None:
+            self._fallback.save_burst(record)
+        else:
+            logger.warning(
+                "PostgresPhaseSink does not persist video bursts; skipping %s (no fallback)",
+                record.id,
+            )
+
+    @staticmethod
+    def _object_key(record: FrameRecord) -> str:
+        """Deterministic, human-navigable, unique MinIO object key for a frame.
+
+        ``{run_id}/{phase}/{pose_id}/{capture_id}.jpg`` — grouped by run/phase/
+        pose for browsing; the capture id makes it unique and the upload
+        idempotent across re-runs.
+        """
+        pose = record.survey_context.pose_id or "_nopose"
+        return f"{record.capture.run_id}/{record.capture.phase.value}/{pose}/{record.id}.jpg"
+
+
+__all__ = ["PostgresPhaseSink"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "alembic>=1.13",
     "bcrypt>=4.0",
+    "boto3>=1.43.25",
 ]
 
 [project.scripts]

--- a/tests/infrastructure/test_minio_frame_store.py
+++ b/tests/infrastructure/test_minio_frame_store.py
@@ -1,0 +1,99 @@
+"""Unit tests for :class:`MinioFrameStore` (mocked S3 client)."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from botocore.exceptions import ClientError
+
+from poc_homography.infrastructure.clients.minio_frame_store import (
+    DEFAULT_BUCKET,
+    MinioFrameStore,
+)
+
+
+class FakeS3:
+    """Records boto3 S3 client calls; ``head_missing`` makes head_bucket 404."""
+
+    def __init__(self, *, head_missing: bool = False) -> None:
+        self.head_missing = head_missing
+        self.puts: list[dict] = []
+        self.created: list[str] = []
+        self.heads: list[str] = []
+
+    def head_bucket(self, Bucket: str) -> None:
+        self.heads.append(Bucket)
+        if self.head_missing:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadBucket")
+
+    def create_bucket(self, Bucket: str) -> None:
+        self.created.append(Bucket)
+
+    def put_object(self, **kwargs: object) -> None:
+        self.puts.append(kwargs)
+
+    def generate_presigned_url(self, op: str, Params: dict, ExpiresIn: int) -> str:
+        return f"https://minio/{op}/{Params['Bucket']}/{Params['Key']}?e={ExpiresIn}"
+
+
+def _store(client: FakeS3, bucket: str = "cleanplate-frames") -> MinioFrameStore:
+    return MinioFrameStore(
+        endpoint_url="http://minio:9000",
+        access_key="k",
+        secret_key="s",
+        bucket=bucket,
+        client=client,
+    )
+
+
+def test_put_frame_uploads_and_returns_sha256() -> None:
+    client = FakeS3()
+    store = _store(client)
+    data = b"\xff\xd8\xff jpeg bytes"
+
+    result = store.put_frame(data, "run1/main/p1/cap1.jpg")
+
+    assert result.bucket == "cleanplate-frames"
+    assert result.key == "run1/main/p1/cap1.jpg"
+    assert result.sha256 == hashlib.sha256(data).hexdigest()
+    assert len(client.puts) == 1
+    put = client.puts[0]
+    assert put["Bucket"] == "cleanplate-frames"
+    assert put["Key"] == "run1/main/p1/cap1.jpg"
+    assert put["Body"] == data
+    assert put["ContentType"] == "image/jpeg"
+    assert put["Metadata"]["sha256"] == result.sha256
+
+
+def test_ensure_bucket_creates_when_missing() -> None:
+    client = FakeS3(head_missing=True)
+    _store(client).ensure_bucket()
+    assert client.created == ["cleanplate-frames"]
+
+
+def test_ensure_bucket_noop_when_present() -> None:
+    client = FakeS3(head_missing=False)
+    _store(client).ensure_bucket()
+    assert client.created == []
+
+
+def test_presign_get_delegates_to_client() -> None:
+    client = FakeS3()
+    url = _store(client).presign_get("run1/x.jpg", expires_in=120)
+    assert url == "https://minio/get_object/cleanplate-frames/run1/x.jpg?e=120"
+
+
+def test_from_env_reads_minio_vars() -> None:
+    env = {
+        "MINIO_ENDPOINT": "http://minio:9000",
+        "MINIO_ACCESS_KEY": "k",
+        "MINIO_SECRET_KEY": "s",
+    }
+    store = MinioFrameStore.from_env(env)
+    assert store.bucket == DEFAULT_BUCKET
+
+
+def test_from_env_missing_raises() -> None:
+    with pytest.raises(RuntimeError, match="MINIO_ACCESS_KEY"):
+        MinioFrameStore.from_env({"MINIO_ENDPOINT": "http://minio:9000"})

--- a/tests/infrastructure/test_postgres_phase_sink.py
+++ b/tests/infrastructure/test_postgres_phase_sink.py
@@ -1,0 +1,163 @@
+"""Unit tests for :class:`PostgresPhaseSink` (mocked store + session)."""
+
+from __future__ import annotations
+
+import hashlib
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from tests.domain.survey.builders import make_frame_record
+
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.infrastructure.clients.minio_frame_store import PutResult
+from poc_homography.infrastructure.survey.postgres_phase_sink import PostgresPhaseSink
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from poc_homography.infrastructure.models.clean_plate_frame import CleanPlateFrameModel
+
+
+class FakeStore:
+    """Records uploads; returns a real sha256 like the production store."""
+
+    bucket = "cleanplate-frames"
+
+    def __init__(self) -> None:
+        self.ensured = False
+        self.uploads: list[tuple[bytes, str]] = []
+
+    def ensure_bucket(self) -> None:
+        self.ensured = True
+
+    def put_frame(self, data: bytes, key: str, content_type: str = "image/jpeg") -> PutResult:
+        self.uploads.append((data, key))
+        return PutResult(self.bucket, key, hashlib.sha256(data).hexdigest())
+
+
+class FakeSession:
+    """Minimal SQLAlchemy-Session stand-in keyed by primary key."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, CleanPlateFrameModel] = {}
+        self.flushes = 0
+
+    def get(self, _model: type, pk: str) -> CleanPlateFrameModel | None:
+        return self.rows.get(pk)
+
+    def add(self, row: CleanPlateFrameModel) -> None:
+        self.rows[row.id] = row
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+
+def _factory(session: FakeSession):
+    @contextmanager
+    def factory() -> Iterator[FakeSession]:
+        yield session
+
+    return factory
+
+
+def _frame_with_image(tmp_path: Path):
+    img = tmp_path / "cap-0001.jpg"
+    data = b"\xff\xd8\xff floor pixels"
+    img.write_bytes(data)
+    record = make_frame_record(
+        capture_id="cap-0001",
+        run_id="run-42",
+        camera_id="cam04",
+        phase=SurveyPhase.MAIN_SURVEY,
+        frame_index=2,
+        image_path=str(img),
+        with_clean_plate=True,
+    )
+    return record, data
+
+
+def test_save_frame_uploads_and_upserts(tmp_path: Path) -> None:
+    store = FakeStore()
+    session = FakeSession()
+    record, data = _frame_with_image(tmp_path)
+
+    sink = PostgresPhaseSink(store, session_factory=_factory(session))  # type: ignore[arg-type]
+    sink.save_frame(record)
+
+    # image uploaded under the deterministic key
+    assert store.ensured is True
+    assert len(store.uploads) == 1
+    up_data, up_key = store.uploads[0]
+    assert up_data == data
+    assert up_key == "run-42/main_survey/p+0120.0_t-0015.0_z004.00/cap-0001.jpg"
+
+    # row upserted with the right projection columns + linkage
+    row = session.rows["cap-0001"]
+    assert row.run_id == "run-42"
+    assert row.camera_id == "cam04"
+    assert row.phase == "main_survey"
+    assert row.pose_id == "p+0120.0_t-0015.0_z004.00"
+    assert row.frame_index == 2
+    assert row.minio_bucket == "cleanplate-frames"
+    assert row.minio_object_key == up_key
+    assert row.checksum_sha256 == hashlib.sha256(data).hexdigest()
+    # lossless full record in JSONB
+    assert row.record["capture"]["capture_id"] == "cap-0001"
+    assert row.record["schema_version"]
+
+
+def test_save_frame_is_idempotent(tmp_path: Path) -> None:
+    store = FakeStore()
+    session = FakeSession()
+    record, _ = _frame_with_image(tmp_path)
+
+    sink = PostgresPhaseSink(store, session_factory=_factory(session))  # type: ignore[arg-type]
+    sink.save_frame(record)
+    sink.save_frame(record)
+
+    assert len(session.rows) == 1  # same id → updated, not duplicated
+    assert len(store.uploads) == 2  # re-upload to the same key (overwrite)
+
+
+class _RecordingFallback:
+    def __init__(self) -> None:
+        self.inventory: list[object] = []
+        self.bursts: list[object] = []
+
+    def save_inventory(self, record: object) -> None:
+        self.inventory.append(record)
+
+    def save_frame(self, record: object) -> None:  # pragma: no cover - unused
+        raise AssertionError("frames must not go to the fallback")
+
+    def save_burst(self, record: object) -> None:
+        self.bursts.append(record)
+
+
+def test_inventory_and_burst_forwarded_to_fallback(tmp_path: Path) -> None:
+    store = FakeStore()
+    session = FakeSession()
+    fallback = _RecordingFallback()
+    sink = PostgresPhaseSink(
+        store,
+        session_factory=_factory(session),  # type: ignore[arg-type]
+        fallback=fallback,
+    )
+
+    sentinel_inv = object()
+    sentinel_burst = object()
+    sink.save_inventory(sentinel_inv)  # type: ignore[arg-type]
+    sink.save_burst(sentinel_burst)  # type: ignore[arg-type]
+
+    assert fallback.inventory == [sentinel_inv]
+    assert fallback.bursts == [sentinel_burst]
+
+
+def test_inventory_without_fallback_is_skipped_not_raised() -> None:
+    class _Rec:
+        id = "inv-1"
+
+    sink = PostgresPhaseSink(FakeStore())  # type: ignore[arg-type]
+    # no fallback → logged + skipped, must not raise
+    sink.save_inventory(_Rec())  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -397,6 +397,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d0/9154ca8bd6051a55102a5c8bb077b15959681a5f4dcf614a423afaefdf83/boto3-1.43.25.tar.gz", hash = "sha256:91f3deb0dfc32403a187f57c19a78dc8e38d25ee2967a511fa8905acf00cc074", size = 113169, upload-time = "2026-06-08T19:49:27.877Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/89/d27be8bb3dc72a6d1d1d8f9e039e89ae86827c05c47385d78a1d964571f4/boto3-1.43.25-py3-none-any.whl", hash = "sha256:e4e2515533a1593eb2302e9eda5baf4e1510abb219b41dd0db4696cc21bc5039", size = 140538, upload-time = "2026-06-08T19:49:25.427Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/03/9dc102506c3ebc3758a9e8602e7dafb78789993bcac5daa82398b56ae884/botocore-1.43.25.tar.gz", hash = "sha256:faab543ca6ae6f8fdc5f6318240bebfb8c05cd25823715fe02aad7edf0c4b383", size = 15478403, upload-time = "2026-06-08T19:49:13.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/a5/6ceef332b18c348be9ec26aeff0da5b3f7ea046bf3fc654feecf6974c4d9/botocore-1.43.25-py3-none-any.whl", hash = "sha256:ef1d210ac9085ea0e5fc6ad2e63f0c7e97103c74f52156bf944289aaf6278d1b", size = 15161721, upload-time = "2026-06-08T19:49:08.751Z" },
+]
+
+[[package]]
 name = "celery"
 version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1917,6 +1945,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2888,6 +2925,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
+    { name = "boto3" },
     { name = "defusedxml" },
     { name = "django", version = "5.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2940,6 +2978,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "bcrypt", specifier = ">=4.0" },
+    { name = "boto3", specifier = ">=1.43.25" },
     { name = "defusedxml", specifier = ">=0.7" },
     { name = "django", specifier = ">=5.0" },
     { name = "dvc", extras = ["gdrive"], specifier = ">=3.50" },
@@ -4182,6 +4221,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/02/bb3ff8b6e6d02ce9e3740f4c17dfbbfb55f34c789c139e9cd91985f356c7/ruff-0.14.11-py3-none-win32.whl", hash = "sha256:337c5dd11f16ee52ae217757d9b82a26400be7efac883e9e852646f1557ed841", size = 12851094, upload-time = "2026-01-08T19:11:45.163Z" },
     { url = "https://files.pythonhosted.org/packages/58/f1/90ddc533918d3a2ad628bc3044cdfc094949e6d4b929220c3f0eb8a1c998/ruff-0.14.11-py3-none-win_amd64.whl", hash = "sha256:f981cea63d08456b2c070e64b79cb62f951aa1305282974d4d5216e6e0178ae6", size = 14001379, upload-time = "2026-01-08T19:11:52.591Z" },
     { url = "https://files.pythonhosted.org/packages/c4/1c/1dbe51782c0e1e9cfce1d1004752672d2d4629ea46945d19d731ad772b3b/ruff-0.14.11-py3-none-win_arm64.whl", hash = "sha256:649fb6c9edd7f751db276ef42df1f3df41c38d67d199570ae2a7bd6cbc3590f0", size = 12938644, upload-time = "2026-01-08T19:11:50.027Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -372,3 +372,7 @@ synth_command  # typer cleanplate command (poc_homography/cli/cleanplate.py)
 _.minio_bucket  # CleanPlateFrameModel MinIO bucket column (poc_homography/infrastructure/models/clean_plate_frame.py)
 _.minio_object_key  # CleanPlateFrameModel MinIO object-key column (poc_homography/infrastructure/models/clean_plate_frame.py)
 _.checksum_sha256  # CleanPlateFrameModel image content-hash column (poc_homography/infrastructure/models/clean_plate_frame.py)
+
+# -- MinIO frame store (#284); entry points consumed by capture wiring + gallery (#285) --
+_.from_env  # MinioFrameStore env constructor; used by the maglor capture script (poc_homography/infrastructure/clients/minio_frame_store.py)
+_.presign_get  # MinioFrameStore presigned-GET URL minting; consumed by the gallery API (#285) (poc_homography/infrastructure/clients/minio_frame_store.py)


### PR DESCRIPTION
Part of #284. Part of epic #286. Depends on #283 (merged — `clean_plate_frames` table).

## What

The library to send clean-plate frames to **MinIO** (image) + **Neon** (metadata), replacing the disk+YAML path:

- **`MinioFrameStore`** — thin S3 client (MinIO speaks the S3 API): `put_frame` → `(bucket, key, sha256)`, `ensure_bucket`, `presign_get` (for the gallery), `from_env` (`MINIO_*`). Adds `boto3`.
- **`RepoPostgresCleanPlateFrame`** — idempotent `upsert` of `clean_plate_frames` rows (indexed projection columns + full `FrameRecord` JSONB + MinIO object location).
- **`PostgresPhaseSink`** (`PhaseSink`) — per frame: uploads the image under `{run_id}/{phase}/{pose_id}/{capture_id}.jpg` and upserts the metadata row. Inventory/burst records (not part of the clean-plate frame model) are forwarded to an optional `fallback` sink, otherwise logged + skipped (never silently dropped).

## Tests

`test_minio_frame_store.py` + `test_postgres_phase_sink.py` (mocked S3 + session): upload+upsert, idempotency, fallback routing, sha256, `from_env` validation. `poe validate` ✅ · `pytest tests/infrastructure tests/survey tests/domain/survey` → 202 passed.

## Not in this PR (tracked under #284)

Wiring the maglor capture script (`run_cleanplate_capture_cam04.py`) onto `PostgresPhaseSink` (+ `YamlPhaseSink` fallback) and the **live e2e verification** (JPEGs in MinIO `cleanplate-frames` + rows in Neon `clean_plate_frames`) — done out-of-band when maglor is awake. #284 stays open until that's verified.