### PR TITLE
fix(test): skip degenerate identity-homography case in steep-tilt projection test [#282]

### DIFF
--- a/tests/homography/test_planar_synthetic.py
+++ b/tests/homography/test_planar_synthetic.py
@@ -296,6 +296,18 @@ class TestHomographySyntheticProjection:
         H = result.homography_matrix
         assert H.shape == (3, 3), f"Homography must be 3x3, got {H.shape}"
 
+        # Skip degenerate configurations where the world origin lies on the
+        # camera horizon (z_cam approx 0). In that case the raw homography has
+        # H[2, 2] approx 0 and _calculate_ground_homography_static falls back to
+        # the identity matrix (see camera_geometry.py), so project_via_homography
+        # returns the raw world XY rather than a true pixel projection. This is
+        # intended degenerate-geometry handling, not a projection error, and the
+        # sibling IEH test below applies the same guard. Without it, hypothesis
+        # can latently generate such a steep-tilt example (e.g. pos=[0, 2, 2],
+        # tilt=45) that fails non-deterministically once cached (issue #282).
+        if np.allclose(H, np.eye(3)):
+            return
+
         # Compute rotation matrix independently
         R = compute_rotation_matrix(pan_deg, tilt_deg)
 


### PR DESCRIPTION
## Summary

test_homography_matches_3d_projection_camera_geometry had a latent failing example at steep camera tilt where the world origin lies on the camera horizon (z_cam approx 0). In that degenerate case CameraGeometry._calculate_ground_homography_static intentionally falls back to the identity matrix, so project_via_homography returns the raw world XY instead of a true pixel projection, yielding a ~500px diff. hypothesis rarely generates this example on a fresh-DB CI run but reproduces deterministically once cached. Fix adds the same np.allclose(H, np.eye(3)) skip-guard that the sibling IEH test already uses. Root cause is test robustness, not a projection bug: the identity fallback is documented degenerate-geometry handling, so no production math changed.

## Test plan

Reproduced exact issue example (pos=[0,2,2], pan=0, tilt=45): confirmed H is identity and pre-guard pixel_diff=5.00e+02 (matches issue). Guard now triggers early return. Ran: uv run pytest tests/homography/test_planar_synthetic.py -> 10 passed. poe validate -> EXIT 0. Offline full suite (excl live_camera/integration) -> 1197 passed, 51 skipped, 0 failed.

## Closes DoD bullets

- The test passes deterministically with a populated .hypothesis cache (no steep-tilt false failure).
- The root cause (test-robustness vs. project_via_homography degenerate passthrough) is stated with evidence in the PR.
- poe validate and offline poe test pass.
