### PR TITLE
feat(camera): add camera registry module with TTL cache + per-camera credentials [#203]

### DIFF
--- a/poc_homography/camera_config.py
+++ b/poc_homography/camera_config.py
@@ -492,13 +492,18 @@ def get_cameras_for_tenant(tenant_id: str) -> list:
     """
     Get all cameras belonging to a tenant.
 
+    Reads from the database-backed :class:`CameraRegistry` cache, falling back
+    to the hardcoded ``CAMERAS`` list when the database is unavailable.
+
     Args:
         tenant_id: ID of the tenant
 
     Returns:
         List of camera configuration dicts for the tenant
     """
-    return [cam for cam in CAMERAS if cam.get("tenant_id") == tenant_id]
+    from poc_homography.camera_registry import get_registry
+
+    return get_registry().get_cameras_for_tenant(tenant_id)
 
 
 def get_tenant_credentials(tenant_id: str) -> tuple[str | None, str | None]:
@@ -534,13 +539,22 @@ def get_camera_configs() -> list:
         List of camera configuration dicts containing camera parameters,
         GPS coordinates, and calibration data. Does not require credentials
         and does not generate RTSP URLs.
+
+    Reads from the database-backed :class:`CameraRegistry` cache, falling back
+    to the hardcoded ``CAMERAS`` list when the database is unavailable.
     """
-    return CAMERAS
+    from poc_homography.camera_registry import get_registry
+
+    return get_registry().get_all_cameras()
 
 
 def get_camera_by_id(camera_id: str) -> dict | None:
     """
     Find camera configuration by ID.
+
+    Reads from the database-backed :class:`CameraRegistry` cache, falling back
+    to the hardcoded ``CAMERAS`` list when the database is unavailable or the
+    camera is absent from the database.
 
     Args:
         camera_id: Full camera ID (e.g., "valte_cam01", "setram_cam01")
@@ -548,7 +562,9 @@ def get_camera_by_id(camera_id: str) -> dict | None:
     Returns:
         Camera configuration dict or None if not found
     """
-    return next((cam for cam in CAMERAS if cam.get("id") == camera_id), None)
+    from poc_homography.camera_registry import get_registry
+
+    return get_registry().get_camera_by_id(camera_id)
 
 
 def get_camera_by_name(camera_name: str) -> dict | None:
@@ -585,8 +601,11 @@ def get_rtsp_url(camera_name: str, stream_type: str = "main") -> str | None:
     """
     Get RTSP URL for a camera.
 
-    Uses tenant-specific credentials if available, otherwise falls back to
-    global CAMERA_USERNAME/CAMERA_PASSWORD environment variables.
+    Prefers per-camera credentials stored in the database (surfaced as
+    ``username`` / ``password`` on the camera dict via :class:`CameraRegistry`).
+    When the camera has no per-camera credentials (fallback mode), uses
+    tenant-specific credentials, otherwise falls back to global
+    CAMERA_USERNAME/CAMERA_PASSWORD environment variables.
 
     Args:
         camera_name: Name or ID of the camera
@@ -602,9 +621,14 @@ def get_rtsp_url(camera_name: str, stream_type: str = "main") -> str | None:
     if not cam:
         return None
 
-    # Get tenant-specific credentials (falls back to global)
     tenant_id = cam.get("tenant_id") or ""
-    username, password = get_tenant_credentials(tenant_id)
+
+    # Prefer per-camera credentials from the database; fall back to
+    # tenant-level credentials (which themselves fall back to the globals).
+    username = cam.get("username")
+    password = cam.get("password")
+    if not username or not password:
+        username, password = get_tenant_credentials(tenant_id)
 
     # Validate that credentials are set
     if not username or not password:

--- a/poc_homography/camera_registry.py
+++ b/poc_homography/camera_registry.py
@@ -128,7 +128,12 @@ class CameraRegistry:
         return cls._instance
 
     def _init_state(self) -> None:
+        # ``_lock`` guards the in-memory cache (held only for microseconds).
+        # ``_refresh_lock`` serialises database refreshes so the (slow) DB load
+        # never runs while ``_lock`` is held — readers are not blocked behind a
+        # network round-trip, and at most one thread queries the DB per refresh.
         self._lock = threading.RLock()
+        self._refresh_lock = threading.Lock()
         self._cameras: dict[str, dict[str, Any]] = {}
         self._last_loaded: float | None = None
         self._ttl: int = _resolve_ttl()
@@ -154,10 +159,13 @@ class CameraRegistry:
 
             with get_session() as session:
                 entities = RepoPostgresCameraConfig(session).get_all()
-        except Exception:
+        except Exception as exc:
+            # Log only the exception *type*, never the traceback or message:
+            # SQLAlchemy/psycopg connection errors can embed DATABASE_URL
+            # (user:password@host) in their text.
             logger.warning(
-                "Camera database query failed; falling back to hardcoded CAMERAS",
-                exc_info=True,
+                "Camera database query failed (%s); falling back to hardcoded CAMERAS",
+                type(exc).__name__,
             )
             return None
 
@@ -194,16 +202,32 @@ class CameraRegistry:
             cameras[cam_id] = {**base, **overlay}
         return cameras
 
-    def _refresh_locked(self) -> None:
-        """Reload the cache. Must be called while holding ``self._lock``."""
-        self._ttl = _resolve_ttl()
-        self._cameras = self._build_cameras()
-        self._last_loaded = _now()
-
     def _ensure_fresh(self) -> None:
+        """Refresh the cache if the TTL has lapsed, without blocking readers.
+
+        The database load runs *outside* ``self._lock`` so concurrent reads are
+        never stalled behind a network round-trip. ``self._refresh_lock``
+        ensures only one thread performs the load per refresh; the result is
+        swapped in under ``self._lock`` (a microsecond-scale critical section).
+        """
         with self._lock:
-            if self._is_expired():
-                self._refresh_locked()
+            if not self._is_expired():
+                return
+
+        with self._refresh_lock:
+            # Re-check: another thread may have refreshed while we waited.
+            with self._lock:
+                if not self._is_expired():
+                    return
+
+            ttl = _resolve_ttl()
+            cameras = self._build_cameras()  # DB I/O — no cache lock held
+            now = _now()
+
+            with self._lock:
+                self._ttl = ttl
+                self._cameras = cameras
+                self._last_loaded = now
 
     # -- public API -------------------------------------------------------
 
@@ -216,19 +240,14 @@ class CameraRegistry:
     def get_camera_by_id(self, camera_id: str) -> dict[str, Any] | None:
         """Return a single camera by id, or ``None`` if unknown.
 
-        Falls back to the hardcoded ``CAMERAS`` list for that camera if it is
-        not present in the (database-backed) cache.
+        The cache is always seeded from the hardcoded ``CAMERAS`` list (then
+        overlaid with database data), so a camera absent from the database is
+        still served from its hardcoded entry — no separate fallback is needed.
         """
         self._ensure_fresh()
         with self._lock:
             cam = self._cameras.get(camera_id)
-            if cam is not None:
-                return dict(cam)
-        # Per-camera fallback: camera absent from the cache entirely.
-        for cam in _hardcoded_cameras():
-            if cam.get("id") == camera_id:
-                return dict(cam)
-        return None
+            return dict(cam) if cam is not None else None
 
     def get_cameras_for_tenant(self, tenant_id: str) -> list[dict[str, Any]]:
         """Return all cameras belonging to ``tenant_id``."""

--- a/poc_homography/camera_registry.py
+++ b/poc_homography/camera_registry.py
@@ -136,7 +136,10 @@ class CameraRegistry:
         self._refresh_lock = threading.Lock()
         self._cameras: dict[str, dict[str, Any]] = {}
         self._last_loaded: float | None = None
-        self._ttl: int = _resolve_ttl()
+        # Placeholder until the first refresh resolves the real TTL; never used
+        # for an expiry decision (the initial cache is always expired because
+        # ``_last_loaded`` is None).
+        self._ttl: int = DEFAULT_CACHE_TTL
 
     # -- internal helpers -------------------------------------------------
 

--- a/poc_homography/camera_registry.py
+++ b/poc_homography/camera_registry.py
@@ -1,0 +1,263 @@
+"""TTL-cached camera registry.
+
+Bridges the PostgreSQL ``CameraConfig`` store (Neon) and the hardcoded
+``camera_config.CAMERAS`` fallback so that existing callers transparently get
+database-backed camera data without code changes.
+
+Design notes
+------------
+* The PostgreSQL ``camera_configs`` table (see
+  :class:`poc_homography.infrastructure.models.camera_config.CameraConfigModel`)
+  stores only *registration* data: ``id``, ``tenant_id``, ``map_id``, ``name``,
+  ``spec``, ``credential`` (``{username, password}``) and ``ip_address``.  It does
+  **not** store the rich calibration parameters (``k1``, ``k2``,
+  ``pan_offset_deg``, ``geotiff_params``, ``sensor_width_mm`` …) that homography
+  and calibration consumers rely on.  Those still live in the hardcoded
+  ``CAMERAS`` list.
+
+  To satisfy both "read from the database" and "no changes in the 19 importers",
+  the registry **merges** the database base fields (ip, credentials, name) onto
+  the hardcoded calibration template for the matching camera ``id``.  Cameras
+  absent from the database fall back to their hardcoded entry verbatim.
+
+* If the database is unavailable (``DATABASE_URL`` unset, connection error, empty
+  result set) the registry falls back to the hardcoded ``CAMERAS`` / tenant data.
+
+* Access is thread-safe and the cache honours a TTL configured via the
+  ``CAMERA_CACHE_TTL`` environment variable (seconds, default 300).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.camera_config import CameraConfig
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_TTL = 300
+
+
+def _now() -> float:
+    """Monotonic clock used for TTL accounting.
+
+    Indirected through a module-level function so tests can monkeypatch it.
+    """
+    return time.monotonic()
+
+
+def _resolve_ttl() -> int:
+    """Resolve the cache TTL from ``CAMERA_CACHE_TTL`` (default 300 seconds)."""
+    raw = os.getenv("CAMERA_CACHE_TTL")
+    if raw is None or raw == "":
+        return DEFAULT_CACHE_TTL
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid CAMERA_CACHE_TTL=%r; falling back to default %d seconds",
+            raw,
+            DEFAULT_CACHE_TTL,
+        )
+        return DEFAULT_CACHE_TTL
+
+
+def _spec_model_name(spec: Any) -> str:
+    """Best-effort human-readable model name for a ``CameraSpec`` enum member."""
+    return getattr(spec, "model_name", None) or getattr(spec, "name", str(spec))
+
+
+def _entity_to_camera_dict(entity: CameraConfig) -> dict[str, Any]:
+    """Transform a ``CameraConfig`` entity into a legacy camera dict.
+
+    Maps database field names to the keys used by the hardcoded ``CAMERAS``
+    list (``ip_address`` -> ``ip``) and flattens the credential value object
+    into per-camera ``username`` / ``password`` fields.
+    """
+    credential = entity.credential
+    return {
+        "id": entity.id,
+        "tenant_id": entity.tenant_id,
+        "map_id": entity.map_id,
+        "name": entity.name,
+        "ip": entity.ip_address,
+        "username": credential.username,
+        "password": credential.password,
+        "model": _spec_model_name(entity.spec),
+    }
+
+
+def _hardcoded_cameras() -> list[dict[str, Any]]:
+    """Hardcoded fallback cameras (lazy import to avoid an import cycle)."""
+    from poc_homography.camera_config import CAMERAS
+
+    return CAMERAS
+
+
+class CameraRegistry:
+    """Singleton TTL cache over camera registration data.
+
+    The cache stores::
+
+        {
+            "cameras": {camera_id: camera_dict, ...},
+            "last_loaded": <monotonic timestamp or None>,
+            "ttl": <seconds>,
+        }
+
+    Tenant data is intentionally out of scope: ``camera_config`` already loads
+    tenants from a dynamic source (the DDD YAML repository) with env-injected
+    credentials, so it does not need this cache.
+    """
+
+    _instance: CameraRegistry | None = None
+    _singleton_lock = threading.Lock()
+
+    def __new__(cls) -> CameraRegistry:
+        if cls._instance is None:
+            with cls._singleton_lock:
+                if cls._instance is None:
+                    instance = super().__new__(cls)
+                    instance._init_state()
+                    cls._instance = instance
+        return cls._instance
+
+    def _init_state(self) -> None:
+        self._lock = threading.RLock()
+        self._cameras: dict[str, dict[str, Any]] = {}
+        self._last_loaded: float | None = None
+        self._ttl: int = _resolve_ttl()
+
+    # -- internal helpers -------------------------------------------------
+
+    def _is_expired(self) -> bool:
+        if self._last_loaded is None:
+            return True
+        return (_now() - self._last_loaded) >= self._ttl
+
+    def _load_from_database(self) -> list[dict[str, Any]] | None:
+        """Load cameras from PostgreSQL.
+
+        Returns a list of camera dicts on success, or ``None`` when the database
+        is unavailable / returns no rows (signalling the caller to fall back).
+        """
+        try:
+            from poc_homography.infrastructure.database import get_session
+            from poc_homography.infrastructure.repositories import (
+                RepoPostgresCameraConfig,
+            )
+
+            with get_session() as session:
+                entities = RepoPostgresCameraConfig(session).get_all()
+        except Exception:
+            logger.warning(
+                "Camera database query failed; falling back to hardcoded CAMERAS",
+                exc_info=True,
+            )
+            return None
+
+        if not entities:
+            logger.info("Camera database returned no rows; falling back to hardcoded CAMERAS")
+            return None
+
+        return [_entity_to_camera_dict(e) for e in entities]
+
+    def _build_cameras(self) -> dict[str, dict[str, Any]]:
+        """Build the camera cache, merging DB data over hardcoded calibration.
+
+        Starts from the hardcoded ``CAMERAS`` (preserving calibration fields),
+        then overlays the non-empty database fields for each matching camera id.
+        Cameras present only in the database are added; cameras present only in
+        the hardcoded list are kept as-is.
+        """
+        cameras: dict[str, dict[str, Any]] = {
+            cam["id"]: dict(cam) for cam in _hardcoded_cameras() if cam.get("id")
+        }
+
+        db_cameras = self._load_from_database()
+        if db_cameras is None:
+            return cameras
+
+        for db_cam in db_cameras:
+            cam_id = db_cam.get("id")
+            if not cam_id:
+                continue
+            # Only overlay non-None DB values so a NULL ip_address does not wipe
+            # the hardcoded calibration template's ip.
+            overlay = {k: v for k, v in db_cam.items() if v is not None}
+            base = cameras.get(cam_id, {})
+            cameras[cam_id] = {**base, **overlay}
+        return cameras
+
+    def _refresh_locked(self) -> None:
+        """Reload the cache. Must be called while holding ``self._lock``."""
+        self._ttl = _resolve_ttl()
+        self._cameras = self._build_cameras()
+        self._last_loaded = _now()
+
+    def _ensure_fresh(self) -> None:
+        with self._lock:
+            if self._is_expired():
+                self._refresh_locked()
+
+    # -- public API -------------------------------------------------------
+
+    def get_all_cameras(self) -> list[dict[str, Any]]:
+        """Return all cameras (database-backed where available)."""
+        self._ensure_fresh()
+        with self._lock:
+            return [dict(cam) for cam in self._cameras.values()]
+
+    def get_camera_by_id(self, camera_id: str) -> dict[str, Any] | None:
+        """Return a single camera by id, or ``None`` if unknown.
+
+        Falls back to the hardcoded ``CAMERAS`` list for that camera if it is
+        not present in the (database-backed) cache.
+        """
+        self._ensure_fresh()
+        with self._lock:
+            cam = self._cameras.get(camera_id)
+            if cam is not None:
+                return dict(cam)
+        # Per-camera fallback: camera absent from the cache entirely.
+        for cam in _hardcoded_cameras():
+            if cam.get("id") == camera_id:
+                return dict(cam)
+        return None
+
+    def get_cameras_for_tenant(self, tenant_id: str) -> list[dict[str, Any]]:
+        """Return all cameras belonging to ``tenant_id``."""
+        self._ensure_fresh()
+        with self._lock:
+            return [
+                dict(cam) for cam in self._cameras.values() if cam.get("tenant_id") == tenant_id
+            ]
+
+    def invalidate(self) -> None:
+        """Clear the cache and reset the load timestamp (thread-safe)."""
+        with self._lock:
+            self._cameras = {}
+            self._last_loaded = None
+
+
+def get_registry() -> CameraRegistry:
+    """Return the process-wide :class:`CameraRegistry` singleton."""
+    return CameraRegistry()
+
+
+def invalidate_cache() -> None:
+    """Invalidate the camera registry cache.
+
+    The next access after invalidation triggers a fresh database query.
+    Intended for administrative actions (e.g. after rotating credentials or
+    updating a camera's IP address in the database).
+    """
+    get_registry().invalidate()
+
+
+__all__ = ["CameraRegistry", "get_registry", "invalidate_cache"]

--- a/tests/test_camera_registry.py
+++ b/tests/test_camera_registry.py
@@ -1,0 +1,293 @@
+"""Unit tests for :mod:`poc_homography.camera_registry`.
+
+Covers TTL cache behaviour (hit / miss / expiry), database fallback, per-camera
+fallback, calibration merge, cache invalidation, credential mapping and thread
+safety. The database layer is mocked throughout — these tests never touch a real
+PostgreSQL connection.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from poc_homography import camera_registry
+from poc_homography.camera_registry import (
+    CameraRegistry,
+    _entity_to_camera_dict,
+    _resolve_ttl,
+    get_registry,
+    invalidate_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Reset the process-wide singleton around every test."""
+    CameraRegistry._instance = None
+    yield
+    CameraRegistry._instance = None
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Controllable monotonic clock for TTL tests."""
+    state = {"t": 1000.0}
+    monkeypatch.setattr(camera_registry, "_now", lambda: state["t"])
+    return state
+
+
+def _fresh_registry(monkeypatch, *, db_cameras, ttl="300"):
+    """Build a registry whose DB load returns ``db_cameras`` and count loads.
+
+    ``db_cameras`` may be a list (rows), ``None`` (DB unavailable / empty), or a
+    callable returning one of those.
+    """
+    monkeypatch.setenv("CAMERA_CACHE_TTL", ttl)
+    reg = get_registry()
+    calls = {"n": 0}
+
+    def fake_load():
+        calls["n"] += 1
+        return db_cameras() if callable(db_cameras) else db_cameras
+
+    monkeypatch.setattr(reg, "_load_from_database", fake_load)
+    return reg, calls
+
+
+# --------------------------------------------------------------------------- #
+# TTL resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_ttl_default(monkeypatch):
+    monkeypatch.delenv("CAMERA_CACHE_TTL", raising=False)
+    assert _resolve_ttl() == 300
+
+
+def test_resolve_ttl_from_env(monkeypatch):
+    monkeypatch.setenv("CAMERA_CACHE_TTL", "42")
+    assert _resolve_ttl() == 42
+
+
+def test_resolve_ttl_invalid_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("CAMERA_CACHE_TTL", "not-a-number")
+    assert _resolve_ttl() == 300
+
+
+# --------------------------------------------------------------------------- #
+# Cache hit / miss / TTL expiry
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_miss_triggers_load(monkeypatch, clock):
+    reg, calls = _fresh_registry(monkeypatch, db_cameras=None)
+    reg.get_all_cameras()
+    assert calls["n"] == 1
+
+
+def test_cache_hit_does_not_reload(monkeypatch, clock):
+    reg, calls = _fresh_registry(monkeypatch, db_cameras=None)
+    reg.get_all_cameras()
+    reg.get_all_cameras()
+    reg.get_camera_by_id("valte_cam01")
+    assert calls["n"] == 1
+
+
+def test_ttl_expiry_triggers_reload(monkeypatch, clock):
+    reg, calls = _fresh_registry(monkeypatch, db_cameras=None, ttl="300")
+    reg.get_all_cameras()
+    assert calls["n"] == 1
+    clock["t"] += 299  # still fresh
+    reg.get_all_cameras()
+    assert calls["n"] == 1
+    clock["t"] += 2  # now 301s elapsed, expired
+    reg.get_all_cameras()
+    assert calls["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Fallback behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_db_unavailable_falls_back_to_hardcoded(monkeypatch, clock):
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=None)
+    cams = reg.get_all_cameras()
+    ids = {c["id"] for c in cams}
+    assert "valte_cam01" in ids
+    # Calibration fields preserved from the hardcoded list.
+    assert "k1" in reg.get_camera_by_id("valte_cam01")
+
+
+def test_empty_db_result_falls_back_to_hardcoded(monkeypatch, clock):
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=[])
+    # An explicit empty list from _load_from_database means "no overlay";
+    # hardcoded cameras remain.
+    assert reg.get_camera_by_id("valte_cam01") is not None
+
+
+def test_load_from_database_returns_none_on_exception(monkeypatch):
+    """The real loader swallows DB errors and signals fallback via None."""
+
+    def boom():
+        raise RuntimeError("DATABASE_URL not set")
+
+    import poc_homography.infrastructure.database as db
+
+    monkeypatch.setattr(db, "get_session", boom)
+    reg = get_registry()
+    assert reg._load_from_database() is None
+
+
+# --------------------------------------------------------------------------- #
+# DB overlay / calibration merge
+# --------------------------------------------------------------------------- #
+
+
+def test_db_overlay_merges_over_hardcoded_calibration(monkeypatch, clock):
+    db_rows = [
+        {
+            "id": "valte_cam01",
+            "tenant_id": "valte",
+            "name": "Cam01",
+            "ip": "9.9.9.9",
+            "username": "dbuser",
+            "password": "dbpass",
+            "model": "HIKVISION_DS_2DF8425IX",
+        }
+    ]
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=db_rows)
+    cam = reg.get_camera_by_id("valte_cam01")
+    assert cam["ip"] == "9.9.9.9"  # DB overrides
+    assert cam["username"] == "dbuser"
+    assert cam["k1"] == pytest.approx(-0.341052)  # calibration merged from hardcoded
+
+
+def test_db_null_field_does_not_clobber_hardcoded(monkeypatch, clock):
+    db_rows = [
+        {
+            "id": "valte_cam01",
+            "tenant_id": "valte",
+            "name": "Cam01",
+            "ip": None,  # NULL ip_address must not wipe the hardcoded ip
+            "username": "dbuser",
+            "password": "dbpass",
+        }
+    ]
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=db_rows)
+    cam = reg.get_camera_by_id("valte_cam01")
+    assert cam["ip"] == "10.207.99.178"
+
+
+def test_camera_only_in_db_is_added(monkeypatch, clock):
+    db_rows = [
+        {
+            "id": "brandnew_cam99",
+            "tenant_id": "brandnew",
+            "name": "Cam99",
+            "ip": "1.2.3.4",
+            "username": "u",
+            "password": "p",
+        }
+    ]
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=db_rows)
+    cam = reg.get_camera_by_id("brandnew_cam99")
+    assert cam is not None
+    assert cam["ip"] == "1.2.3.4"
+
+
+def test_per_camera_fallback_when_absent_from_db(monkeypatch, clock):
+    # DB only knows about an unrelated camera; valte_cam01 still resolves from
+    # the hardcoded list.
+    db_rows = [{"id": "other_cam", "tenant_id": "x", "ip": "1.1.1.1"}]
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=db_rows)
+    cam = reg.get_camera_by_id("valte_cam01")
+    assert cam is not None
+    assert cam["ip"] == "10.207.99.178"
+
+
+def test_get_cameras_for_tenant_filters(monkeypatch, clock):
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=None)
+    icozee = reg.get_cameras_for_tenant("icozee")
+    assert len(icozee) >= 1
+    assert all(c["tenant_id"] == "icozee" for c in icozee)
+
+
+# --------------------------------------------------------------------------- #
+# Invalidation
+# --------------------------------------------------------------------------- #
+
+
+def test_invalidate_forces_reload(monkeypatch, clock):
+    reg, calls = _fresh_registry(monkeypatch, db_cameras=None)
+    reg.get_all_cameras()
+    assert calls["n"] == 1
+    invalidate_cache()
+    reg.get_all_cameras()
+    assert calls["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Entity → dict transform
+# --------------------------------------------------------------------------- #
+
+
+def test_entity_to_camera_dict_maps_fields():
+    entity = SimpleNamespace(
+        id="valte_cam01",
+        tenant_id="valte",
+        map_id="map-1",
+        name="Cam01",
+        ip_address="10.0.0.1",
+        spec=SimpleNamespace(model_name="DS-2DF8425IX-AELW"),
+        credential=SimpleNamespace(username="admin", password="secret"),
+    )
+    d = _entity_to_camera_dict(entity)
+    assert d == {
+        "id": "valte_cam01",
+        "tenant_id": "valte",
+        "map_id": "map-1",
+        "name": "Cam01",
+        "ip": "10.0.0.1",
+        "username": "admin",
+        "password": "secret",
+        "model": "DS-2DF8425IX-AELW",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Singleton + thread safety
+# --------------------------------------------------------------------------- #
+
+
+def test_singleton_identity():
+    assert get_registry() is get_registry()
+    assert CameraRegistry() is get_registry()
+
+
+def test_concurrent_access_does_not_corrupt(monkeypatch, clock):
+    reg, _ = _fresh_registry(monkeypatch, db_cameras=None)
+    results: list[int] = []
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            for _ in range(20):
+                results.append(len(reg.get_all_cameras()))
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    # Every read saw a consistent, non-empty camera count.
+    assert results
+    assert len(set(results)) == 1
+    assert results[0] > 0

--- a/tests/test_camera_registry_integration.py
+++ b/tests/test_camera_registry_integration.py
@@ -1,0 +1,142 @@
+"""Integration tests for the camera registry + ``camera_config`` wiring.
+
+These exercise the full path that consumers (the Django ``webapp`` tools
+camera_diagnostic / camera_survey / camera_evaluation, and the CLI/API layers)
+travel: ``camera_config`` public functions -> :class:`CameraRegistry` ->
+database loader. The PostgreSQL session and repository are mocked so the tests
+run without a live database, but the registry's *real* ``_load_from_database``
+plumbing (``get_session`` + ``RepoPostgresCameraConfig.get_all``) is executed.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import poc_homography.camera_config as cc
+from poc_homography.camera_registry import CameraRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    CameraRegistry._instance = None
+    yield
+    CameraRegistry._instance = None
+
+
+def _make_entity(cam_id, tenant_id, ip, username, password, name="Cam"):
+    return SimpleNamespace(
+        id=cam_id,
+        tenant_id=tenant_id,
+        map_id="map-1",
+        name=name,
+        ip_address=ip,
+        spec=SimpleNamespace(model_name="DS-2DF8425IX-AELW"),
+        credential=SimpleNamespace(username=username, password=password),
+    )
+
+
+@pytest.fixture
+def mock_db(monkeypatch):
+    """Patch the registry's DB dependencies to return controlled entities.
+
+    Returns a mutable list of entities the fake repository will yield.
+    """
+    entities: list = []
+
+    @contextmanager
+    def fake_get_session():
+        yield object()  # session is unused by the fake repo
+
+    class FakeRepo:
+        def __init__(self, session):
+            self._session = session
+
+        def get_all(self):
+            return list(entities)
+
+    import poc_homography.infrastructure.database as db
+    import poc_homography.infrastructure.repositories as repos
+
+    monkeypatch.setattr(db, "get_session", fake_get_session)
+    monkeypatch.setattr(repos, "RepoPostgresCameraConfig", FakeRepo)
+    return entities
+
+
+@pytest.mark.integration
+def test_camera_config_functions_return_db_backed_data(mock_db):
+    mock_db.append(_make_entity("valte_cam01", "valte", "9.8.7.6", "dbuser", "dbpass"))
+
+    cam = cc.get_camera_by_id("valte_cam01")
+    assert cam["ip"] == "9.8.7.6"  # from the database
+    assert "k1" in cam  # calibration still merged from hardcoded list
+
+    all_cams = cc.get_camera_configs()
+    assert any(c["id"] == "valte_cam01" and c["ip"] == "9.8.7.6" for c in all_cams)
+
+    valte_cams = cc.get_cameras_for_tenant("valte")
+    assert any(c["id"] == "valte_cam01" for c in valte_cams)
+
+
+@pytest.mark.integration
+def test_get_rtsp_url_uses_per_camera_credentials(mock_db, monkeypatch):
+    # Ensure no tenant/global env credentials are present so the test proves the
+    # per-camera DB credentials are what get used.
+    for var in (
+        "VALTE_CAMERA_USERNAME",
+        "VALTE_CAMERA_PASSWORD",
+        "CAMERA_USERNAME",
+        "CAMERA_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(cc, "USERNAME", None)
+    monkeypatch.setattr(cc, "PASSWORD", None)
+
+    mock_db.append(_make_entity("valte_cam01", "valte", "9.8.7.6", "dbuser", "dbpass"))
+
+    url = cc.get_rtsp_url("valte_cam01", stream_type="main")
+    assert url == "rtsp://dbuser:dbpass@9.8.7.6:554/Streaming/Channels/101"
+
+
+@pytest.mark.integration
+def test_fallback_mode_uses_tenant_credentials_when_db_unavailable(monkeypatch):
+    # No DB: get_session raises -> registry falls back to hardcoded cameras,
+    # which carry no per-camera credentials, so tenant env vars are used.
+    def boom():
+        raise RuntimeError("DATABASE_URL not set")
+
+    import poc_homography.infrastructure.database as db
+
+    monkeypatch.setattr(db, "get_session", boom)
+    monkeypatch.setenv("VALTE_CAMERA_USERNAME", "tenantuser")
+    monkeypatch.setenv("VALTE_CAMERA_PASSWORD", "tenantpass")
+
+    cam = cc.get_camera_by_id("valte_cam01")
+    assert cam["ip"] == "10.207.99.178"  # hardcoded fallback
+
+    url = cc.get_rtsp_url("valte_cam01", stream_type="main")
+    assert url == "rtsp://tenantuser:tenantpass@10.207.99.178:554/Streaming/Channels/101"
+
+
+@pytest.mark.integration
+def test_missing_credentials_raise_value_error(monkeypatch):
+    def boom():
+        raise RuntimeError("DATABASE_URL not set")
+
+    import poc_homography.infrastructure.database as db
+
+    monkeypatch.setattr(db, "get_session", boom)
+    for var in (
+        "VALTE_CAMERA_USERNAME",
+        "VALTE_CAMERA_PASSWORD",
+        "CAMERA_USERNAME",
+        "CAMERA_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(cc, "USERNAME", None)
+    monkeypatch.setattr(cc, "PASSWORD", None)
+
+    with pytest.raises(ValueError, match="credentials not set"):
+        cc.get_rtsp_url("valte_cam01")

--- a/tests/test_camera_registry_integration.py
+++ b/tests/test_camera_registry_integration.py
@@ -65,6 +65,32 @@ def mock_db(monkeypatch):
     return entities
 
 
+@pytest.fixture
+def no_db(monkeypatch):
+    """Make the registry's DB load fail, forcing the hardcoded fallback."""
+
+    def boom():
+        raise RuntimeError("DATABASE_URL not set")
+
+    import poc_homography.infrastructure.database as db
+
+    monkeypatch.setattr(db, "get_session", boom)
+
+
+@pytest.fixture
+def clear_creds(monkeypatch):
+    """Remove all tenant/global credential sources from the environment."""
+    for var in (
+        "VALTE_CAMERA_USERNAME",
+        "VALTE_CAMERA_PASSWORD",
+        "CAMERA_USERNAME",
+        "CAMERA_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(cc, "USERNAME", None)
+    monkeypatch.setattr(cc, "PASSWORD", None)
+
+
 @pytest.mark.integration
 def test_camera_config_functions_return_db_backed_data(mock_db):
     mock_db.append(_make_entity("valte_cam01", "valte", "9.8.7.6", "dbuser", "dbpass"))
@@ -81,19 +107,8 @@ def test_camera_config_functions_return_db_backed_data(mock_db):
 
 
 @pytest.mark.integration
-def test_get_rtsp_url_uses_per_camera_credentials(mock_db, monkeypatch):
-    # Ensure no tenant/global env credentials are present so the test proves the
-    # per-camera DB credentials are what get used.
-    for var in (
-        "VALTE_CAMERA_USERNAME",
-        "VALTE_CAMERA_PASSWORD",
-        "CAMERA_USERNAME",
-        "CAMERA_PASSWORD",
-    ):
-        monkeypatch.delenv(var, raising=False)
-    monkeypatch.setattr(cc, "USERNAME", None)
-    monkeypatch.setattr(cc, "PASSWORD", None)
-
+def test_get_rtsp_url_uses_per_camera_credentials(mock_db, clear_creds):
+    # clear_creds proves the per-camera DB credentials are what get used.
     mock_db.append(_make_entity("valte_cam01", "valte", "9.8.7.6", "dbuser", "dbpass"))
 
     url = cc.get_rtsp_url("valte_cam01", stream_type="main")
@@ -101,15 +116,9 @@ def test_get_rtsp_url_uses_per_camera_credentials(mock_db, monkeypatch):
 
 
 @pytest.mark.integration
-def test_fallback_mode_uses_tenant_credentials_when_db_unavailable(monkeypatch):
-    # No DB: get_session raises -> registry falls back to hardcoded cameras,
-    # which carry no per-camera credentials, so tenant env vars are used.
-    def boom():
-        raise RuntimeError("DATABASE_URL not set")
-
-    import poc_homography.infrastructure.database as db
-
-    monkeypatch.setattr(db, "get_session", boom)
+def test_fallback_mode_uses_tenant_credentials_when_db_unavailable(no_db, monkeypatch):
+    # No DB -> registry falls back to hardcoded cameras, which carry no
+    # per-camera credentials, so tenant env vars are used.
     monkeypatch.setenv("VALTE_CAMERA_USERNAME", "tenantuser")
     monkeypatch.setenv("VALTE_CAMERA_PASSWORD", "tenantpass")
 
@@ -121,22 +130,6 @@ def test_fallback_mode_uses_tenant_credentials_when_db_unavailable(monkeypatch):
 
 
 @pytest.mark.integration
-def test_missing_credentials_raise_value_error(monkeypatch):
-    def boom():
-        raise RuntimeError("DATABASE_URL not set")
-
-    import poc_homography.infrastructure.database as db
-
-    monkeypatch.setattr(db, "get_session", boom)
-    for var in (
-        "VALTE_CAMERA_USERNAME",
-        "VALTE_CAMERA_PASSWORD",
-        "CAMERA_USERNAME",
-        "CAMERA_PASSWORD",
-    ):
-        monkeypatch.delenv(var, raising=False)
-    monkeypatch.setattr(cc, "USERNAME", None)
-    monkeypatch.setattr(cc, "PASSWORD", None)
-
+def test_missing_credentials_raise_value_error(no_db, clear_creds):
     with pytest.raises(ValueError, match="credentials not set"):
         cc.get_rtsp_url("valte_cam01")


### PR DESCRIPTION
Closes #203

## Summary

Add poc_homography/camera_registry.py: a thread-safe singleton CameraRegistry that provides a TTL cache over PostgreSQL CameraConfig data, transparently backing the existing camera_config.py functions. TTL is configurable via CAMERA_CACHE_TTL (default 300s). On any database unavailability (DATABASE_URL unset, connection error, empty result) or missing camera, the registry falls back to the hardcoded CAMERAS list. Database base fields (ip, per-camera username/password, name, model) are merged over the hardcoded calibration template per camera id so calibration-dependent consumers keep working with zero changes across the 19 importers. get_rtsp_url() now prefers per-camera credentials from the database, falling back to tenant/global env credentials. invalidate_cache() supports manual refresh. Note: the data layer is SQLAlchemy (not Django as the issue text assumed); the Django webapp tools consume camera data through camera_config.py and are covered transparently. Tenant data stays on the existing dynamic YAML path and is intentionally out of the cache's scope.

## Test plan

uv run pytest tests/test_camera_registry.py tests/test_camera_registry_integration.py (22 tests). Regression: tests/test_camera_diagnostic.py + tests/test_new_commands.py (134 total passed). ruff check + format clean; vulture clean.
