### PR TITLE
ci: enable Dependabot alerts and updates [#26]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Python dependencies (pyproject.toml + uv.lock)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # SPA frontend dependencies (spa/package.json)
+  - package-ecosystem: "npm"
+    directory: "/spa"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Container base image (Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions workflow dependencies (.github/workflows/)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
Enables Dependabot Alerts and Updates for the repository (closes #26).

- Adds `.github/dependabot.yml` configuring **weekly** version updates for all four detected ecosystems, each capped at **5** open PRs:
  - `pip` at `/` (pyproject.toml + uv.lock)
  - `npm` at `/spa` (spa/package.json)
  - `docker` at `/` (Dockerfile)
  - `github-actions` at `/` (.github/workflows/)
- Dependabot **security alerts** enabled via `PUT /repos/.../vulnerability-alerts` (GET now returns HTTP 204).
- Dependabot **automated security fixes** enabled via `PUT /repos/.../automated-security-fixes`.

## Test Plan
- `dependabot.yml` parses as valid YAML (version 2, 4 ecosystems).
- `GET vulnerability-alerts` → HTTP 204 (enabled).
- GitHub validates the config against the default branch after merge; first scan runs automatically.

## Definition of Done
- [x] Dependabot alerts enabled for repository (API returns 204)
- [x] `.github/dependabot.yml` exists with valid configuration
- [x] Package ecosystems detected and configured: pip, npm, docker, github-actions
- [x] Update schedule set to weekly
- [x] Open pull request limit set to 5