### PR TITLE
feat(s3): Map entity + ORM store asset_url/asset_key; Alembic migration [#291]

### DIFF
--- a/alembic/versions/3a9f1c4b2e7d_add_asset_ref_to_maps.py
+++ b/alembic/versions/3a9f1c4b2e7d_add_asset_ref_to_maps.py
@@ -1,0 +1,32 @@
+"""add asset_key/asset_url to maps
+
+Revision ID: 3a9f1c4b2e7d
+Revises: 121dcd273bee
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3a9f1c4b2e7d"
+down_revision: str | Sequence[str] | None = "121dcd273bee"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Object-storage reference for the GeoTIFF map asset. Nullable so existing
+    # rows need no back-fill; populated by the upload pipeline (#290).
+    op.add_column("maps", sa.Column("asset_key", sa.String(), nullable=True))
+    op.add_column("maps", sa.Column("asset_url", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("maps", "asset_url")
+    op.drop_column("maps", "asset_key")

--- a/poc_homography/domain/entities/map.py
+++ b/poc_homography/domain/entities/map.py
@@ -22,12 +22,19 @@ class Map:
         tenant_id: ID of the tenant this map belongs to (e.g., "valte").
         photo: The map image with its dimensions.
         geotiff: GeoTiff metadata for coordinate transformation.
+        asset_key: Object-storage key (e.g. ``maps/valte.tif``) for the map
+            GeoTIFF asset. Endpoint-agnostic; the API derives URLs at serve
+            time. ``None`` until the asset is uploaded (see #290).
+        asset_url: Optional fully-qualified URL to the map asset. ``None``
+            when the asset is resolved from ``asset_key`` at serve time.
     """
 
     id: str
     tenant_id: str
     photo: Photo
     geotiff: GeoTiff
+    asset_key: str | None = None
+    asset_url: str | None = None
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
@@ -44,6 +51,8 @@ class Map:
             "tenant_id": self.tenant_id,
             "photo": self.photo.to_dict(),
             "geotiff": self.geotiff.to_dict(),
+            "asset_key": self.asset_key,
+            "asset_url": self.asset_url,
         }
 
     @classmethod
@@ -57,4 +66,6 @@ class Map:
             tenant_id=data.get("tenant_id", ""),
             photo=Photo.from_dict(data["photo"]),
             geotiff=GeoTiff.from_dict(data["geotiff"]),
+            asset_key=data.get("asset_key"),
+            asset_url=data.get("asset_url"),
         )

--- a/poc_homography/infrastructure/models/map.py
+++ b/poc_homography/infrastructure/models/map.py
@@ -28,6 +28,10 @@ class MapModel(Base):
     Value objects stored as JSONB:
       - photo: ``{path, width, height}``
       - geotiff: ``{geotransform: {origin_easting, pixel_width, ...}, crs}``
+
+    Object-storage reference for the GeoTIFF asset (nullable until uploaded):
+      - asset_key: endpoint-agnostic object key (preferred)
+      - asset_url: optional fully-qualified URL
     """
 
     __tablename__ = "maps"
@@ -40,6 +44,10 @@ class MapModel(Base):
     # Value objects serialised as JSONB
     photo: Mapped[dict] = mapped_column(JSONB, nullable=False)
     geotiff: Mapped[dict] = mapped_column(JSONB, nullable=False)
+
+    # Object-storage reference for the GeoTIFF asset
+    asset_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    asset_url: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # -- relationships --
     tenant: Mapped[TenantModel] = relationship("TenantModel", back_populates="maps")

--- a/tests/domain/test_map.py
+++ b/tests/domain/test_map.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Map domain entity serialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from poc_homography.domain.entities.map import Map
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.domain.vo.photo import Photo
+from poc_homography.types import (
+    Easting,
+    Meters,
+    Northing,
+    Pixels,
+    Unitless,
+)
+
+
+def _make_map(**overrides: object) -> Map:
+    base = {
+        "id": "valte",
+        "tenant_id": "valte",
+        "photo": Photo(path=Path("valte.png"), width=Pixels(1000), height=Pixels(800)),
+        "geotiff": GeoTiff(
+            geotransform=GeoTransform(
+                origin_easting=Easting(500000.0),
+                pixel_width=Meters(0.5),
+                row_rotation=Unitless(0.0),
+                origin_northing=Northing(4400000.0),
+                col_rotation=Unitless(0.0),
+                pixel_height=Meters(-0.5),
+            ),
+            crs="EPSG:25830",
+        ),
+    }
+    base.update(overrides)
+    return Map(**base)  # type: ignore[arg-type]
+
+
+def test_asset_ref_defaults_to_none() -> None:
+    m = _make_map()
+    assert m.asset_key is None
+    assert m.asset_url is None
+    data = m.to_dict()
+    assert data["asset_key"] is None
+    assert data["asset_url"] is None
+
+
+def test_to_dict_from_dict_round_trips_asset_ref() -> None:
+    m = _make_map(
+        asset_key="maps/valte.tif",
+        asset_url="https://s3.example.test/cleanplate/maps/valte.tif",
+    )
+    restored = Map.from_dict(m.to_dict())
+    assert restored.asset_key == "maps/valte.tif"
+    assert restored.asset_url == "https://s3.example.test/cleanplate/maps/valte.tif"
+
+
+def test_from_dict_tolerates_missing_asset_ref() -> None:
+    """Rows persisted before the migration carry no asset fields."""
+    data = _make_map().to_dict()
+    del data["asset_key"]
+    del data["asset_url"]
+    restored = Map.from_dict(data)
+    assert restored.asset_key is None
+    assert restored.asset_url is None

--- a/tests/infrastructure/test_repo_postgres.py
+++ b/tests/infrastructure/test_repo_postgres.py
@@ -8,6 +8,7 @@ fixture which rolls back after each test — no permanent data is written.
 from __future__ import annotations
 
 import uuid
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Entity construction helpers
 # ---------------------------------------------------------------------------
+
 
 def _uid(prefix: str = "") -> str:
     """Return a short unique id to avoid collisions between tests."""
@@ -209,7 +211,8 @@ def _make_lens_calibration_table(camera_config_id: str) -> LensCalibrationTable:
             ZoomCalibrationEntry(
                 zoom_factor=Unitless(1.0),
                 distortion=LensDistortion(
-                    k1=Unitless(-0.1), k2=Unitless(0.01),
+                    k1=Unitless(-0.1),
+                    k2=Unitless(0.01),
                 ),
                 calibration_date="2024-01-15",
                 source_images=("img1.jpg", "img2.jpg"),
@@ -243,6 +246,7 @@ def _make_calibration_line_trace_set(name: str | None = None) -> CalibrationLine
 # Helpers to persist FK parents
 # ---------------------------------------------------------------------------
 
+
 def _persist_tenant(session: Session, tenant_id: str | None = None) -> Tenant:
     tenant = _make_tenant(tenant_id)
     RepoPostgresTenant(session).save(tenant)
@@ -253,7 +257,6 @@ def _persist_map(session: Session, tenant_id: str, map_id: str | None = None) ->
     m = _make_map(tenant_id, map_id)
     RepoPostgresMap(session).save(m)
     return m
-
 
 
 def _persist_frame(
@@ -389,7 +392,6 @@ class TestRepoPostgresMap:
         assert m1.id in ids
         assert m2.id in ids
 
-
     def test_get_by_tenant(self, db_session: Session) -> None:
         t1 = _persist_tenant(db_session)
         t2 = _persist_tenant(db_session)
@@ -416,12 +418,34 @@ class TestRepoPostgresMap:
         assert float(gt.origin_northing) == 4400000.0
         assert float(gt.pixel_height) == -0.5
 
+    def test_asset_ref_defaults_to_none(self, db_session: Session, test_tenant: Tenant) -> None:
+        repo = RepoPostgresMap(db_session)
+        m = _make_map(test_tenant.id)
+        repo.save(m)
+
+        loaded = repo.get(m.id)
+        assert loaded is not None
+        assert loaded.asset_key is None
+        assert loaded.asset_url is None
+
+    def test_asset_ref_round_trip(self, db_session: Session, test_tenant: Tenant) -> None:
+        repo = RepoPostgresMap(db_session)
+        m = replace(
+            _make_map(test_tenant.id),
+            asset_key="maps/valte.tif",
+            asset_url="https://s3.example.test/cleanplate/maps/valte.tif",
+        )
+        repo.save(m)
+
+        loaded = repo.get(m.id)
+        assert loaded is not None
+        assert loaded.asset_key == "maps/valte.tif"
+        assert loaded.asset_url == "https://s3.example.test/cleanplate/maps/valte.tif"
+
 
 @pytest.mark.integration
 class TestRepoPostgresCameraConfig:
-    def test_save_and_get(
-        self, db_session: Session, test_tenant: Tenant, test_map: Map
-    ) -> None:
+    def test_save_and_get(self, db_session: Session, test_tenant: Tenant, test_map: Map) -> None:
         repo = RepoPostgresCameraConfig(db_session)
         cc = _make_camera_config(test_tenant.id, test_map.id)
         repo.save(cc)
@@ -441,18 +465,14 @@ class TestRepoPostgresCameraConfig:
         repo = RepoPostgresCameraConfig(db_session)
         assert repo.get("nonexistent/cam") is None
 
-    def test_exists(
-        self, db_session: Session, test_tenant: Tenant, test_map: Map
-    ) -> None:
+    def test_exists(self, db_session: Session, test_tenant: Tenant, test_map: Map) -> None:
         repo = RepoPostgresCameraConfig(db_session)
         cc = _make_camera_config(test_tenant.id, test_map.id)
         repo.save(cc)
         assert repo.exists(cc.id) is True
         assert repo.exists("nonexistent/cam") is False
 
-    def test_delete(
-        self, db_session: Session, test_tenant: Tenant, test_map: Map
-    ) -> None:
+    def test_delete(self, db_session: Session, test_tenant: Tenant, test_map: Map) -> None:
         repo = RepoPostgresCameraConfig(db_session)
         cc = _make_camera_config(test_tenant.id, test_map.id)
         repo.save(cc)
@@ -460,9 +480,7 @@ class TestRepoPostgresCameraConfig:
         assert repo.delete(cc.id) is True
         assert repo.get(cc.id) is None
 
-    def test_get_all(
-        self, db_session: Session, test_tenant: Tenant, test_map: Map
-    ) -> None:
+    def test_get_all(self, db_session: Session, test_tenant: Tenant, test_map: Map) -> None:
         repo = RepoPostgresCameraConfig(db_session)
         cc1 = _make_camera_config(test_tenant.id, test_map.id)
         cc2 = _make_camera_config(test_tenant.id, test_map.id)
@@ -473,7 +491,6 @@ class TestRepoPostgresCameraConfig:
         ids = {c.id for c in all_ccs}
         assert cc1.id in ids
         assert cc2.id in ids
-
 
     def test_get_by_tenant(self, db_session: Session) -> None:
         t1 = _persist_tenant(db_session)
@@ -490,7 +507,6 @@ class TestRepoPostgresCameraConfig:
         result = repo.get_by_tenant(t1.id)
         assert cc1.id in result
         assert cc2.id not in result
-
 
     def test_get_by_map(self, db_session: Session) -> None:
         t = _persist_tenant(db_session)
@@ -825,7 +841,6 @@ class TestRepoPostgresGroundControlPoint:
         gcp = _make_gcp(test_map.id, "GCP_X")
         assert gcp.id == f"{test_map.id}/GCP_X"
 
-
     def test_get_by_map(self, db_session: Session) -> None:
         t = _persist_tenant(db_session)
         m1 = _persist_map(db_session, t.id)
@@ -895,7 +910,7 @@ class TestRepoPostgresLine:
         repo.save(l2)
 
         all_lines = repo.get_all()
-        ids = {l.id for l in all_lines}
+        ids = {ln.id for ln in all_lines}
         assert l1.id in ids
         assert l2.id in ids
 
@@ -915,10 +930,9 @@ class TestRepoPostgresLine:
         repo.save(l2)
 
         result = repo.get_by_map_id(m1.id)
-        result_ids = {l.id for l in result}
+        result_ids = {ln.id for ln in result}
         assert l1.id in result_ids
         assert l2.id not in result_ids
-
 
     def test_get_by_map(self, db_session: Session) -> None:
         t = _persist_tenant(db_session)
@@ -1108,7 +1122,7 @@ class TestRepoPostgresLensCalibrationTable:
         repo.save(lct)
 
         all_lcts = repo.get_all()
-        ids = {l.id for l in all_lcts}
+        ids = {ln.id for ln in all_lcts}
         assert lct.id in ids
 
     def test_entries_round_trip(


### PR DESCRIPTION
## Summary

Extend the `Map` domain entity and `MapModel` ORM with an object-storage reference (`asset_key` + `asset_url`) for the GeoTIFF map asset, so the app can resolve map assets from Postgres instead of a hardcoded filesystem path.

- `asset_key` — endpoint-agnostic object key (preferred; URLs derived at serve time)
- `asset_url` — optional fully-qualified URL

Both columns are **nullable**, so existing rows need no back-fill. The generic `RepoPostgres` base round-trips the new fields with no repository changes.

## Changes
- **Map entity**: nullable `asset_key`/`asset_url` fields; `to_dict`/`from_dict` round-trip (tolerant of pre-migration rows missing the keys).
- **MapModel ORM**: nullable `asset_key`/`asset_url` `String` columns.
- **Alembic migration** `3a9f1c4b2e7d`: adds both columns; verified `upgrade head` + `downgrade` against a fresh DB.
- **Tests**: DB-free domain serialization tests + Postgres repo round-trip coverage.
- Drive-by: rename pre-existing ambiguous `l` loop vars (E741) in `test_repo_postgres.py` to unblock pre-commit ruff.

## Test plan
- Domain unit tests (DB-free): `to_dict`/`from_dict` round-trip + tolerance of pre-migration rows.
- Postgres repo integration tests: asset-ref round-trip + null defaults.
- Verified `alembic upgrade head` and `downgrade` run cleanly against a fresh SSL-enabled Postgres.
- Full suite: **1249 passed, 157 skipped** (integration skipped without `DATABASE_URL`, as in CI).

## Definition of Done
- [x] `MapModel` has the asset reference column(s); migration adds them to `maps`.
- [x] `Map` entity carries the asset reference and serializes it via `to_dict`/`from_dict`.
- [x] The Map repository persists and loads the asset reference.
- [x] `alembic upgrade head` and `downgrade` run cleanly against a fresh DB.
- [x] Existing tests pass; the new field is covered.

Closes #291
Part of #246