### PR TITLE
feat(gallery): clean-plate gallery — FastAPI endpoints + SPA page + imgproxy thumbnails [#285]

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ def health() -> dict[str, str]:
     """Liveness probe."""
     return {"status": "ok"}
 
+
 # ---------------------------------------------------------------------------
 # CORS configuration
 # ---------------------------------------------------------------------------
@@ -50,11 +51,12 @@ app.add_middleware(
 # Routers
 # ---------------------------------------------------------------------------
 
-from api.routers import (
+from api.routers import (  # noqa: E402 — routers imported after app + CORS setup (intentional)
     camera_annotator,
     camera_diagnostic,
     camera_evaluation,
     camera_line_annotator,
+    clean_plate_gallery,
     distortion_validator,
     gcp,
     homography_precision,
@@ -67,6 +69,7 @@ app.include_router(camera_annotator.router)
 app.include_router(camera_diagnostic.router)
 app.include_router(camera_evaluation.router)
 app.include_router(camera_line_annotator.router)
+app.include_router(clean_plate_gallery.router)
 app.include_router(distortion_validator.router)
 app.include_router(gcp.router)
 app.include_router(homography_precision.router)

--- a/api/routers/clean_plate_gallery.py
+++ b/api/routers/clean_plate_gallery.py
@@ -1,0 +1,119 @@
+"""FastAPI router for the clean-plate gallery (frames + runs).
+
+Reads survey frame metadata from the Neon ``clean_plate_frames`` table and mints
+short-TTL presigned MinIO URLs for the full images plus signed imgproxy URLs for
+thumbnails, so the SPA gallery can browse maglor's captured floor images without
+downloading them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 — needed at runtime for Query typing
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, Query
+
+from api.deps import get_current_user, get_db_session
+from api.schemas.clean_plate_gallery import (
+    CleanPlateFrameListResponse,
+    CleanPlateFrameOut,
+    RunListResponse,
+    RunOut,
+)
+from api.utils.imgproxy import ImgproxySigner
+from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
+from poc_homography.infrastructure.repositories.repo_postgres_clean_plate_frame import (
+    RepoPostgresCleanPlateFrame,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.infrastructure.models.clean_plate_frame import CleanPlateFrameModel
+    from poc_homography.infrastructure.models.user import UserModel
+
+# Presigned-URL TTL (seconds). Short-lived: the gallery re-fetches on load.
+_PRESIGN_TTL = 3600
+
+router = APIRouter(prefix="/clean-plate", tags=["clean-plate"])
+
+
+def _to_frame_out(
+    row: CleanPlateFrameModel,
+    store: MinioFrameStore,
+    signer: ImgproxySigner | None,
+) -> CleanPlateFrameOut:
+    """Map a DB row to the API schema, minting image + thumbnail URLs."""
+    image_url = store.presign_get(row.minio_object_key, expires_in=_PRESIGN_TTL)
+    if signer is not None and row.minio_bucket and row.minio_object_key:
+        thumbnail_url = signer.thumbnail_url(f"s3://{row.minio_bucket}/{row.minio_object_key}")
+    else:
+        # imgproxy not configured — fall back to the full presigned image.
+        thumbnail_url = image_url
+    return CleanPlateFrameOut(
+        id=row.id,
+        run_id=row.run_id,
+        camera_id=row.camera_id,
+        phase=row.phase,
+        pose_id=row.pose_id,
+        commanded_pan=row.commanded_pan,
+        commanded_tilt=row.commanded_tilt,
+        commanded_zoom=row.commanded_zoom,
+        burst_id=row.burst_id,
+        frame_index=row.frame_index,
+        captured_at=row.captured_at,
+        image_url=image_url,
+        thumbnail_url=thumbnail_url,
+        record=row.record,
+    )
+
+
+@router.get("/frames", response_model=CleanPlateFrameListResponse)
+def get_frames(
+    run_id: str | None = Query(default=None),
+    pose_id: str | None = Query(default=None),
+    camera_id: str | None = Query(default=None),
+    phase: str | None = Query(default=None),
+    captured_after: datetime | None = Query(default=None),
+    captured_before: datetime | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    session: Session = Depends(get_db_session),
+    user: UserModel = Depends(get_current_user),
+) -> CleanPlateFrameListResponse:
+    """Query clean-plate frames with filters + pagination.
+
+    Returns metadata plus a presigned MinIO image URL and an imgproxy thumbnail
+    URL per frame, newest first.
+    """
+    repo = RepoPostgresCleanPlateFrame(session)
+    rows, total = repo.query_frames(
+        run_id=run_id,
+        pose_id=pose_id,
+        camera_id=camera_id,
+        phase=phase,
+        captured_after=captured_after,
+        captured_before=captured_before,
+        limit=limit,
+        offset=offset,
+    )
+
+    if rows:
+        store = MinioFrameStore.from_env()
+        signer = ImgproxySigner.from_env()
+        frames = [_to_frame_out(row, store, signer) for row in rows]
+    else:
+        frames = []
+
+    return CleanPlateFrameListResponse(frames=frames, total=total, limit=limit, offset=offset)
+
+
+@router.get("/runs", response_model=RunListResponse)
+def get_runs(
+    session: Session = Depends(get_db_session),
+    user: UserModel = Depends(get_current_user),
+) -> RunListResponse:
+    """List distinct capture runs (with frame counts and time spans)."""
+    repo = RepoPostgresCleanPlateFrame(session)
+    runs = repo.list_runs()
+    return RunListResponse(runs=[RunOut(**run) for run in runs])

--- a/api/routers/clean_plate_gallery.py
+++ b/api/routers/clean_plate_gallery.py
@@ -44,9 +44,12 @@ def _to_frame_out(
     signer: ImgproxySigner | None,
 ) -> CleanPlateFrameOut:
     """Map a DB row to the API schema, minting image + thumbnail URLs."""
-    image_url = store.presign_get(row.minio_object_key, expires_in=_PRESIGN_TTL)
-    if signer is not None and row.minio_bucket and row.minio_object_key:
-        thumbnail_url = signer.thumbnail_url(f"s3://{row.minio_bucket}/{row.minio_object_key}")
+    # The row records where the image actually lives; treat it as authoritative
+    # (fall back to the store's configured bucket only when the row is blank).
+    bucket = row.minio_bucket or store.bucket
+    image_url = store.presign_get(row.minio_object_key, expires_in=_PRESIGN_TTL, bucket=bucket)
+    if signer is not None and bucket and row.minio_object_key:
+        thumbnail_url = signer.thumbnail_url(f"s3://{bucket}/{row.minio_object_key}")
     else:
         # imgproxy not configured — fall back to the full presigned image.
         thumbnail_url = image_url

--- a/api/schemas/clean_plate_gallery.py
+++ b/api/schemas/clean_plate_gallery.py
@@ -1,0 +1,72 @@
+"""Pydantic response schemas for the clean-plate gallery endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 — needed at runtime for Pydantic
+from typing import Any
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Frame schemas
+# ---------------------------------------------------------------------------
+
+
+class CleanPlateFrameOut(BaseModel):
+    """A single clean-plate frame: metadata + presigned image + thumbnail URL."""
+
+    id: str
+    run_id: str
+    camera_id: str
+    phase: str
+    pose_id: str
+    commanded_pan: float
+    commanded_tilt: float
+    commanded_zoom: float
+    burst_id: str | None
+    frame_index: int
+    captured_at: datetime
+    # Presigned MinIO GET URL for the full-resolution image (short TTL).
+    image_url: str
+    # imgproxy-served resized thumbnail (falls back to ``image_url`` when
+    # imgproxy is not configured).
+    thumbnail_url: str
+    # Full lossless ``FrameRecord.to_dict()`` blob (optics, pose, etc.).
+    record: dict[str, Any]
+
+
+class CleanPlateFrameListResponse(BaseModel):
+    """Envelope for ``GET /clean-plate/frames``."""
+
+    frames: list[CleanPlateFrameOut]
+    total: int
+    limit: int
+    offset: int
+
+
+# ---------------------------------------------------------------------------
+# Run schemas
+# ---------------------------------------------------------------------------
+
+
+class RunOut(BaseModel):
+    """A distinct capture run with its frame count and time span."""
+
+    run_id: str
+    frame_count: int
+    first_captured_at: datetime
+    last_captured_at: datetime
+
+
+class RunListResponse(BaseModel):
+    """Envelope for ``GET /clean-plate/runs``."""
+
+    runs: list[RunOut]
+
+
+__all__ = [
+    "CleanPlateFrameListResponse",
+    "CleanPlateFrameOut",
+    "RunListResponse",
+    "RunOut",
+]

--- a/api/utils/imgproxy.py
+++ b/api/utils/imgproxy.py
@@ -1,0 +1,93 @@
+"""imgproxy signed-URL builder for clean-plate gallery thumbnails.
+
+imgproxy serves on-the-fly resized thumbnails from the MinIO ``cleanplate-frames``
+bucket. Each thumbnail URL is signed with an HMAC-SHA256 keyed on imgproxy's
+configured key/salt so imgproxy will only honour URLs this API minted. The
+source is referenced as an ``s3://bucket/key`` URL, which imgproxy fetches
+directly from MinIO (imgproxy must be deployed with S3 integration pointed at
+the same bucket — see the infra deployment issue).
+
+Config comes from the environment (all required to enable thumbnails):
+
+- ``IMGPROXY_BASE_URL``  e.g. ``https://imgproxy.vasco-dev.pedweb.link``
+- ``IMGPROXY_KEY``       hex-encoded HMAC key (imgproxy ``IMGPROXY_KEY``)
+- ``IMGPROXY_SALT``      hex-encoded HMAC salt (imgproxy ``IMGPROXY_SALT``)
+
+When any variable is unset, :meth:`ImgproxySigner.from_env` returns ``None`` and
+the gallery falls back to the presigned full-resolution image for thumbnails.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+DEFAULT_THUMB_SIZE = 320
+
+
+class ImgproxySigner:
+    """Builds signed imgproxy URLs for resized thumbnails of MinIO objects."""
+
+    def __init__(self, *, base_url: str, key_hex: str, salt_hex: str) -> None:
+        """Build the signer.
+
+        Args:
+            base_url: imgproxy public base URL (scheme + host, no trailing path).
+            key_hex: Hex-encoded HMAC key (imgproxy ``IMGPROXY_KEY``).
+            salt_hex: Hex-encoded HMAC salt (imgproxy ``IMGPROXY_SALT``).
+
+        Raises:
+            ValueError: If ``key_hex`` or ``salt_hex`` is not valid hex.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._key = bytes.fromhex(key_hex)
+        self._salt = bytes.fromhex(salt_hex)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ImgproxySigner | None:
+        """Build a signer from ``IMGPROXY_*`` env vars, or ``None`` if unset.
+
+        Returns ``None`` (thumbnails disabled) when any required variable is
+        missing, so the gallery degrades gracefully to full-image previews.
+        """
+        src = env if env is not None else os.environ
+        base = src.get("IMGPROXY_BASE_URL", "")
+        key = src.get("IMGPROXY_KEY", "")
+        salt = src.get("IMGPROXY_SALT", "")
+        if not (base and key and salt):
+            return None
+        return cls(base_url=base, key_hex=key, salt_hex=salt)
+
+    def thumbnail_url(
+        self,
+        source_url: str,
+        *,
+        width: int = DEFAULT_THUMB_SIZE,
+        height: int = DEFAULT_THUMB_SIZE,
+    ) -> str:
+        """Return a signed imgproxy URL that resizes ``source_url`` to fit.
+
+        Args:
+            source_url: Source the thumbnail is generated from — an
+                ``s3://bucket/key`` URL imgproxy fetches from MinIO.
+            width: Target bounding-box width in pixels.
+            height: Target bounding-box height in pixels.
+
+        Returns:
+            A fully-qualified, signed imgproxy URL.
+        """
+        encoded_source = base64.urlsafe_b64encode(source_url.encode()).decode().rstrip("=")
+        # rs:fit:W:H:0 — resize to fit within WxH without enlarging.
+        path = f"/rs:fit:{width}:{height}:0/{encoded_source}"
+        digest = hmac.new(self._key, self._salt + path.encode(), hashlib.sha256).digest()
+        signature = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+        return f"{self._base_url}/{signature}{path}"
+
+
+__all__ = ["DEFAULT_THUMB_SIZE", "ImgproxySigner"]

--- a/poc_homography/infrastructure/clients/minio_frame_store.py
+++ b/poc_homography/infrastructure/clients/minio_frame_store.py
@@ -126,11 +126,16 @@ class MinioFrameStore:
         )
         return PutResult(bucket=self.bucket, key=key, sha256=sha256)
 
-    def presign_get(self, key: str, expires_in: int = 3600) -> str:
-        """Return a presigned GET URL for ``key`` (used by the gallery)."""
+    def presign_get(self, key: str, expires_in: int = 3600, *, bucket: str | None = None) -> str:
+        """Return a presigned GET URL for ``key`` (used by the gallery).
+
+        ``bucket`` overrides the store's configured bucket so callers can presign
+        against the bucket recorded on a frame row (the authoritative location of
+        that image), rather than assuming the store's env-configured bucket.
+        """
         return self._client.generate_presigned_url(
             "get_object",
-            Params={"Bucket": self.bucket, "Key": key},
+            Params={"Bucket": bucket or self.bucket, "Key": key},
             ExpiresIn=expires_in,
         )
 

--- a/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import func, select
+
 from poc_homography.infrastructure.models.clean_plate_frame import CleanPlateFrameModel
 
 if TYPE_CHECKING:
@@ -72,6 +74,81 @@ class RepoPostgresCleanPlateFrame:
         except Exception:
             logger.exception("Failed to upsert clean-plate frame %s", frame_id)
             return False
+
+    def query_frames(
+        self,
+        *,
+        run_id: str | None = None,
+        pose_id: str | None = None,
+        camera_id: str | None = None,
+        phase: str | None = None,
+        captured_after: datetime | None = None,
+        captured_before: datetime | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[CleanPlateFrameModel], int]:
+        """Query frame rows by filters, newest first, with pagination.
+
+        Returns the page of rows (ordered by ``captured_at`` descending) and the
+        total count matching the filters (ignoring ``limit``/``offset``), so the
+        gallery can paginate. Consumed by the gallery API (#285).
+        """
+        model = CleanPlateFrameModel
+        conditions = []
+        if run_id is not None:
+            conditions.append(model.run_id == run_id)
+        if pose_id is not None:
+            conditions.append(model.pose_id == pose_id)
+        if camera_id is not None:
+            conditions.append(model.camera_id == camera_id)
+        if phase is not None:
+            conditions.append(model.phase == phase)
+        if captured_after is not None:
+            conditions.append(model.captured_at >= captured_after)
+        if captured_before is not None:
+            conditions.append(model.captured_at <= captured_before)
+
+        total = self._session.execute(
+            select(func.count()).select_from(model).where(*conditions)
+        ).scalar_one()
+
+        stmt = (
+            select(model)
+            .where(*conditions)
+            .order_by(model.captured_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        rows = list(self._session.execute(stmt).scalars().all())
+        return rows, total
+
+    def list_runs(self) -> list[dict[str, Any]]:
+        """List distinct runs with frame count and capture time span.
+
+        One entry per ``run_id`` (newest run first), used by the gallery run
+        picker (#285).
+        """
+        model = CleanPlateFrameModel
+        stmt = (
+            select(
+                model.run_id,
+                func.count().label("frame_count"),
+                func.min(model.captured_at).label("first_captured_at"),
+                func.max(model.captured_at).label("last_captured_at"),
+            )
+            .group_by(model.run_id)
+            .order_by(func.max(model.captured_at).desc())
+        )
+        rows = self._session.execute(stmt).all()
+        return [
+            {
+                "run_id": row.run_id,
+                "frame_count": row.frame_count,
+                "first_captured_at": row.first_captured_at,
+                "last_captured_at": row.last_captured_at,
+            }
+            for row in rows
+        ]
 
 
 __all__ = ["RepoPostgresCleanPlateFrame"]

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -15,6 +15,7 @@ import CameraSurveyPage from './pages/CameraSurveyPage';
 import CameraEvaluationPage from './pages/CameraEvaluationPage';
 import LensCalibrationPage from './pages/LensCalibrationPage';
 import DistortionValidatorPage from './pages/DistortionValidatorPage';
+import CleanPlateGalleryPage from './pages/CleanPlateGalleryPage';
 
 export default function App() {
   return (
@@ -61,6 +62,10 @@ export default function App() {
               <Route
                 path="distortion-validator"
                 element={<DistortionValidatorPage />}
+              />
+              <Route
+                path="clean-plate-gallery"
+                element={<CleanPlateGalleryPage />}
               />
             </Route>
           </Route>

--- a/spa/src/pages/CleanPlateGalleryPage.module.css
+++ b/spa/src/pages/CleanPlateGalleryPage.module.css
@@ -1,0 +1,181 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px;
+  gap: 16px;
+  overflow: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.title {
+  font-size: 1.5rem;
+  color: #333;
+  margin: 0;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label {
+  font-weight: 600;
+  color: #666;
+}
+
+.select {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  font-size: 0.9rem;
+  min-width: 280px;
+}
+
+.status {
+  color: #666;
+}
+
+.error {
+  padding: 10px 14px;
+  border-radius: 6px;
+  background: #fdecea;
+  color: #b3261e;
+  border: 1px solid #f5c6c2;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.thumb {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: #f8f9fa;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.thumb:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.thumbImg {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: #e9ecef;
+  display: block;
+}
+
+.thumbCaption {
+  padding: 6px 8px;
+  font-size: 0.75rem;
+  color: #555;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ----- Modal ----- */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.modal {
+  position: relative;
+  background: #fff;
+  border-radius: 10px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  border: none;
+  background: transparent;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #666;
+}
+
+.closeBtn:hover {
+  color: #000;
+}
+
+.modalImg {
+  max-width: 100%;
+  max-height: 60vh;
+  object-fit: contain;
+  border-radius: 6px;
+  background: #000;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.meta dt {
+  font-weight: 600;
+  color: #666;
+}
+
+.meta dd {
+  margin: 0;
+  color: #333;
+}
+
+.rawMeta {
+  font-size: 0.8rem;
+}
+
+.rawMeta summary {
+  cursor: pointer;
+  color: #667eea;
+}
+
+.rawMetaPre {
+  margin: 8px 0 0;
+  padding: 10px;
+  background: #f8f9fa;
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 240px;
+  font-size: 0.75rem;
+}

--- a/spa/src/pages/CleanPlateGalleryPage.tsx
+++ b/spa/src/pages/CleanPlateGalleryPage.tsx
@@ -1,0 +1,235 @@
+/**
+ * Clean-plate gallery: pick a capture run, browse a responsive grid of
+ * lazy-loaded imgproxy thumbnails, and click a thumb to see the full presigned
+ * image plus its metadata. Reads two backend endpoints:
+ *
+ *   GET /clean-plate/runs    — run picker
+ *   GET /clean-plate/frames  — thumbnail grid (metadata + presigned/thumbnail URLs)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useApiFetch } from '../hooks/useAuthFetch';
+import styles from './CleanPlateGalleryPage.module.css';
+
+interface Run {
+  run_id: string;
+  frame_count: number;
+  first_captured_at: string;
+  last_captured_at: string;
+}
+
+interface Frame {
+  id: string;
+  run_id: string;
+  camera_id: string;
+  phase: string;
+  pose_id: string;
+  commanded_pan: number;
+  commanded_tilt: number;
+  commanded_zoom: number;
+  burst_id: string | null;
+  frame_index: number;
+  captured_at: string;
+  image_url: string;
+  thumbnail_url: string;
+  record: Record<string, unknown>;
+}
+
+interface FramesResponse {
+  frames: Frame[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface RunsResponse {
+  runs: Run[];
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+export default function CleanPlateGalleryPage() {
+  const apiFetch = useApiFetch();
+
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState<string>('');
+  const [frames, setFrames] = useState<Frame[]>([]);
+  const [loadingRuns, setLoadingRuns] = useState(false);
+  const [loadingFrames, setLoadingFrames] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedFrame, setSelectedFrame] = useState<Frame | null>(null);
+
+  const fetchJson = useCallback(
+    async <T,>(url: string, signal: AbortSignal): Promise<T> => {
+      const res = await apiFetch(url, { signal });
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      return (await res.json()) as T;
+    },
+    [apiFetch],
+  );
+
+  // Load runs once on mount; pre-select the most recent.
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void (async () => {
+      setLoadingRuns(true);
+      setError(null);
+      try {
+        const data = await fetchJson<RunsResponse>('/clean-plate/runs', controller.signal);
+        if (controller.signal.aborted) return;
+        setRuns(data.runs);
+        if (data.runs.length > 0) setSelectedRunId(data.runs[0].run_id);
+      } catch (err: unknown) {
+        if (!controller.signal.aborted)
+          setError(err instanceof Error ? err.message : 'Failed to load runs');
+      } finally {
+        if (!controller.signal.aborted) setLoadingRuns(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [fetchJson]);
+
+  // Load frames whenever the selected run changes.
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void (async () => {
+      if (!selectedRunId) {
+        setFrames([]);
+        return;
+      }
+      setLoadingFrames(true);
+      setError(null);
+      try {
+        const query = new URLSearchParams({ run_id: selectedRunId, limit: '200' });
+        const data = await fetchJson<FramesResponse>(
+          `/clean-plate/frames?${query.toString()}`,
+          controller.signal,
+        );
+        if (!controller.signal.aborted) setFrames(data.frames);
+      } catch (err: unknown) {
+        if (!controller.signal.aborted)
+          setError(err instanceof Error ? err.message : 'Failed to load frames');
+      } finally {
+        if (!controller.signal.aborted) setLoadingFrames(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [selectedRunId, fetchJson]);
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Clean-Plate Gallery</h1>
+        <div className={styles.controls}>
+          <label htmlFor="run-select" className={styles.label}>
+            Run
+          </label>
+          <select
+            id="run-select"
+            className={styles.select}
+            value={selectedRunId}
+            onChange={(e) => setSelectedRunId(e.target.value)}
+            disabled={loadingRuns || runs.length === 0}
+          >
+            {runs.length === 0 && <option value="">No runs</option>}
+            {runs.map((run) => (
+              <option key={run.run_id} value={run.run_id}>
+                {run.run_id} ({run.frame_count} frames ·{' '}
+                {formatTimestamp(run.last_captured_at)})
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      {error && <div className={styles.error}>{error}</div>}
+      {loadingRuns && <p className={styles.status}>Loading runs…</p>}
+      {!loadingRuns && loadingFrames && <p className={styles.status}>Loading frames…</p>}
+      {!loadingFrames && selectedRunId && frames.length === 0 && !error && (
+        <p className={styles.status}>No frames for this run.</p>
+      )}
+
+      <div className={styles.grid}>
+        {frames.map((frame) => (
+          <button
+            type="button"
+            key={frame.id}
+            className={styles.thumb}
+            onClick={() => setSelectedFrame(frame)}
+            title={`${frame.pose_id} · ${formatTimestamp(frame.captured_at)}`}
+          >
+            <img
+              className={styles.thumbImg}
+              src={frame.thumbnail_url}
+              alt={`Frame ${frame.id} (${frame.pose_id})`}
+              loading="lazy"
+            />
+            <span className={styles.thumbCaption}>{frame.pose_id || frame.id}</span>
+          </button>
+        ))}
+      </div>
+
+      {selectedFrame && (
+        <div
+          className={styles.modalOverlay}
+          role="presentation"
+          onClick={() => setSelectedFrame(null)}
+        >
+          <div
+            className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Frame ${selectedFrame.id}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              className={styles.closeBtn}
+              onClick={() => setSelectedFrame(null)}
+              aria-label="Close"
+            >
+              ×
+            </button>
+            <img
+              className={styles.modalImg}
+              src={selectedFrame.image_url}
+              alt={`Frame ${selectedFrame.id} (full resolution)`}
+            />
+            <dl className={styles.meta}>
+              <dt>Capture ID</dt>
+              <dd>{selectedFrame.id}</dd>
+              <dt>Pose</dt>
+              <dd>{selectedFrame.pose_id || '—'}</dd>
+              <dt>Camera</dt>
+              <dd>{selectedFrame.camera_id || '—'}</dd>
+              <dt>Phase</dt>
+              <dd>{selectedFrame.phase || '—'}</dd>
+              <dt>Pan / Tilt / Zoom</dt>
+              <dd>
+                {selectedFrame.commanded_pan} / {selectedFrame.commanded_tilt} /{' '}
+                {selectedFrame.commanded_zoom}
+              </dd>
+              <dt>Captured at</dt>
+              <dd>{formatTimestamp(selectedFrame.captured_at)}</dd>
+              <dt>Frame index</dt>
+              <dd>{selectedFrame.frame_index}</dd>
+            </dl>
+            <details className={styles.rawMeta}>
+              <summary>Full metadata (optics, …)</summary>
+              <pre className={styles.rawMetaPre}>
+                {JSON.stringify(selectedFrame.record, null, 2)}
+              </pre>
+            </details>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/spa/src/pages/DashboardPage.tsx
+++ b/spa/src/pages/DashboardPage.tsx
@@ -77,6 +77,14 @@ const TOOL_CARDS: ToolCardDef[] = [
     description:
       'Validate lens distortion calibration by viewing undistorted images side-by-side. Draw lines on undistorted images to verify straightness and calibration quality.',
   },
+  {
+    to: '/clean-plate-gallery',
+    title: 'Clean-Plate Gallery',
+    badge: 'New',
+    alwaysEnabled: true,
+    description:
+      "Browse maglor's captured clean-plate floor images by run. Responsive thumbnail grid (imgproxy-served) with per-frame metadata; click a thumbnail for the full image and pose/optics details.",
+  },
 ];
 
 export default function DashboardPage() {

--- a/spa/vite.config.ts
+++ b/spa/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       '/homography-precision': 'http://localhost:8000',
       '/lens-calibration': 'http://localhost:8000',
       '/distortion-validator': 'http://localhost:8000',
+      '/clean-plate': 'http://localhost:8000',
       '/health': 'http://localhost:8000',
     },
   },

--- a/tests/test_api/test_clean_plate_gallery.py
+++ b/tests/test_api/test_clean_plate_gallery.py
@@ -86,6 +86,10 @@ class TestGetFrames:
         mock_signer_cls.from_env.return_value.thumbnail_url.assert_called_once_with(
             "s3://cleanplate-frames/run-1/clean_plate/pose-1/f1.jpg"
         )
+        # Presign uses the bucket recorded on the row (authoritative), not the
+        # store's env-configured default.
+        presign = mock_store_cls.from_env.return_value.presign_get
+        assert presign.call_args.kwargs["bucket"] == "cleanplate-frames"
 
     @patch("api.routers.clean_plate_gallery.ImgproxySigner")
     @patch("api.routers.clean_plate_gallery.MinioFrameStore")

--- a/tests/test_api/test_clean_plate_gallery.py
+++ b/tests/test_api/test_clean_plate_gallery.py
@@ -1,0 +1,211 @@
+"""Integration tests for the clean-plate gallery router (frames + runs).
+
+The DB repository, the MinIO store, and the imgproxy signer are all mocked, so
+these tests run fully offline.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from tests.test_api.conftest import make_basic_auth_header
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Test data factory
+# ---------------------------------------------------------------------------
+
+
+def _make_row(frame_id: str = "f1", run_id: str = "run-1") -> SimpleNamespace:
+    """A stand-in for a ``CleanPlateFrameModel`` row (attribute access only)."""
+    return SimpleNamespace(
+        id=frame_id,
+        run_id=run_id,
+        camera_id="cam-1",
+        phase="clean_plate",
+        pose_id="pose-1",
+        commanded_pan=10.0,
+        commanded_tilt=20.0,
+        commanded_zoom=1.5,
+        burst_id=None,
+        frame_index=0,
+        captured_at=datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc),
+        minio_bucket="cleanplate-frames",
+        minio_object_key=f"run-1/clean_plate/pose-1/{frame_id}.jpg",
+        checksum_sha256="abc123",
+        record={"optics": {"fov_deg": 60.0}, "pose_id": "pose-1"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /clean-plate/frames
+# ---------------------------------------------------------------------------
+
+
+class TestGetFrames:
+    """Tests for ``GET /clean-plate/frames``."""
+
+    @patch("api.routers.clean_plate_gallery.ImgproxySigner")
+    @patch("api.routers.clean_plate_gallery.MinioFrameStore")
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_returns_frames_with_image_and_thumbnail_urls(
+        self,
+        mock_repo_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_signer_cls: MagicMock,
+        client: TestClient,
+    ) -> None:
+        mock_repo_cls.return_value.query_frames.return_value = ([_make_row()], 1)
+        mock_store_cls.from_env.return_value.presign_get.return_value = (
+            "https://minio/presigned/f1.jpg"
+        )
+        mock_signer_cls.from_env.return_value.thumbnail_url.return_value = (
+            "https://imgproxy/sig/rs:fit:320:320:0/abc"
+        )
+
+        resp = client.get("/clean-plate/frames")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["limit"] == 100
+        assert body["offset"] == 0
+        assert len(body["frames"]) == 1
+        frame = body["frames"][0]
+        assert frame["id"] == "f1"
+        assert frame["image_url"] == "https://minio/presigned/f1.jpg"
+        assert frame["thumbnail_url"] == "https://imgproxy/sig/rs:fit:320:320:0/abc"
+        assert frame["record"]["optics"]["fov_deg"] == 60.0
+        # imgproxy source is the s3:// URL of the frame object.
+        mock_signer_cls.from_env.return_value.thumbnail_url.assert_called_once_with(
+            "s3://cleanplate-frames/run-1/clean_plate/pose-1/f1.jpg"
+        )
+
+    @patch("api.routers.clean_plate_gallery.ImgproxySigner")
+    @patch("api.routers.clean_plate_gallery.MinioFrameStore")
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_thumbnail_falls_back_to_image_when_imgproxy_unset(
+        self,
+        mock_repo_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        mock_signer_cls: MagicMock,
+        client: TestClient,
+    ) -> None:
+        mock_repo_cls.return_value.query_frames.return_value = ([_make_row()], 1)
+        mock_store_cls.from_env.return_value.presign_get.return_value = "https://minio/full.jpg"
+        mock_signer_cls.from_env.return_value = None  # imgproxy not configured
+
+        resp = client.get("/clean-plate/frames")
+
+        assert resp.status_code == 200
+        frame = resp.json()["frames"][0]
+        assert frame["thumbnail_url"] == "https://minio/full.jpg"
+        assert frame["image_url"] == "https://minio/full.jpg"
+
+    @patch("api.routers.clean_plate_gallery.MinioFrameStore")
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_empty_result_does_not_touch_minio(
+        self,
+        mock_repo_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        client: TestClient,
+    ) -> None:
+        mock_repo_cls.return_value.query_frames.return_value = ([], 0)
+
+        resp = client.get("/clean-plate/frames")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"frames": [], "total": 0, "limit": 100, "offset": 0}
+        mock_store_cls.from_env.assert_not_called()
+
+    @patch("api.routers.clean_plate_gallery.MinioFrameStore")
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_filters_and_pagination_passed_to_repo(
+        self,
+        mock_repo_cls: MagicMock,
+        mock_store_cls: MagicMock,
+        client: TestClient,
+    ) -> None:
+        mock_repo_cls.return_value.query_frames.return_value = ([], 0)
+
+        resp = client.get(
+            "/clean-plate/frames",
+            params={
+                "run_id": "run-7",
+                "pose_id": "pose-9",
+                "camera_id": "cam-2",
+                "phase": "clean_plate",
+                "limit": 25,
+                "offset": 50,
+            },
+        )
+
+        assert resp.status_code == 200
+        kwargs = mock_repo_cls.return_value.query_frames.call_args.kwargs
+        assert kwargs["run_id"] == "run-7"
+        assert kwargs["pose_id"] == "pose-9"
+        assert kwargs["camera_id"] == "cam-2"
+        assert kwargs["phase"] == "clean_plate"
+        assert kwargs["limit"] == 25
+        assert kwargs["offset"] == 50
+
+    def test_limit_out_of_range_is_rejected(self, client: TestClient) -> None:
+        resp = client.get("/clean-plate/frames", params={"limit": 9999})
+        assert resp.status_code == 422
+
+    def test_requires_authentication(self, client_no_auth_override: TestClient) -> None:
+        resp = client_no_auth_override.get(
+            "/clean-plate/frames",
+            headers=make_basic_auth_header("nobody", "wrong"),
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /clean-plate/runs
+# ---------------------------------------------------------------------------
+
+
+class TestGetRuns:
+    """Tests for ``GET /clean-plate/runs``."""
+
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_returns_runs(self, mock_repo_cls: MagicMock, client: TestClient) -> None:
+        mock_repo_cls.return_value.list_runs.return_value = [
+            {
+                "run_id": "run-2",
+                "frame_count": 3,
+                "first_captured_at": datetime(2026, 6, 2, 9, 0, tzinfo=timezone.utc),
+                "last_captured_at": datetime(2026, 6, 2, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "run_id": "run-1",
+                "frame_count": 5,
+                "first_captured_at": datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc),
+                "last_captured_at": datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc),
+            },
+        ]
+
+        resp = client.get("/clean-plate/runs")
+
+        assert resp.status_code == 200
+        runs = resp.json()["runs"]
+        assert len(runs) == 2
+        assert runs[0]["run_id"] == "run-2"
+        assert runs[0]["frame_count"] == 3
+        assert runs[1]["run_id"] == "run-1"
+
+    @patch("api.routers.clean_plate_gallery.RepoPostgresCleanPlateFrame")
+    def test_returns_empty_list(self, mock_repo_cls: MagicMock, client: TestClient) -> None:
+        mock_repo_cls.return_value.list_runs.return_value = []
+
+        resp = client.get("/clean-plate/runs")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"runs": []}

--- a/tests/test_api/test_imgproxy.py
+++ b/tests/test_api/test_imgproxy.py
@@ -1,0 +1,83 @@
+"""Unit tests for the imgproxy signed-URL builder."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+from api.utils.imgproxy import ImgproxySigner
+
+# imgproxy keys/salts are hex-encoded; "0011..." decodes to raw bytes.
+_KEY_HEX = "0011223344556677"
+_SALT_HEX = "8899aabbccddeeff"
+_SOURCE = "s3://cleanplate-frames/run-1/clean_plate/pose-1/f1.jpg"
+
+
+def _decode_segment(b64url: str) -> bytes:
+    padding = "=" * (-len(b64url) % 4)
+    return base64.urlsafe_b64decode(b64url + padding)
+
+
+class TestFromEnv:
+    """``ImgproxySigner.from_env`` enable/disable behaviour."""
+
+    def test_returns_none_when_any_var_missing(self) -> None:
+        assert ImgproxySigner.from_env({"IMGPROXY_BASE_URL": "https://x"}) is None
+        assert ImgproxySigner.from_env({}) is None
+
+    def test_builds_signer_when_all_vars_present(self) -> None:
+        signer = ImgproxySigner.from_env(
+            {
+                "IMGPROXY_BASE_URL": "https://imgproxy.example",
+                "IMGPROXY_KEY": _KEY_HEX,
+                "IMGPROXY_SALT": _SALT_HEX,
+            }
+        )
+        assert isinstance(signer, ImgproxySigner)
+
+
+class TestThumbnailUrl:
+    """``ImgproxySigner.thumbnail_url`` structure + signature correctness."""
+
+    def _signer(self, base_url: str = "https://imgproxy.example") -> ImgproxySigner:
+        return ImgproxySigner(base_url=base_url, key_hex=_KEY_HEX, salt_hex=_SALT_HEX)
+
+    def test_url_structure_and_encoded_source_roundtrip(self) -> None:
+        url = self._signer().thumbnail_url(_SOURCE, width=320, height=240)
+
+        prefix = "https://imgproxy.example/"
+        assert url.startswith(prefix)
+        signature, processing, encoded_source = url[len(prefix) :].split("/")
+        assert processing == "rs:fit:320:240:0"
+        assert _decode_segment(encoded_source) == _SOURCE.encode()
+        # Signature is a non-empty url-safe base64 segment.
+        assert signature and "=" not in signature
+
+    def test_signature_matches_hmac_over_salt_plus_path(self) -> None:
+        url = self._signer().thumbnail_url(_SOURCE)
+        signature, processing, encoded_source = url.split("/")[-3:]
+
+        path = f"/{processing}/{encoded_source}".encode()
+        expected = (
+            base64.urlsafe_b64encode(
+                hmac.new(
+                    bytes.fromhex(_KEY_HEX), bytes.fromhex(_SALT_HEX) + path, hashlib.sha256
+                ).digest()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        assert signature == expected
+
+    def test_different_key_yields_different_signature(self) -> None:
+        url_a = self._signer().thumbnail_url(_SOURCE)
+        other = ImgproxySigner(
+            base_url="https://imgproxy.example", key_hex="ffff", salt_hex=_SALT_HEX
+        )
+        url_b = other.thumbnail_url(_SOURCE)
+        assert url_a.split("/")[3] != url_b.split("/")[3]
+
+    def test_trailing_slash_in_base_url_is_normalised(self) -> None:
+        url = self._signer(base_url="https://imgproxy.example/").thumbnail_url(_SOURCE)
+        assert "https://imgproxy.example//" not in url

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -376,3 +376,7 @@ _.checksum_sha256  # CleanPlateFrameModel image content-hash column (poc_homogra
 # -- MinIO frame store (#284); entry points consumed by capture wiring + gallery (#285) --
 _.from_env  # MinioFrameStore env constructor; used by the maglor capture script (poc_homography/infrastructure/clients/minio_frame_store.py)
 _.presign_get  # MinioFrameStore presigned-GET URL minting; consumed by the gallery API (#285) (poc_homography/infrastructure/clients/minio_frame_store.py)
+
+# -- Clean-plate gallery repository reads (#285); consumed by the gallery API router (outside vulture scope) --
+_.query_frames  # RepoPostgresCleanPlateFrame filtered+paginated read (poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py)
+_.list_runs  # RepoPostgresCleanPlateFrame distinct-run aggregation (poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py)


### PR DESCRIPTION
Closes #285

## Summary

Adds a clean-plate gallery to browse maglor's captured floor frames quickly, with per-frame metadata, without downloading — a thin layer over MinIO (images) + Neon (metadata).

**API (`api/`)**
- New router `api/routers/clean_plate_gallery.py`:
  - `GET /clean-plate/frames` — query `clean_plate_frames` with filters (run_id, pose_id, camera_id, phase, captured_at range) + limit/offset pagination; returns metadata plus a short-TTL presigned MinIO image URL and an imgproxy thumbnail URL per frame, newest first. Presigning uses the bucket recorded on each row (authoritative).
  - `GET /clean-plate/runs` — distinct runs (run_id + frame count + first/last captured_at) for the run picker.
- `api/utils/imgproxy.py` — `ImgproxySigner`: HMAC-SHA256-signed imgproxy thumbnail URLs over `s3://bucket/key` sources. `from_env()` returns `None` when imgproxy is unconfigured, so the gallery gracefully falls back to the presigned full image.
- `api/schemas/clean_plate_gallery.py`; router wired into `api/main.py`.

**Repository (`poc_homography/`)**
- `RepoPostgresCleanPlateFrame.query_frames()` (filtered + paginated, returns rows + total) and `list_runs()` (per-run aggregation). `MinioFrameStore.presign_get()` gained an optional `bucket` override.

**SPA (`spa/`)**
- `CleanPlateGalleryPage`: run picker + responsive, lazy-loaded imgproxy thumbnail grid; clicking a thumb opens the full presigned image with pose/optics metadata. Wired into App routes, dashboard nav, and the vite `/clean-plate` proxy.

**Infra (out of this PR, per scope decision)**
- imgproxy k8s-lab deployment is tracked separately in `PedwebOrg/infra#12`. The API already mints signed URLs the deployed imgproxy will honor.

Includes a code-review pass; the bucket-authority fix above came from it.

## Test plan

- `poe validate` (ruff, format-check, pyright, pylint, vulture) — green.
- `poe test` — full suite green (1211 passed, 151 skipped; skips are DB/DVC/live-camera, expected offline).
- New endpoint tests (mocked DB + S3 + imgproxy): list/runs behaviour, filters + pagination, limit out-of-range → 422, imgproxy fallback when unconfigured, empty result does not touch MinIO, presign uses row bucket, auth required → 401.
- `imgproxy` signer unit tests: signature == HMAC over `salt + path`, base64url source round-trip, key sensitivity, base-URL normalisation.
- SPA: `tsc -b && vite build` green; changed SPA files lint clean.
