### PR TITLE
feat(annotator): auto-save camera-frame annotations on every mutation [#235]

### DIFF
--- a/api/routers/camera_annotator.py
+++ b/api/routers/camera_annotator.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import mimetypes
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from sqlalchemy.orm import Session
 
 from api.deps import get_current_user, get_db_session
 from api.schemas.camera_annotator import (
@@ -28,8 +28,12 @@ from api.utils.frame_helpers import (
 )
 from poc_homography.domain.entities.annotation import Annotation
 from poc_homography.domain.vo import PixelPoint
-from poc_homography.infrastructure.models.user import UserModel
 from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.infrastructure.models.user import UserModel
 
 # ---------------------------------------------------------------------------
 # Router
@@ -71,8 +75,7 @@ def list_gcps(
         return []
 
     return [
-        GcpOut(id=pid, pixel_x=p.pixel_x, pixel_y=p.pixel_y)
-        for pid, p in registry.points.items()
+        GcpOut(id=pid, pixel_x=p.pixel_x, pixel_y=p.pixel_y) for pid, p in registry.points.items()
     ]
 
 
@@ -142,8 +145,8 @@ def save_annotations(
     if frame is None:
         raise HTTPException(status_code=400, detail="No image selected")
 
-    if not body.annotations:
-        raise HTTPException(status_code=400, detail="No annotations to save")
+    # An empty list is valid: deleting the last annotation must persist as an
+    # empty annotations section rather than leaving a stale entry.
 
     # Build domain entities with rounded coordinates
     ann_entities = [

--- a/spa/src/pages/CameraAnnotatorPage.module.css
+++ b/spa/src/pages/CameraAnnotatorPage.module.css
@@ -278,32 +278,6 @@
   background: #d32f2f;
 }
 
-/* ---------- Save section ---------- */
-.saveActions {
-  display: flex;
-  gap: 0;
-}
-
-.saveBtn {
-  flex: 1;
-  padding: 12px;
-  color: #fff;
-  border: none;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  background: #1976d2;
-}
-
-.saveBtn:hover {
-  background: #1565c0;
-}
-
-.saveBtn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
 /* ---------- Coordinates display ---------- */
 .coordsDisplay {
   position: fixed;

--- a/spa/src/pages/CameraAnnotatorPage.tsx
+++ b/spa/src/pages/CameraAnnotatorPage.tsx
@@ -61,6 +61,12 @@ export default function CameraAnnotatorPage() {
   const annotationsRef = useRef(annotations);
   annotationsRef.current = annotations;
 
+  /* ---- auto-save serialization ---- */
+  /* Tail of the in-flight save chain. Each mutation appends its POST so saves
+     are issued strictly in mutation order — a later snapshot can never be
+     overwritten on the server by an earlier one arriving out of order. */
+  const saveChainRef = useRef<Promise<void>>(Promise.resolve());
+
   /* ---- DOM refs ---- */
   const imgRef = useRef<HTMLImageElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -181,8 +187,8 @@ export default function CameraAnnotatorPage() {
      logged, never alerted, so an auto-save error never interrupts annotating.
      An empty list is a valid save: it clears the last annotation server-side. */
   const autoSave = useCallback(
-    async (anns: Annotation[]) => {
-      if (!selectedTenantId || !currentFilename) return;
+    (anns: Annotation[]): Promise<void> => {
+      if (!selectedTenantId || !currentFilename) return Promise.resolve();
 
       const cleanAnnotations = anns.map((a) => ({
         gcp_id: a.gcp_id,
@@ -190,21 +196,28 @@ export default function CameraAnnotatorPage() {
         pixel_y: parseFloat(a.pixel_y.toFixed(1)),
       }));
 
-      try {
-        const { error } = await client.POST(
-          '/camera-annotator/api/save-annotations/',
-          {
-            params: { query: { tenant_id: selectedTenantId } },
-            body: {
-              image_filename: currentFilename,
-              annotations: cleanAnnotations,
+      const doSave = async () => {
+        try {
+          const { error } = await client.POST(
+            '/camera-annotator/api/save-annotations/',
+            {
+              params: { query: { tenant_id: selectedTenantId } },
+              body: {
+                image_filename: currentFilename,
+                annotations: cleanAnnotations,
+              },
             },
-          },
-        );
-        if (error) console.error('Auto-save failed:', error);
-      } catch (err: unknown) {
-        console.error('Auto-save failed:', err);
-      }
+          );
+          if (error) console.error('Auto-save failed:', error);
+        } catch (err: unknown) {
+          console.error('Auto-save failed:', err);
+        }
+      };
+
+      // Append to the chain so POSTs are issued in mutation order. doSave never
+      // rejects (it catches internally), so the chain cannot break.
+      saveChainRef.current = saveChainRef.current.then(doSave);
+      return saveChainRef.current;
     },
     [selectedTenantId, currentFilename],
   );

--- a/spa/src/pages/CameraAnnotatorPage.tsx
+++ b/spa/src/pages/CameraAnnotatorPage.tsx
@@ -55,8 +55,6 @@ export default function CameraAnnotatorPage() {
   const [gcpSearchQuery, setGcpSearchQuery] = useState('');
   const [selectedGcpIndex, setSelectedGcpIndex] = useState(-1);
   const [coordsText, setCoordsText] = useState('Move mouse over image');
-  const [saveLabel, setSaveLabel] = useState('Save to Repo');
-  const [saving, setSaving] = useState(false);
 
   /* ---- drag state (ref to avoid re-renders during drag) ---- */
   const dragRef = useRef<DragState | null>(null);
@@ -174,6 +172,44 @@ export default function CameraAnnotatorPage() {
   /* Blob URL cleanup is handled by useImageBlob hook */
 
   /* ================================================================ */
+  /*  Auto-save                                                       */
+  /* ================================================================ */
+
+  /* Persist the given annotation list after every mutation. The list is
+     passed explicitly (rather than read from state) so the save reflects the
+     mutation that just happened, not the stale pre-update render. Failures are
+     logged, never alerted, so an auto-save error never interrupts annotating.
+     An empty list is a valid save: it clears the last annotation server-side. */
+  const autoSave = useCallback(
+    async (anns: Annotation[]) => {
+      if (!selectedTenantId || !currentFilename) return;
+
+      const cleanAnnotations = anns.map((a) => ({
+        gcp_id: a.gcp_id,
+        pixel_x: parseFloat(a.pixel_x.toFixed(1)),
+        pixel_y: parseFloat(a.pixel_y.toFixed(1)),
+      }));
+
+      try {
+        const { error } = await client.POST(
+          '/camera-annotator/api/save-annotations/',
+          {
+            params: { query: { tenant_id: selectedTenantId } },
+            body: {
+              image_filename: currentFilename,
+              annotations: cleanAnnotations,
+            },
+          },
+        );
+        if (error) console.error('Auto-save failed:', error);
+      } catch (err: unknown) {
+        console.error('Auto-save failed:', err);
+      }
+    },
+    [selectedTenantId, currentFilename],
+  );
+
+  /* ================================================================ */
   /*  Image click -> pending point                                    */
   /* ================================================================ */
 
@@ -205,14 +241,16 @@ export default function CameraAnnotatorPage() {
     (gcp: Gcp) => {
       if (!pendingPoint) return;
 
-      setAnnotations((prev) => [
-        ...prev,
+      const next = [
+        ...annotationsRef.current,
         { pixel_x: pendingPoint.x, pixel_y: pendingPoint.y, gcp_id: gcp.id },
-      ]);
+      ];
+      setAnnotations(next);
       setPendingPoint(null);
       setGcpSearchQuery('');
+      void autoSave(next);
     },
-    [pendingPoint],
+    [pendingPoint, autoSave],
   );
 
   const handleGcpKeyDown = useCallback(
@@ -289,6 +327,8 @@ export default function CameraAnnotatorPage() {
         dragRef.current = null;
         // Force re-render to remove dragging class
         setAnnotations((a) => [...a]);
+        // Persist the moved marker's final position.
+        void autoSave(annotationsRef.current);
       }
     };
 
@@ -298,15 +338,20 @@ export default function CameraAnnotatorPage() {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, []);
+  }, [autoSave]);
 
   /* ================================================================ */
   /*  Delete annotation                                               */
   /* ================================================================ */
 
-  const deleteAnnotation = useCallback((index: number) => {
-    setAnnotations((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  const deleteAnnotation = useCallback(
+    (index: number) => {
+      const next = annotationsRef.current.filter((_, i) => i !== index);
+      setAnnotations(next);
+      void autoSave(next);
+    },
+    [autoSave],
+  );
 
   /* ================================================================ */
   /*  Switch image                                                    */
@@ -334,50 +379,6 @@ export default function CameraAnnotatorPage() {
     },
     [selectedTenantId, loadImage],
   );
-
-  /* ================================================================ */
-  /*  Save annotations                                                */
-  /* ================================================================ */
-
-  const handleSave = useCallback(async () => {
-    if (
-      annotations.length === 0 ||
-      !selectedTenantId ||
-      !currentFilename ||
-      saving
-    )
-      return;
-
-    setSaving(true);
-    const cleanAnnotations = annotations.map((a) => ({
-      gcp_id: a.gcp_id,
-      pixel_x: parseFloat(a.pixel_x.toFixed(1)),
-      pixel_y: parseFloat(a.pixel_y.toFixed(1)),
-    }));
-
-    try {
-      const { data } = await client.POST(
-        '/camera-annotator/api/save-annotations/',
-        {
-          params: { query: { tenant_id: selectedTenantId } },
-          body: {
-            image_filename: currentFilename,
-            annotations: cleanAnnotations,
-          },
-        },
-      );
-
-      if (data?.success) {
-        setSaveLabel(`Saved ${data.saved}!`);
-        setTimeout(() => setSaveLabel('Save to Repo'), 2000);
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      alert(`Save failed: ${message}`);
-    } finally {
-      setSaving(false);
-    }
-  }, [annotations, selectedTenantId, currentFilename, saving]);
 
   /* ================================================================ */
   /*  Render                                                          */
@@ -529,20 +530,6 @@ export default function CameraAnnotatorPage() {
               </button>
             </div>
           ))}
-        </div>
-
-        {/* Save section */}
-        <div className={styles.panelSection}>
-          <div className={styles.saveActions}>
-            <button
-              type="button"
-              className={styles.saveBtn}
-              onClick={handleSave}
-              disabled={annotations.length === 0 || saving}
-            >
-              {saveLabel}
-            </button>
-          </div>
         </div>
       </div>
 

--- a/tests/test_api/test_camera_annotator.py
+++ b/tests/test_api/test_camera_annotator.py
@@ -1,0 +1,98 @@
+"""Integration tests for the camera-annotator save endpoint (issue #235).
+
+The SPA auto-saves the full annotation list after every mutation. Deleting the
+last annotation fires a save with an empty list, which must persist (returning
+``saved: 0``) rather than be rejected. These tests patch the router's frame
+helpers so the endpoint runs without a real database or filesystem.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+SAVE_URL = "/camera-annotator/api/save-annotations/?tenant_id=t1"
+
+
+def _mock_frame() -> MagicMock:
+    """A stand-in CapturedFrame with the attributes the view reads."""
+    frame = MagicMock()
+    frame.id = "frame-1"
+    frame.ptz_state = MagicMock()
+    return frame
+
+
+class TestSaveAnnotations:
+    """Tests for ``POST /camera-annotator/api/save-annotations/``."""
+
+    @patch("api.routers.camera_annotator.save_annotations_for_frame")
+    @patch("api.routers.camera_annotator.image_filename_to_frame")
+    def test_empty_list_saves_zero(
+        self,
+        mock_frame: MagicMock,
+        mock_save: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """An empty list is a valid save and reports zero saved (DoD #235)."""
+        mock_frame.return_value = _mock_frame()
+
+        resp = client.post(
+            SAVE_URL,
+            json={"image_filename": "cam/frame.jpg", "annotations": []},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "saved": 0}
+        # The empty list is still forwarded to the repo so it overwrites the
+        # stored annotations rather than leaving a stale entry behind.
+        mock_save.assert_called_once()
+        assert mock_save.call_args.args[1] == []
+
+    @patch("api.routers.camera_annotator.save_annotations_for_frame")
+    @patch("api.routers.camera_annotator.image_filename_to_frame")
+    def test_nonempty_list_rounds_and_saves(
+        self,
+        mock_frame: MagicMock,
+        mock_save: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """A populated list saves, rounding pixel coordinates to one decimal."""
+        mock_frame.return_value = _mock_frame()
+
+        resp = client.post(
+            SAVE_URL,
+            json={
+                "image_filename": "cam/frame.jpg",
+                "annotations": [
+                    {"gcp_id": "G1", "pixel_x": 10.06, "pixel_y": 20.04},
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "saved": 1}
+
+        entities = mock_save.call_args.args[1]
+        assert len(entities) == 1
+        assert entities[0].gcp_id == "G1"
+        assert float(entities[0].pixel.x) == 10.1
+        assert float(entities[0].pixel.y) == 20.0
+
+    @patch("api.routers.camera_annotator.image_filename_to_frame")
+    def test_unknown_image_returns_400(
+        self,
+        mock_frame: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """An unresolvable image still fails — the empty-list fix is narrow."""
+        mock_frame.return_value = None
+
+        resp = client.post(
+            SAVE_URL,
+            json={"image_filename": "missing.jpg", "annotations": []},
+        )
+
+        assert resp.status_code == 400

--- a/tests/test_camera_annotator_views.py
+++ b/tests/test_camera_annotator_views.py
@@ -1,0 +1,89 @@
+"""Tests for the camera annotator save-annotations view (issue #235).
+
+The annotator auto-saves the full annotation list after every mutation. Deleting
+the last annotation fires a save with an empty list, which must persist (overwrite
+the YAML with an empty annotations section) rather than be rejected. These tests
+monkeypatch the view's repository-writing collaborators so the endpoint is
+exercised without any real frames or filesystem writes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add webapp to path for Django imports
+PROJECT_ROOT = Path(__file__).parent.parent
+WEBAPP_DIR = PROJECT_ROOT / "webapp"
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "homography_web.settings")
+
+import django
+
+django.setup()
+
+from django.test import Client
+
+# URL prefix under which camera_annotator.urls is mounted (homography_web/urls.py).
+PREFIX = "/camera-annotator"
+SAVE_URL = f"{PREFIX}/api/save-annotations/"
+
+
+@pytest.fixture
+def patched_views(monkeypatch):
+    """Stub the view's repo collaborators and record what gets saved.
+
+    Django resolves the URLconf via the ``camera_annotator.views`` module object
+    (webapp/ is on sys.path), so we patch that exact module.
+    """
+    import camera_annotator.views as views
+
+    saved: dict = {}
+
+    def fake_save(image_filename, annotations):
+        saved["image_filename"] = image_filename
+        saved["annotations"] = annotations
+
+    monkeypatch.setattr(views, "_get_tenant_map_id", lambda request: "map-1")
+    monkeypatch.setattr(views, "get_current_image", lambda request, map_id=None: "cam_a/frame.jpg")
+    monkeypatch.setattr(views, "save_annotations_to_repo", fake_save)
+    monkeypatch.setattr(views, "invalidate_cache", lambda: None)
+    return saved
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def test_save_empty_annotations_succeeds(client, patched_views):
+    """Saving an empty list persists and reports zero saved (DoD, issue #235)."""
+    resp = client.post(
+        SAVE_URL,
+        data=json.dumps({"annotations": []}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True, "saved": 0}
+    # The empty list is forwarded to the repo so the YAML is overwritten.
+    assert patched_views["annotations"] == []
+
+
+def test_save_nonempty_annotations_succeeds(client, patched_views):
+    """A populated list still saves and rounds pixel values to one decimal."""
+    resp = client.post(
+        SAVE_URL,
+        data=json.dumps({"annotations": [{"gcp_id": "G1", "pixel_x": 10.04, "pixel_y": 20.06}]}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True, "saved": 1}
+    assert patched_views["annotations"] == [{"gcp_id": "G1", "pixel_x": 10.0, "pixel_y": 20.1}]

--- a/webapp/camera_annotator/templates/camera_annotator/index.html
+++ b/webapp/camera_annotator/templates/camera_annotator/index.html
@@ -261,25 +261,6 @@
             background: #d32f2f;
         }
 
-        /* Save section */
-        .save-actions {
-            display: flex;
-            gap: 0;
-        }
-
-        .save-actions button {
-            flex: 1;
-            padding: 12px;
-            color: #fff;
-            border: none;
-            font-size: 13px;
-            font-weight: 500;
-            cursor: pointer;
-        }
-
-        #save-btn { background: #1976d2; }
-        #save-btn:hover { background: #1565c0; }
-
         /* Instructions */
         #instructions {
             padding: 12px;
@@ -355,12 +336,6 @@
             <h2>Annotations (<span id="annotation-count">0</span>)</h2>
         </div>
         <div id="annotations-list"></div>
-
-        <div class="panel-section">
-            <div class="save-actions">
-                <button id="save-btn">Save to Repo</button>
-            </div>
-        </div>
     </div>
 
     <div id="coords-display">Move mouse over image</div>
@@ -487,6 +462,32 @@
             renderMarkers();
             renderAnnotationsList();
             updateYamlPreview();
+            autoSave();
+        }
+
+        // Persist the current annotation list to the repo. Called after every
+        // mutation (add, move, delete). Failures are logged, never alerted, so
+        // an auto-save error does not interrupt the annotation workflow.
+        async function autoSave() {
+            const cleanAnnotations = annotations.map(a => ({
+                gcp_id: a.gcp_id,
+                pixel_x: parseFloat(a.pixel_x.toFixed(1)),
+                pixel_y: parseFloat(a.pixel_y.toFixed(1)),
+            }));
+
+            try {
+                const resp = await fetch('{% url "camera_annotator:api_save_annotations" %}', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ annotations: cleanAnnotations })
+                });
+                const result = await resp.json();
+                if (!result.success) {
+                    console.error('Auto-save failed:', result.error || 'Unknown error');
+                }
+            } catch (err) {
+                console.error('Auto-save failed:', err.message);
+            }
         }
 
         // Render annotations list
@@ -515,6 +516,7 @@
                     renderMarkers();
                     renderAnnotationsList();
                     updateYamlPreview();
+                    autoSave();
                 });
             });
         }
@@ -571,6 +573,7 @@
             renderMarkers();
             renderAnnotationsList();
             updateYamlPreview();
+            autoSave();
         });
 
         // Event: GCP search input
@@ -601,35 +604,6 @@
                 pendingPoint = null;
                 gcpSection.classList.remove('active');
                 renderMarkers();
-            }
-        });
-
-        // Event: Save to Repo button
-        const saveBtn = document.getElementById('save-btn');
-        saveBtn.addEventListener('click', async () => {
-            if (annotations.length === 0) return;
-
-            const cleanAnnotations = annotations.map(a => ({
-                gcp_id: a.gcp_id,
-                pixel_x: parseFloat(a.pixel_x.toFixed(1)),
-                pixel_y: parseFloat(a.pixel_y.toFixed(1)),
-            }));
-
-            try {
-                const resp = await fetch('{% url "camera_annotator:api_save_annotations" %}', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ annotations: cleanAnnotations })
-                });
-                const result = await resp.json();
-                if (result.success) {
-                    saveBtn.textContent = `Saved ${result.saved}!`;
-                    setTimeout(() => { saveBtn.textContent = 'Save to Repo'; }, 2000);
-                } else {
-                    alert('Save failed: ' + (result.error || 'Unknown error'));
-                }
-            } catch (err) {
-                alert('Save failed: ' + err.message);
             }
         });
 

--- a/webapp/camera_annotator/views.py
+++ b/webapp/camera_annotator/views.py
@@ -196,9 +196,9 @@ def api_save_annotations(request: HttpRequest) -> JsonResponse:
     if not current_image:
         return JsonResponse({"error": "No image selected"}, status=400)
 
+    # An empty list is valid: deleting the last annotation must persist as an
+    # empty annotations section rather than leaving a stale YAML entry.
     new_annotations = data.get("annotations", [])
-    if not new_annotations:
-        return JsonResponse({"error": "No annotations to save"}, status=400)
 
     # Validate annotation format
     for ann in new_annotations:


### PR DESCRIPTION
Closes #235

## Summary

Replace the manual "Save to Repo" button in the camera-frame annotator with automatic persistence. After every annotation mutation (add, move, delete) the frontend POSTs the full current annotation list to the existing save-annotations endpoint.

Primary deliverable is the live FastAPI + React SPA stack:
- SPA (spa/src/pages/CameraAnnotatorPage.tsx): added an autoSave() helper that rounds pixel coords to 1 decimal and POSTs the current list, logging failures to console.error (no alert). Wired into all three mutation sites — add (selectGcp), move (mouseup drag-end), delete (deleteAnnotation). Removed the Save button, handleSave, saveLabel/saving state, the Save-section JSX, and the dead .saveActions/.saveBtn CSS.
- Backend (api/routers/camera_annotator.py): removed the `if not body.annotations` 400 guard so saving an empty list persists and returns {success: true, saved: 0}. This lets deleting the last annotation clear the stored YAML instead of leaving a stale entry. Also moved the annotation-only Session/UserModel imports into a TYPE_CHECKING block to satisfy ruff TC001/TC002 (verified FastAPI dependency resolution still works).

The superseded Django webapp/camera_annotator/ stack received the equivalent changes for consistency.

## Test plan

- tests/test_api/test_camera_annotator.py (FastAPI): empty list -> {success, saved:0} and forwards [] to the repo; non-empty rounds pixel_x/pixel_y to 1 decimal; unknown image still 400. All 3 pass.
- tests/test_camera_annotator_views.py (Django): empty + non-empty save paths. Both pass.
- SPA: `tsc -b` passes (EXIT 0); eslint at pre-existing baseline (no new errors).
- ruff check + ruff format + pyright clean on changed Python; vulture clean over webapp.
- Full local suite delegated to CI (property-based calibration tests are slow and unrelated to this diff).

## Closes DoD bullets

- Adding an annotation and refreshing the page shows the annotation without any manual save
- Moving an annotation marker and refreshing the page shows the updated position
- Deleting the last annotation and refreshing the page shows zero annotations (no stale YAML entries)
- Deleting an annotation (including the last one) does not produce a browser console error or alert
- No "Save to Repo" button is present in the rendered page
- api_save_annotations returns success true saved 0 when called with empty annotations
