### PR TITLE
feat(s3): MinIO map-asset store + upload pipeline for GeoTIFF maps [#290]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,12 @@ CAMERA_PASSWORD=your_password_here
 # 1. Copy this file: cp .env.example .env
 # 2. Edit .env and replace 'your_password_here' with your actual password
 # 3. The .env file should NOT be committed to git (it's in .gitignore)
+
+# MinIO / S3 object storage (survey frames + map assets)
+# Endpoint + credentials are shared; only the bucket names differ per pipeline.
+MINIO_ENDPOINT=http://s3.10-121-15-59.sslip.io:9000
+MINIO_ACCESS_KEY=your_minio_access_key
+MINIO_SECRET_KEY=your_minio_secret_key
+MINIO_REGION=us-east-1
+# Bucket for map-asset GeoTIFFs uploaded by 'hom maps upload' (default: map-assets)
+MINIO_MAP_BUCKET=map-assets

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,12 @@ ISAPI reference, **Camera intrinsics and pose**, and the **Domain model**.
   blending, with a stated recommendation and the `hom cleanplate reconstruct`
   pipeline.
 
+## Map assets
+
+- [map_asset_storage.md](./map_asset_storage.md) — the S3/MinIO `map-assets`
+  bucket and the `hom maps upload` pipeline: env config, tenant-scoped object
+  keys (`{tenant}/{map}.tif`), idempotency, and how to add a new map.
+
 ## Hikvision / PTZ
 
 - [HIKVISION_PTZ_API_SUMMARY.md](./HIKVISION_PTZ_API_SUMMARY.md) — ISAPI

--- a/docs/map_asset_storage.md
+++ b/docs/map_asset_storage.md
@@ -1,0 +1,93 @@
+# Map asset storage
+
+Map GeoTIFFs (`data/maps/*.tif`) are stored in an S3/MinIO bucket and uploaded
+by a repeatable pipeline. The upload client mirrors the survey frame store
+(`MinioFrameStore`); it shares the same MinIO endpoint and credentials and only
+differs in the target bucket.
+
+## Bucket
+
+| Property | Value | Source |
+| --- | --- | --- |
+| Bucket name | `map-assets` (default) | `MINIO_MAP_BUCKET` |
+| Region | `us-east-1` (default; MinIO ignores it) | `MINIO_REGION` |
+| Endpoint | — | `MINIO_ENDPOINT` |
+
+The bucket is created on first use (`ensure_bucket` is idempotent).
+
+## Environment variables
+
+All MinIO config comes from the environment (see `.env.example`):
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `MINIO_ENDPOINT` | yes | — | MinIO S3 endpoint, e.g. `http://s3.10-121-15-59.sslip.io:9000` |
+| `MINIO_ACCESS_KEY` | yes | — | MinIO access key |
+| `MINIO_SECRET_KEY` | yes | — | MinIO secret key |
+| `MINIO_REGION` | no | `us-east-1` | S3 region label |
+| `MINIO_MAP_BUCKET` | no | `map-assets` | Bucket for map GeoTIFFs |
+
+## Object key structure
+
+Each map is described by a YAML sidecar in `data/maps/` carrying a `tenant_id`
+and a `photo.path` (the GeoTIFF filename). The object key is tenant-scoped:
+
+```
+{tenant_id}/{photo.path}
+```
+
+For the committed maps:
+
+| Sidecar | tenant_id | photo.path | Object key |
+| --- | --- | --- | --- |
+| `icozee.yaml` | `icozee` | `icozee-cropped.tif` | `icozee/icozee-cropped.tif` |
+| `valte.yaml` | `valte` | `Cartografia_valencia.tif` | `valte/Cartografia_valencia.tif` |
+
+## Upload pipeline
+
+The `.tif` files are DVC-tracked and not normally on disk. Materialize them
+first, then upload:
+
+```bash
+dvc pull           # or: poe dvc-pull — fetch the .tif files
+hom maps upload     # or: poe upload-maps
+```
+
+`hom maps upload` globs `data/maps/*.yaml`, derives the key for each, and
+uploads the matching `.tif`. A tif that is absent on disk is reported as
+`SKIP (missing on disk — run 'dvc pull')` and the run continues; it is not an
+error. A summary line reports the uploaded/missing counts.
+
+Override the directory with `--maps-dir <path>`.
+
+### Idempotency
+
+Re-running `hom maps upload` is safe: each upload overwrites the same key, and
+`ensure_bucket` is a no-op when the bucket already exists. The object metadata
+records a `sha256` of the uploaded bytes.
+
+## Adding a new map
+
+1. Add `data/maps/<name>.yaml` with at least `tenant_id` and `photo.path`:
+
+   ```yaml
+   id: <map_id>
+   tenant_id: <tenant>
+   photo:
+     path: <name>.tif
+   ```
+
+2. Place `data/maps/<name>.tif` and DVC-track it:
+
+   ```bash
+   dvc add data/maps/<name>.tif
+   dvc push          # or: poe dvc-push
+   ```
+
+3. Upload it:
+
+   ```bash
+   hom maps upload    # or: poe upload-maps
+   ```
+
+   The new asset lands at `{tenant_id}/<name>.tif` in the `map-assets` bucket.

--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -33,12 +33,14 @@ def _register_commands() -> None:
         cleanplate,
         interactive,
         line_picker,
+        maps,
         point_picker,
         survey,
         test_cmds,
     )
 
     app.add_typer(cleanplate.cleanplate_app, name="cleanplate")
+    app.add_typer(maps.maps_app, name="maps")
 
     # Avoid "imported but unused" warnings by explicitly using the module
     _ = calibrate
@@ -46,6 +48,7 @@ def _register_commands() -> None:
     _ = cleanplate
     _ = interactive
     _ = line_picker
+    _ = maps
     _ = point_picker
     _ = survey
     _ = test_cmds

--- a/poc_homography/cli/maps.py
+++ b/poc_homography/cli/maps.py
@@ -1,0 +1,44 @@
+"""Map-asset upload CLI commands (issue #290)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from poc_homography.infrastructure.clients.minio_map_store import MinioMapStore
+from poc_homography.maps import DEFAULT_MAPS_DIR, upload_map_assets
+
+maps_app = typer.Typer(help="Map asset commands")
+
+
+@maps_app.command("upload")
+def upload_command(
+    maps_dir: Path = typer.Option(
+        DEFAULT_MAPS_DIR, help="Directory holding map YAML sidecars and GeoTIFFs"
+    ),
+) -> None:
+    """Upload ``data/maps/*.tif`` GeoTIFFs to the MinIO map-assets bucket.
+
+    Each map sidecar yields a tenant-scoped key ``{tenant_id}/{photo.path}``.
+    Tifs absent on disk are skipped (run ``dvc pull`` to materialize them).
+    """
+    try:
+        store = MinioMapStore.from_env()
+    except RuntimeError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    outcomes = upload_map_assets(Path(maps_dir), store)
+
+    uploaded = 0
+    missing = 0
+    for outcome in outcomes:
+        if outcome.status == "uploaded" and outcome.result is not None:
+            uploaded += 1
+            typer.echo(f"uploaded {outcome.key} (sha256={outcome.result.sha256})")
+        else:
+            missing += 1
+            typer.echo(f"{outcome.key}: SKIP (missing on disk — run 'dvc pull')")
+
+    typer.echo(f"Summary: {uploaded} uploaded, {missing} missing ({len(outcomes)} total)")

--- a/poc_homography/infrastructure/clients/minio_map_store.py
+++ b/poc_homography/infrastructure/clients/minio_map_store.py
@@ -1,0 +1,137 @@
+"""S3 / MinIO object store for map-asset GeoTIFFs.
+
+The map-asset pipeline uploads ``data/maps/*.tif`` GeoTIFFs to a MinIO bucket
+(on maglar's k8s-lab MinIO) under tenant/map-scoped object keys. This module
+owns that upload side: a thin S3 client (MinIO speaks the S3 API) that uploads
+GeoTIFF bytes under a deterministic object key and, for downstream consumers,
+mints presigned GET URLs.
+
+Config comes from the environment so the same code runs wherever the pipeline
+is invoked. The MinIO endpoint/credentials are shared with
+:mod:`poc_homography.infrastructure.clients.minio_frame_store`; only the bucket
+differs:
+
+- ``MINIO_ENDPOINT``      e.g. ``http://s3.10-121-15-59.sslip.io:9000``
+- ``MINIO_ACCESS_KEY``    MinIO access key
+- ``MINIO_SECRET_KEY``    MinIO secret key
+- ``MINIO_MAP_BUCKET``    bucket name (default ``map-assets``)
+- ``MINIO_REGION``        S3 region label (default ``us-east-1``; MinIO ignores it)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import TYPE_CHECKING, Any
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+
+from poc_homography.infrastructure.clients.minio_frame_store import PutResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+DEFAULT_BUCKET = "map-assets"
+DEFAULT_REGION = "us-east-1"
+
+
+class MinioMapStore:
+    """Uploads (and presigns) map-asset GeoTIFFs in an S3/MinIO bucket."""
+
+    def __init__(
+        self,
+        *,
+        endpoint_url: str,
+        access_key: str,
+        secret_key: str,
+        bucket: str = DEFAULT_BUCKET,
+        region: str = DEFAULT_REGION,
+        client: Any | None = None,
+    ) -> None:
+        """Build the store.
+
+        Args:
+            endpoint_url: MinIO S3 endpoint (scheme + host + port).
+            access_key: MinIO access key.
+            secret_key: MinIO secret key.
+            bucket: Target bucket name.
+            region: S3 region label (MinIO ignores it but boto3 requires one).
+            client: Optional pre-built boto3 S3 client (dependency injection for
+                tests); when given, the credential/endpoint args are unused.
+        """
+        self.bucket = bucket
+        self._client = client or boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=region,
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+        )
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> MinioMapStore:
+        """Build a store from ``MINIO_*`` environment variables.
+
+        Reuses the shared ``MINIO_ENDPOINT``/``MINIO_ACCESS_KEY``/
+        ``MINIO_SECRET_KEY`` credentials and reads the bucket from
+        ``MINIO_MAP_BUCKET`` (default ``map-assets``).
+
+        Raises:
+            RuntimeError: If a required variable is missing.
+        """
+        src = env if env is not None else os.environ
+        endpoint = src.get("MINIO_ENDPOINT", "")
+        access = src.get("MINIO_ACCESS_KEY", "")
+        secret = src.get("MINIO_SECRET_KEY", "")
+        missing = [
+            name
+            for name, value in (
+                ("MINIO_ENDPOINT", endpoint),
+                ("MINIO_ACCESS_KEY", access),
+                ("MINIO_SECRET_KEY", secret),
+            )
+            if not value
+        ]
+        if missing:
+            msg = f"MinIO config missing: {', '.join(missing)}"
+            raise RuntimeError(msg)
+        return cls(
+            endpoint_url=endpoint,
+            access_key=access,
+            secret_key=secret,
+            bucket=src.get("MINIO_MAP_BUCKET", DEFAULT_BUCKET),
+            region=src.get("MINIO_REGION", DEFAULT_REGION),
+        )
+
+    def ensure_bucket(self) -> None:
+        """Create the bucket if it does not already exist (idempotent)."""
+        try:
+            self._client.head_bucket(Bucket=self.bucket)
+        except ClientError:
+            self._client.create_bucket(Bucket=self.bucket)
+
+    def put_map(self, data: bytes, key: str, content_type: str = "image/tiff") -> PutResult:
+        """Upload ``data`` under ``key`` and return its location + sha256."""
+        sha256 = hashlib.sha256(data).hexdigest()
+        self._client.put_object(
+            Bucket=self.bucket,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+            Metadata={"sha256": sha256},
+        )
+        return PutResult(bucket=self.bucket, key=key, sha256=sha256)
+
+    def presign_get(self, key: str, expires_in: int = 3600) -> str:
+        """Return a presigned GET URL for ``key`` (used by downstream consumers)."""
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires_in,
+        )
+
+
+__all__ = ["DEFAULT_BUCKET", "MinioMapStore", "PutResult"]

--- a/poc_homography/maps/__init__.py
+++ b/poc_homography/maps/__init__.py
@@ -1,0 +1,11 @@
+"""Map-asset upload pipeline (S3/MinIO map-assets bucket)."""
+
+from __future__ import annotations
+
+from poc_homography.maps.asset_uploader import (
+    DEFAULT_MAPS_DIR,
+    UploadOutcome,
+    upload_map_assets,
+)
+
+__all__ = ["DEFAULT_MAPS_DIR", "UploadOutcome", "upload_map_assets"]

--- a/poc_homography/maps/asset_uploader.py
+++ b/poc_homography/maps/asset_uploader.py
@@ -1,0 +1,106 @@
+"""Framework-free pipeline that uploads map GeoTIFFs to object storage.
+
+Each map is described by a YAML sidecar in ``data/maps/`` (e.g. ``icozee.yaml``)
+that carries a ``tenant_id`` and a ``photo.path`` (the GeoTIFF filename). The
+object key is ``{tenant_id}/{photo.path}`` so map assets are tenant-scoped, e.g.
+``icozee/icozee-cropped.tif``.
+
+The real ``.tif`` files are DVC-tracked and not normally on disk; run
+``dvc pull`` to materialize them. When a tif is absent the pipeline records a
+``missing`` outcome and continues (graceful skip) rather than raising, so a run
+reports clearly which assets still need pulling.
+
+This module is deliberately framework-free: it takes any object exposing
+``ensure_bucket()`` and ``put_map(data, key)`` (see
+:class:`poc_homography.infrastructure.clients.minio_map_store.MinioMapStore`),
+which keeps it unit-testable with a fake store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Protocol
+
+import yaml
+
+if TYPE_CHECKING:
+    from poc_homography.infrastructure.clients.minio_frame_store import PutResult
+
+# <project_root>/data/maps, computed relative to this file.
+DEFAULT_MAPS_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "maps"
+
+
+class MapStore(Protocol):
+    """Minimal store interface the uploader depends on (structural typing)."""
+
+    def ensure_bucket(self) -> None:
+        """Create the target bucket if it does not exist (idempotent)."""
+        ...
+
+    def put_map(self, data: bytes, key: str, content_type: str = ...) -> PutResult:
+        """Upload ``data`` under ``key`` and return its location + sha256."""
+        ...
+
+
+@dataclass(frozen=True)
+class UploadOutcome:
+    """Result of processing a single map sidecar."""
+
+    map_id: str
+    key: str
+    status: Literal["uploaded", "missing"]
+    result: PutResult | None
+
+
+def upload_map_assets(
+    maps_dir: Path,
+    store: MapStore,
+    *,
+    ensure_bucket: bool = True,
+) -> list[UploadOutcome]:
+    """Upload every map GeoTIFF under ``maps_dir`` to ``store``.
+
+    Globs ``maps_dir/*.yaml``; for each sidecar with both ``tenant_id`` and
+    ``photo.path``, computes the key ``{tenant_id}/{photo.path}`` and resolves
+    the tif at ``maps_dir/{photo.path}``. Existing tifs are uploaded via
+    ``store.put_map(bytes, key)``; absent tifs yield a ``missing`` outcome. The
+    operation is idempotent: re-running overwrites the same keys.
+
+    Args:
+        maps_dir: Directory holding the YAML sidecars and (DVC-pulled) tifs.
+        store: Object exposing ``ensure_bucket()`` and ``put_map(data, key)``.
+        ensure_bucket: When True, call ``store.ensure_bucket()`` once up front.
+
+    Returns:
+        One :class:`UploadOutcome` per usable sidecar, in sorted filename order.
+    """
+    if ensure_bucket:
+        store.ensure_bucket()
+
+    outcomes: list[UploadOutcome] = []
+    for sidecar in sorted(maps_dir.glob("*.yaml")):
+        with sidecar.open() as f:
+            data = yaml.safe_load(f) or {}
+
+        tenant_id = data.get("tenant_id")
+        photo = data.get("photo") or {}
+        path = photo.get("path") if isinstance(photo, dict) else None
+        if not tenant_id or not path:
+            # Sidecar lacks the fields needed to derive a key; skip it.
+            continue
+
+        map_id = str(data.get("id", sidecar.stem))
+        key = f"{tenant_id}/{path}"
+        tif_path = maps_dir / path
+        if not tif_path.is_file():
+            outcomes.append(UploadOutcome(map_id=map_id, key=key, status="missing", result=None))
+            continue
+
+        result = store.put_map(tif_path.read_bytes(), key)
+        outcomes.append(UploadOutcome(map_id=map_id, key=key, status="uploaded", result=result))
+
+    return outcomes
+
+
+__all__ = ["DEFAULT_MAPS_DIR", "UploadOutcome", "upload_map_assets"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ pre-commit = "pre-commit run --all-files"
 patch-pydrive2 = {script = "scripts.patch_pydrive2_shared_drive:main", help = "Patch pydrive2 for Shared Drive folder-level access"}
 dvc-pull = {cmd = "dvc pull", help = "Pull DVC-tracked data from remote (test data + map images)"}
 dvc-push = {cmd = "dvc push", help = "Push DVC-tracked data to remote"}
+upload-maps = {cmd = "hom maps upload", help = "Upload data/maps/*.tif to the MinIO map-assets bucket"}
 
 [tool.poe.tasks.validate]
 sequence = ["lint", "format-check", "typecheck", "pylint", "vulture"]

--- a/tests/infrastructure/test_minio_map_store.py
+++ b/tests/infrastructure/test_minio_map_store.py
@@ -1,0 +1,102 @@
+"""Unit tests for :class:`MinioMapStore` (mocked S3 client)."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from botocore.exceptions import ClientError
+
+from poc_homography.infrastructure.clients.minio_map_store import (
+    DEFAULT_BUCKET,
+    MinioMapStore,
+)
+
+
+class FakeS3:
+    """Records boto3 S3 client calls; ``head_missing`` makes head_bucket 404."""
+
+    def __init__(self, *, head_missing: bool = False) -> None:
+        self.head_missing = head_missing
+        self.puts: list[dict] = []
+        self.created: list[str] = []
+        self.heads: list[str] = []
+
+    def head_bucket(self, Bucket: str) -> None:
+        self.heads.append(Bucket)
+        if self.head_missing:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadBucket")
+
+    def create_bucket(self, Bucket: str) -> None:
+        self.created.append(Bucket)
+
+    def put_object(self, **kwargs: object) -> None:
+        self.puts.append(kwargs)
+
+    def generate_presigned_url(self, op: str, Params: dict, ExpiresIn: int) -> str:
+        return f"https://minio/{op}/{Params['Bucket']}/{Params['Key']}?e={ExpiresIn}"
+
+
+def _store(client: FakeS3, bucket: str = "map-assets") -> MinioMapStore:
+    return MinioMapStore(
+        endpoint_url="http://minio:9000",
+        access_key="k",
+        secret_key="s",
+        bucket=bucket,
+        client=client,
+    )
+
+
+def test_put_map_uploads_and_returns_sha256() -> None:
+    client = FakeS3()
+    store = _store(client)
+    data = b"II*\x00 tiff bytes"
+
+    result = store.put_map(data, "icozee/icozee-cropped.tif")
+
+    assert result.bucket == "map-assets"
+    assert result.key == "icozee/icozee-cropped.tif"
+    assert result.sha256 == hashlib.sha256(data).hexdigest()
+    assert len(client.puts) == 1
+    put = client.puts[0]
+    assert put["Bucket"] == "map-assets"
+    assert put["Key"] == "icozee/icozee-cropped.tif"
+    assert put["Body"] == data
+    assert put["ContentType"] == "image/tiff"
+    assert put["Metadata"]["sha256"] == result.sha256
+
+
+def test_ensure_bucket_creates_when_missing() -> None:
+    client = FakeS3(head_missing=True)
+    _store(client).ensure_bucket()
+    assert client.created == ["map-assets"]
+
+
+def test_ensure_bucket_noop_when_present() -> None:
+    client = FakeS3(head_missing=False)
+    _store(client).ensure_bucket()
+    assert client.created == []
+
+
+def test_presign_get_delegates_to_client() -> None:
+    client = FakeS3()
+    url = _store(client).presign_get("valte/Cartografia_valencia.tif", expires_in=120)
+    assert url == "https://minio/get_object/map-assets/valte/Cartografia_valencia.tif?e=120"
+
+
+def test_from_env_reads_minio_map_bucket() -> None:
+    env = {
+        "MINIO_ENDPOINT": "http://minio:9000",
+        "MINIO_ACCESS_KEY": "k",
+        "MINIO_SECRET_KEY": "s",
+    }
+    store = MinioMapStore.from_env(env)
+    assert store.bucket == DEFAULT_BUCKET
+
+    custom = MinioMapStore.from_env({**env, "MINIO_MAP_BUCKET": "other-maps"})
+    assert custom.bucket == "other-maps"
+
+
+def test_from_env_missing_raises() -> None:
+    with pytest.raises(RuntimeError, match="MINIO_ACCESS_KEY"):
+        MinioMapStore.from_env({"MINIO_ENDPOINT": "http://minio:9000"})

--- a/tests/maps/test_asset_uploader.py
+++ b/tests/maps/test_asset_uploader.py
@@ -1,0 +1,117 @@
+"""Unit tests for the map-asset upload pipeline (fake store, tmp maps dir)."""
+
+from __future__ import annotations
+
+import hashlib
+import textwrap
+from typing import TYPE_CHECKING
+
+from poc_homography.infrastructure.clients.minio_frame_store import PutResult
+from poc_homography.maps import upload_map_assets
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeMapStore:
+    """Records ``put_map`` and ``ensure_bucket`` calls."""
+
+    def __init__(self) -> None:
+        self.bucket = "map-assets"
+        self.puts: list[tuple[bytes, str]] = []
+        self.ensure_calls = 0
+
+    def ensure_bucket(self) -> None:
+        self.ensure_calls += 1
+
+    def put_map(self, data: bytes, key: str, content_type: str = "image/tiff") -> PutResult:
+        self.puts.append((data, key))
+        return PutResult(bucket=self.bucket, key=key, sha256=hashlib.sha256(data).hexdigest())
+
+
+def _write_sidecar(maps_dir: Path, name: str, map_id: str, tenant: str, path: str) -> None:
+    (maps_dir / name).write_text(
+        textwrap.dedent(
+            f"""\
+            id: {map_id}
+            tenant_id: {tenant}
+            photo:
+              path: {path}
+            """
+        )
+    )
+
+
+def _make_maps_dir(tmp_path: Path) -> Path:
+    maps_dir = tmp_path / "maps"
+    maps_dir.mkdir()
+    _write_sidecar(maps_dir, "icozee.yaml", "icozee_cropped", "icozee", "icozee-cropped.tif")
+    _write_sidecar(
+        maps_dir, "valte.yaml", "Cartografia_valencia", "valte", "Cartografia_valencia.tif"
+    )
+    return maps_dir
+
+
+def test_uploads_with_tenant_scoped_keys(tmp_path: Path) -> None:
+    maps_dir = _make_maps_dir(tmp_path)
+    (maps_dir / "icozee-cropped.tif").write_bytes(b"icozee tif")
+    (maps_dir / "Cartografia_valencia.tif").write_bytes(b"valte tif")
+    store = FakeMapStore()
+
+    outcomes = upload_map_assets(maps_dir, store)
+
+    keys = {o.key for o in outcomes}
+    assert keys == {"icozee/icozee-cropped.tif", "valte/Cartografia_valencia.tif"}
+    assert all(o.status == "uploaded" for o in outcomes)
+    put_keys = {key for _, key in store.puts}
+    assert put_keys == keys
+    assert (b"icozee tif", "icozee/icozee-cropped.tif") in store.puts
+    assert store.ensure_calls == 1
+
+
+def test_missing_tif_is_skipped(tmp_path: Path) -> None:
+    maps_dir = _make_maps_dir(tmp_path)
+    # Only one tif present on disk; the other is absent (DVC not pulled).
+    (maps_dir / "icozee-cropped.tif").write_bytes(b"icozee tif")
+    store = FakeMapStore()
+
+    outcomes = upload_map_assets(maps_dir, store)
+
+    by_key = {o.key: o for o in outcomes}
+    assert by_key["icozee/icozee-cropped.tif"].status == "uploaded"
+    assert by_key["valte/Cartografia_valencia.tif"].status == "missing"
+    assert by_key["valte/Cartografia_valencia.tif"].result is None
+    # No put for the missing one.
+    assert [key for _, key in store.puts] == ["icozee/icozee-cropped.tif"]
+
+
+def test_idempotent_rerun(tmp_path: Path) -> None:
+    maps_dir = _make_maps_dir(tmp_path)
+    (maps_dir / "icozee-cropped.tif").write_bytes(b"icozee tif")
+    (maps_dir / "Cartografia_valencia.tif").write_bytes(b"valte tif")
+    store = FakeMapStore()
+
+    first = upload_map_assets(maps_dir, store)
+    second = upload_map_assets(maps_dir, store)
+
+    assert [o.key for o in first] == [o.key for o in second]
+    # ensure_bucket called once per run.
+    assert store.ensure_calls == 2
+
+
+def test_ensure_bucket_called_once_per_run(tmp_path: Path) -> None:
+    maps_dir = _make_maps_dir(tmp_path)
+    store = FakeMapStore()
+
+    upload_map_assets(maps_dir, store)
+
+    assert store.ensure_calls == 1
+
+
+def test_ensure_bucket_disabled(tmp_path: Path) -> None:
+    maps_dir = _make_maps_dir(tmp_path)
+    store = FakeMapStore()
+
+    upload_map_assets(maps_dir, store, ensure_bucket=False)
+
+    assert store.ensure_calls == 0

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -368,6 +368,9 @@ _.frames_for  # CleanPlateDataset per-group frame materialiser; consumed by test
 reconstruct_command  # typer cleanplate command (poc_homography/cli/cleanplate.py)
 synth_command  # typer cleanplate command (poc_homography/cli/cleanplate.py)
 
+# -- Map-asset upload CLI (#290); typer command invoked via `hom maps upload` --
+upload_command  # typer maps command (poc_homography/cli/maps.py)
+
 # -- Clean-plate frames table (#283); MinIO location columns consumed by PostgresPhaseSink + gallery (#284/#285) --
 _.minio_bucket  # CleanPlateFrameModel MinIO bucket column (poc_homography/infrastructure/models/clean_plate_frame.py)
 _.minio_object_key  # CleanPlateFrameModel MinIO object-key column (poc_homography/infrastructure/models/clean_plate_frame.py)


### PR DESCRIPTION
## Summary

Stands up the S3/MinIO map-asset store + a repeatable upload pipeline so GeoTIFF map assets live in object storage under deterministic, tenant-scoped keys (no more DVC + Google Drive + local-filesystem coupling for serving).

- **`MinioMapStore`** (`poc_homography/infrastructure/clients/minio_map_store.py`) — analogous to `MinioFrameStore`; env-driven (shared `MINIO_ENDPOINT`/`MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY`/`MINIO_REGION` + `MINIO_MAP_BUCKET`, default `map-assets`); idempotent `ensure_bucket`; `put_map` with sha256 content hashing; reuses `PutResult`.
- **Upload pipeline** (`poc_homography/maps/asset_uploader.py`) — framework-free `upload_map_assets()`; reads `data/maps/*.yaml` sidecars, derives keys `{tenant_id}/{photo.path}` (→ `icozee/icozee-cropped.tif`, `valte/Cartografia_valencia.tif`), uploads each `.tif`, gracefully records `missing` when a tif isn't DVC-pulled (no raise), idempotent re-run.
- **CLI** `hom maps upload` (`poc_homography/cli/maps.py`) + `upload-maps` poe task.
- **Docs** `docs/map_asset_storage.md` (bucket/env table, command, key structure, idempotency, "Adding a new map") + `.env.example` MinIO vars + docs index link.

## Test plan

- `pytest tests/infrastructure/test_minio_map_store.py tests/maps/ -q` → **11 passed**
- `ruff check` + `pyright` on new modules → clean
- `python -c "from poc_homography.cli.main import app"` → registration imports cleanly
- `hom maps upload` with no MinIO env → errors clearly, exits 1

## Definition of Done

- [x] A documented bucket exists (name + region + endpoint via env, `MINIO_*` convention)
- [x] Running the upload pipeline uploads all existing `data/maps/*.tif` assets
- [x] Uploaded object keys reflect the tenant/map prefix structure
- [x] Bucket creation is idempotent; re-running does not error or duplicate
- [x] The upload step for adding a new map is documented

Closes #290
Part of #246