### PR TITLE
feat(lens-calibration): multi-zoom batch calibration wizard + multi-entry save [#214]

### DIFF
--- a/api/routers/lens_calibration.py
+++ b/api/routers/lens_calibration.py
@@ -8,11 +8,10 @@ tables, intrinsics computation, and line-trace-set listing/detail.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from homography_web.calibration_utils import serialize_calibration_entry
-from sqlalchemy.orm import Session
 
 from api.deps import get_current_user, get_db_session
 from api.schemas.lens_calibration import (
@@ -31,12 +30,17 @@ from api.schemas.lens_calibration import (
     ValidateResponse,
 )
 from api.utils.frame_helpers import get_map_for_tenant
-from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo_pg
 from poc_homography.infrastructure.repositories import (
     RepoPostgresCalibrationLineTraceSet,
     RepoPostgresLensCalibrationTable,
     RepoPostgresLineAnnotation,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.infrastructure.models.user import UserModel
 
 logger = logging.getLogger(__name__)
 
@@ -158,9 +162,7 @@ def calibrate_annotated_lines(
 
         result = solver.solve(lines, intrinsic_matrix)
 
-        improvement_percent = (
-            (1 - result.improvement_ratio()) * 100 if result.success else 0.0
-        )
+        improvement_percent = (1 - result.improvement_ratio()) * 100 if result.success else 0.0
 
         return CalibrateAnnotatedLinesResponse(
             success=result.success,
@@ -191,9 +193,7 @@ def calibrate_annotated_lines(
 
     except ImportError:
         logger.exception("Annotated line solver module not available")
-        raise HTTPException(
-            status_code=500, detail="Annotated line solver module not available"
-        )
+        raise HTTPException(status_code=500, detail="Annotated line solver module not available")
     except HTTPException:
         raise
     except Exception:
@@ -265,9 +265,7 @@ def validate_calibration(
         corrected_rmse = straightness_rmse(camera_lines, intrinsic_matrix, distortion=distortion)
 
         improvement = (
-            (baseline_rmse - corrected_rmse) / baseline_rmse * 100
-            if baseline_rmse > 0
-            else 0
+            (baseline_rmse - corrected_rmse) / baseline_rmse * 100 if baseline_rmse > 0 else 0
         )
 
         return ValidateResponse(
@@ -299,9 +297,37 @@ def save_calibration(
             CameraCalibrationTable,
             ZoomCalibrationEntry,
         )
-        from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo_pg
         from poc_homography.domain.vo import LensDistortion
         from poc_homography.types import Unitless
+
+        if body.zoom_entries:
+            table = CameraCalibrationTable(camera_id=body.camera_id)
+            for e in body.zoom_entries:
+                e_coeffs = e.coefficients
+                e_distortion = LensDistortion(
+                    k1=Unitless(e_coeffs.k1),
+                    k2=Unitless(e_coeffs.k2),
+                    k3=Unitless(e_coeffs.k3),
+                    p1=Unitless(e_coeffs.p1),
+                    p2=Unitless(e_coeffs.p2),
+                )
+                table.add_entry(
+                    ZoomCalibrationEntry.from_solver_result(
+                        zoom_factor=e.zoom,
+                        distortion=e_distortion,
+                        validation_rmse=e.validation_rmse,
+                        source_images=[],
+                        num_lines_used=e.num_lines,
+                        fx=float(e.intrinsics.fx) if e.intrinsics else 0.0,
+                        fy=float(e.intrinsics.fy) if e.intrinsics else 0.0,
+                        cx=float(e.intrinsics.cx) if e.intrinsics else 0.0,
+                        cy=float(e.intrinsics.cy) if e.intrinsics else 0.0,
+                    )
+                )
+
+            sync_to_ddd_repo_pg(table, session)
+
+            return SaveCalibrationResponse(success=True, camera_id=body.camera_id)
 
         coeffs = body.coefficients
         distortion = LensDistortion(

--- a/api/routers/lens_calibration.py
+++ b/api/routers/lens_calibration.py
@@ -28,6 +28,7 @@ from api.schemas.lens_calibration import (
     SaveCalibrationResponse,
     ValidateRequest,
     ValidateResponse,
+    ZoomEntryIn,
 )
 from api.utils.frame_helpers import get_map_for_tenant
 from poc_homography.calibration.lens_distortion.ddd_sync import sync_to_ddd_repo_pg
@@ -300,57 +301,41 @@ def save_calibration(
         from poc_homography.domain.vo import LensDistortion
         from poc_homography.types import Unitless
 
-        if body.zoom_entries:
-            table = CameraCalibrationTable(camera_id=body.camera_id)
-            for e in body.zoom_entries:
-                e_coeffs = e.coefficients
-                e_distortion = LensDistortion(
-                    k1=Unitless(e_coeffs.k1),
-                    k2=Unitless(e_coeffs.k2),
-                    k3=Unitless(e_coeffs.k3),
-                    p1=Unitless(e_coeffs.p1),
-                    p2=Unitless(e_coeffs.p2),
-                )
-                table.add_entry(
-                    ZoomCalibrationEntry.from_solver_result(
-                        zoom_factor=e.zoom,
-                        distortion=e_distortion,
-                        validation_rmse=e.validation_rmse,
-                        source_images=[],
-                        num_lines_used=e.num_lines,
-                        fx=float(e.intrinsics.fx) if e.intrinsics else 0.0,
-                        fy=float(e.intrinsics.fy) if e.intrinsics else 0.0,
-                        cx=float(e.intrinsics.cx) if e.intrinsics else 0.0,
-                        cy=float(e.intrinsics.cy) if e.intrinsics else 0.0,
-                    )
-                )
-
-            sync_to_ddd_repo_pg(table, session)
-
-            return SaveCalibrationResponse(success=True, camera_id=body.camera_id)
-
-        coeffs = body.coefficients
-        distortion = LensDistortion(
-            k1=Unitless(coeffs.k1),
-            k2=Unitless(coeffs.k2),
-            k3=Unitless(coeffs.k3),
-            p1=Unitless(coeffs.p1),
-            p2=Unitless(coeffs.p2),
-        )
+        # Normalize the two request shapes into a single list of entries: the
+        # legacy single-entry body is just the 1-element case of a multi-zoom
+        # batch. This keeps the save logic below at one altitude (one loop).
+        entries = body.zoom_entries or [
+            ZoomEntryIn(
+                zoom=body.zoom,
+                coefficients=body.coefficients,
+                intrinsics=body.intrinsics,
+                validation_rmse=body.validation_rmse,
+                num_lines=body.num_lines,
+            )
+        ]
 
         table = CameraCalibrationTable(camera_id=body.camera_id)
-        entry = ZoomCalibrationEntry.from_solver_result(
-            zoom_factor=body.zoom,
-            distortion=distortion,
-            validation_rmse=body.validation_rmse,
-            source_images=[],
-            num_lines_used=body.num_lines,
-            fx=float(body.intrinsics.fx) if body.intrinsics else 0.0,
-            fy=float(body.intrinsics.fy) if body.intrinsics else 0.0,
-            cx=float(body.intrinsics.cx) if body.intrinsics else 0.0,
-            cy=float(body.intrinsics.cy) if body.intrinsics else 0.0,
-        )
-        table.add_entry(entry)
+        for e in entries:
+            distortion = LensDistortion(
+                k1=Unitless(e.coefficients.k1),
+                k2=Unitless(e.coefficients.k2),
+                k3=Unitless(e.coefficients.k3),
+                p1=Unitless(e.coefficients.p1),
+                p2=Unitless(e.coefficients.p2),
+            )
+            table.add_entry(
+                ZoomCalibrationEntry.from_solver_result(
+                    zoom_factor=e.zoom,
+                    distortion=distortion,
+                    validation_rmse=e.validation_rmse,
+                    source_images=[],
+                    num_lines_used=e.num_lines,
+                    fx=float(e.intrinsics.fx) if e.intrinsics else 0.0,
+                    fy=float(e.intrinsics.fy) if e.intrinsics else 0.0,
+                    cx=float(e.intrinsics.cx) if e.intrinsics else 0.0,
+                    cy=float(e.intrinsics.cy) if e.intrinsics else 0.0,
+                )
+            )
 
         sync_to_ddd_repo_pg(table, session)
 

--- a/api/schemas/lens_calibration.py
+++ b/api/schemas/lens_calibration.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
-
 # ---------------------------------------------------------------------------
 # Shared sub-models
 # ---------------------------------------------------------------------------
@@ -131,6 +130,16 @@ class ValidateResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class ZoomEntryIn(BaseModel):
+    """Single per-zoom calibration entry for a multi-zoom batch save."""
+
+    zoom: float
+    coefficients: DistortionCoefficients = Field(default_factory=DistortionCoefficients)
+    intrinsics: IntrinsicsOut | None = None
+    validation_rmse: float = 0.0
+    num_lines: int = 0
+
+
 class SaveCalibrationRequest(BaseModel):
     """Body for ``POST /api/save/``."""
 
@@ -140,6 +149,7 @@ class SaveCalibrationRequest(BaseModel):
     validation_rmse: float = 0.0
     intrinsics: IntrinsicsOut | None = None
     num_lines: int = 0
+    zoom_entries: list[ZoomEntryIn] | None = None
 
 
 class SaveCalibrationResponse(BaseModel):

--- a/spa/src/api/schema.d.ts
+++ b/spa/src/api/schema.d.ts
@@ -851,6 +851,121 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/camera-evaluation/survey/run/start/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Api Survey Run Start
+         * @description Launch a multi-camera survey run.
+         *
+         *     SPA-hook: POST /camera-evaluation/survey/run/start/ — body
+         *     ``{"plan_config", "camera_ids"}``; returns ``{"run_id", "session_ids"}``.
+         */
+        post: operations["api_survey_run_start_camera_evaluation_survey_run_start__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/camera-evaluation/survey/run/{run_id}/status/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Api Survey Run Status
+         * @description Get per-camera status for a survey run.
+         *
+         *     SPA-hook: GET /camera-evaluation/survey/run/{run_id}/status/ — returns
+         *     ``{"run_id", "cameras": {camera_id: {phase, frame_count, ...}}}``.
+         */
+        get: operations["api_survey_run_status_camera_evaluation_survey_run__run_id__status__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/camera-evaluation/survey/run/{run_id}/abort/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Api Survey Run Abort
+         * @description Request graceful abort of a survey run.
+         *
+         *     SPA-hook: POST /camera-evaluation/survey/run/{run_id}/abort/ — returns
+         *     ``{"run_id", "message"}``.
+         */
+        post: operations["api_survey_run_abort_camera_evaluation_survey_run__run_id__abort__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/camera-evaluation/survey/runs/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Api Survey Runs
+         * @description List survey-run summaries (newest first).
+         *
+         *     SPA-hook: GET /camera-evaluation/survey/runs/ — returns
+         *     ``{"runs", "limit", "offset"}``.
+         */
+        get: operations["api_survey_runs_camera_evaluation_survey_runs__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/camera-evaluation/survey/runs/{run_id}/groups/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Api Survey Run Groups
+         * @description Browse dataset grouping keys with frame counts for a survey run.
+         *
+         *     SPA-hook: GET /camera-evaluation/survey/runs/{run_id}/groups/ — optional
+         *     ``phase``/``camera``/``zoom`` filters; returns ``{"groups": [...]}``.
+         */
+        get: operations["api_survey_run_groups_camera_evaluation_survey_runs__run_id__groups__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/camera-line-annotator/api/images/": {
         parameters: {
             query?: never;
@@ -1007,6 +1122,49 @@ export interface paths {
          * @description Get camera PTZ status for a specific image.
          */
         get: operations["camera_status_camera_line_annotator_api_camera_status__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/clean-plate/frames": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Frames
+         * @description Query clean-plate frames with filters + pagination.
+         *
+         *     Returns metadata plus a presigned MinIO image URL and an imgproxy thumbnail
+         *     URL per frame, newest first.
+         */
+        get: operations["get_frames_clean_plate_frames_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/clean-plate/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Runs
+         * @description List distinct capture runs (with frame counts and time spans).
+         */
+        get: operations["get_runs_clean_plate_runs_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1752,8 +1910,8 @@ export interface paths {
          * Add Line
          * @description Add a new line.
          *
-         *     Persists to the YAML repo before mutating in-memory state so a failed
-         *     write never leaves state and disk out of sync.
+         *     Persists to the database before mutating in-memory state so a failed
+         *     write never leaves state and DB out of sync.
          */
         post: operations["add_line_line_picker_api_lines__post"];
         delete?: never;
@@ -1907,8 +2065,8 @@ export interface paths {
          * Add Point
          * @description Add a new GCP.
          *
-         *     Persists to the YAML repo before mutating in-memory state so a failed
-         *     write never leaves state and disk out of sync.
+         *     Persists to the database before mutating in-memory state so a failed
+         *     write never leaves state and DB out of sync.
          */
         post: operations["add_point_point_picker_api_points__post"];
         delete?: never;
@@ -2177,6 +2335,59 @@ export interface components {
             tilt?: number | null;
             /** Zoom */
             zoom?: number | null;
+        };
+        /**
+         * CleanPlateFrameListResponse
+         * @description Envelope for ``GET /clean-plate/frames``.
+         */
+        CleanPlateFrameListResponse: {
+            /** Frames */
+            frames: components["schemas"]["CleanPlateFrameOut"][];
+            /** Total */
+            total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+        };
+        /**
+         * CleanPlateFrameOut
+         * @description A single clean-plate frame: metadata + presigned image + thumbnail URL.
+         */
+        CleanPlateFrameOut: {
+            /** Id */
+            id: string;
+            /** Run Id */
+            run_id: string;
+            /** Camera Id */
+            camera_id: string;
+            /** Phase */
+            phase: string;
+            /** Pose Id */
+            pose_id: string;
+            /** Commanded Pan */
+            commanded_pan: number;
+            /** Commanded Tilt */
+            commanded_tilt: number;
+            /** Commanded Zoom */
+            commanded_zoom: number;
+            /** Burst Id */
+            burst_id: string | null;
+            /** Frame Index */
+            frame_index: number;
+            /**
+             * Captured At
+             * Format: date-time
+             */
+            captured_at: string;
+            /** Image Url */
+            image_url: string;
+            /** Thumbnail Url */
+            thumbnail_url: string;
+            /** Record */
+            record: {
+                [key: string]: unknown;
+            };
         };
         /**
          * ComputeHomographyFromLinesRequest
@@ -2488,10 +2699,6 @@ export interface components {
          * @description Response for ``GET /api/geo-coords/``.
          */
         GeoCoordsResponse: {
-            /** Pixel X */
-            pixel_x: number;
-            /** Pixel Y */
-            pixel_y: number;
             /** Easting */
             easting?: number | null;
             /** Northing */
@@ -2683,11 +2890,11 @@ export interface components {
             /** Map Id */
             map_id: string;
             /** Lines */
-            lines: components["schemas"]["LineOut"][];
+            lines: components["schemas"]["api__schemas__line_picker__LineOut"][];
         };
         /**
          * LineOut
-         * @description Single line serialisation.
+         * @description Single line in the registry.
          */
         LineOut: {
             /** Line Id */
@@ -2709,7 +2916,7 @@ export interface components {
             /** Map Id */
             map_id: string | null;
             /** Lines */
-            lines: components["schemas"]["api__schemas__homography_precision__LineOut"][];
+            lines: components["schemas"]["LineOut"][];
         };
         /**
          * LineTestCaseDetailResponse
@@ -2769,7 +2976,7 @@ export interface components {
         };
         /**
          * LoadCalibrationRequest
-         * @description Body for ``POST /api/load-calibration/``.
+         * @description Body for ``POST /api/load/``.
          */
         LoadCalibrationRequest: {
             /** Camera Id */
@@ -2777,7 +2984,7 @@ export interface components {
         };
         /**
          * LoadCalibrationResponse
-         * @description Response for ``POST /api/load-calibration/``.
+         * @description Response for ``POST /api/load/``.
          */
         LoadCalibrationResponse: {
             /** Camera Id */
@@ -2955,6 +3162,34 @@ export interface components {
             camera_ids?: string[] | null;
         };
         /**
+         * RunListResponse
+         * @description Envelope for ``GET /clean-plate/runs``.
+         */
+        RunListResponse: {
+            /** Runs */
+            runs: components["schemas"]["RunOut"][];
+        };
+        /**
+         * RunOut
+         * @description A distinct capture run with its frame count and time span.
+         */
+        RunOut: {
+            /** Run Id */
+            run_id: string;
+            /** Frame Count */
+            frame_count: number;
+            /**
+             * First Captured At
+             * Format: date-time
+             */
+            first_captured_at: string;
+            /**
+             * Last Captured At
+             * Format: date-time
+             */
+            last_captured_at: string;
+        };
+        /**
          * SaveAnnotationsRequest
          * @description Body for ``POST /api/save-annotations/``.
          */
@@ -3001,6 +3236,8 @@ export interface components {
              * @default 0
              */
             num_lines: number;
+            /** Zoom Entries */
+            zoom_entries?: components["schemas"]["ZoomEntryIn"][] | null;
         };
         /**
          * SaveCalibrationResponse
@@ -3070,6 +3307,18 @@ export interface components {
              * @default false
              */
             max_speed: boolean;
+        };
+        /**
+         * SurveyRunStartRequest
+         * @description Body for ``POST /camera-evaluation/survey/run/start/``.
+         */
+        SurveyRunStartRequest: {
+            /** Plan Config */
+            plan_config: {
+                [key: string]: unknown;
+            };
+            /** Camera Ids */
+            camera_ids: string[];
         };
         /**
          * SurveyStartRequest
@@ -3378,6 +3627,26 @@ export interface components {
             points?: number[][] | null;
         };
         /**
+         * ZoomEntryIn
+         * @description Single per-zoom calibration entry for a multi-zoom batch save.
+         */
+        ZoomEntryIn: {
+            /** Zoom */
+            zoom: number;
+            coefficients?: components["schemas"]["DistortionCoefficients"];
+            intrinsics?: components["schemas"]["IntrinsicsOut"] | null;
+            /**
+             * Validation Rmse
+             * @default 0
+             */
+            validation_rmse: number;
+            /**
+             * Num Lines
+             * @default 0
+             */
+            num_lines: number;
+        };
+        /**
          * SwitchImageResponse
          * @description Response for ``POST /api/switch-image/``.
          */
@@ -3391,20 +3660,24 @@ export interface components {
             camera_status: components["schemas"]["CameraStatusOut"];
         };
         /**
-         * LineOut
-         * @description Single line in the registry.
+         * LoadCalibrationRequest
+         * @description Body for ``POST /api/load-calibration/``.
          */
-        api__schemas__homography_precision__LineOut: {
-            /** Line Id */
-            line_id: string;
-            /** Start X */
-            start_x: number;
-            /** Start Y */
-            start_y: number;
-            /** End X */
-            end_x: number;
-            /** End Y */
-            end_y: number;
+        api__schemas__distortion_validator__LoadCalibrationRequest: {
+            /** Camera Id */
+            camera_id: string;
+        };
+        /**
+         * LoadCalibrationResponse
+         * @description Response for ``POST /api/load-calibration/``.
+         */
+        api__schemas__distortion_validator__LoadCalibrationResponse: {
+            /** Camera Id */
+            camera_id: string;
+            /** Entries */
+            entries: {
+                [key: string]: unknown;
+            }[];
         };
         /**
          * IntrinsicsIn
@@ -3449,30 +3722,30 @@ export interface components {
             zoom?: number | null;
         };
         /**
-         * LoadCalibrationRequest
-         * @description Body for ``POST /api/load/``.
+         * LineOut
+         * @description Single line serialisation.
          */
-        api__schemas__lens_calibration__LoadCalibrationRequest: {
-            /** Camera Id */
-            camera_id: string;
-        };
-        /**
-         * LoadCalibrationResponse
-         * @description Response for ``POST /api/load/``.
-         */
-        api__schemas__lens_calibration__LoadCalibrationResponse: {
-            /** Camera Id */
-            camera_id: string;
-            /** Entries */
-            entries: {
-                [key: string]: unknown;
-            }[];
+        api__schemas__line_picker__LineOut: {
+            /** Line Id */
+            line_id: string;
+            /** Start X */
+            start_x: number;
+            /** Start Y */
+            start_y: number;
+            /** End X */
+            end_x: number;
+            /** End Y */
+            end_y: number;
         };
         /**
          * GeoCoordsResponse
          * @description Response for ``GET /api/geo-coords/``.
          */
-        api__schemas__line_picker__GeoCoordsResponse: {
+        api__schemas__point_picker__GeoCoordsResponse: {
+            /** Pixel X */
+            pixel_x: number;
+            /** Pixel Y */
+            pixel_y: number;
             /** Easting */
             easting?: number | null;
             /** Northing */
@@ -4769,6 +5042,168 @@ export interface operations {
             };
         };
     };
+    api_survey_run_start_camera_evaluation_survey_run_start__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SurveyRunStartRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    api_survey_run_status_camera_evaluation_survey_run__run_id__status__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    api_survey_run_abort_camera_evaluation_survey_run__run_id__abort__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    api_survey_runs_camera_evaluation_survey_runs__get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    api_survey_run_groups_camera_evaluation_survey_runs__run_id__groups__get: {
+        parameters: {
+            query?: {
+                phase?: number | null;
+                camera?: string | null;
+                zoom?: number | null;
+            };
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_images_camera_line_annotator_api_images__get: {
         parameters: {
             query: {
@@ -5068,6 +5503,64 @@ export interface operations {
             };
         };
     };
+    get_frames_clean_plate_frames_get: {
+        parameters: {
+            query?: {
+                run_id?: string | null;
+                pose_id?: string | null;
+                camera_id?: string | null;
+                phase?: string | null;
+                captured_after?: string | null;
+                captured_before?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CleanPlateFrameListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_runs_clean_plate_runs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunListResponse"];
+                };
+            };
+        };
+    };
     calibration_files_distortion_validator_api_calibration_files__get: {
         parameters: {
             query?: never;
@@ -5097,7 +5590,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["LoadCalibrationRequest"];
+                "application/json": components["schemas"]["api__schemas__distortion_validator__LoadCalibrationRequest"];
             };
         };
         responses: {
@@ -5107,7 +5600,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LoadCalibrationResponse"];
+                    "application/json": components["schemas"]["api__schemas__distortion_validator__LoadCalibrationResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5936,7 +6429,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["api__schemas__lens_calibration__LoadCalibrationRequest"];
+                "application/json": components["schemas"]["LoadCalibrationRequest"];
             };
         };
         responses: {
@@ -5946,7 +6439,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__schemas__lens_calibration__LoadCalibrationResponse"];
+                    "application/json": components["schemas"]["LoadCalibrationResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6226,7 +6719,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LineOut"];
+                    "application/json": components["schemas"]["api__schemas__line_picker__LineOut"];
                 };
             };
             /** @description Validation Error */
@@ -6263,7 +6756,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LineOut"];
+                    "application/json": components["schemas"]["api__schemas__line_picker__LineOut"];
                 };
             };
             /** @description Validation Error */
@@ -6360,7 +6853,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__schemas__line_picker__GeoCoordsResponse"];
+                    "application/json": components["schemas"]["GeoCoordsResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6659,7 +7152,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GeoCoordsResponse"];
+                    "application/json": components["schemas"]["api__schemas__point_picker__GeoCoordsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/spa/src/pages/DistortionValidatorPage.module.css
+++ b/spa/src/pages/DistortionValidatorPage.module.css
@@ -715,3 +715,80 @@
 .calMethodLabel {
   color: #78909c;
 }
+
+/* ---------- Compare Zoom Levels ---------- */
+.compareToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #b0bec5;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.compareToggle input {
+  cursor: pointer;
+}
+
+.compareWrapper {
+  flex: 1;
+  overflow: auto;
+  background: #0d0d0d;
+  padding: 16px;
+}
+
+.compareGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.compareCell {
+  background: #263238;
+  border: 1px solid #37474f;
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.compareCellHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  background: #37474f;
+}
+
+.compareCellZoom {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.compareCellRmse {
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.compareCellImage {
+  background: #0d0d0d;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.compareCellImage img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.compareCellError {
+  color: #e57373;
+  font-size: 12px;
+  padding: 24px;
+  text-align: center;
+}

--- a/spa/src/pages/DistortionValidatorPage.tsx
+++ b/spa/src/pages/DistortionValidatorPage.tsx
@@ -69,6 +69,13 @@ interface StatusMessage {
   type: 'info' | 'success' | 'error';
 }
 
+interface ZoomCompareCell {
+  zoomFactor: number;
+  validationRmse?: number;
+  imageUrl: string | null;
+  error: string | null;
+}
+
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */
 /* ------------------------------------------------------------------ */
@@ -140,6 +147,16 @@ function drawLine(
   }
 }
 
+function rmseQuality(rmse: number | undefined): {
+  label: string;
+  color: string;
+} {
+  if (rmse === undefined) return { label: 'N/A', color: '#78909c' };
+  if (rmse < 2.0) return { label: 'good', color: '#4caf50' };
+  if (rmse < 5.0) return { label: 'acceptable', color: '#ff9800' };
+  return { label: 'poor', color: '#f44336' };
+}
+
 function statClass(value: number): string {
   if (value < 1) return styles.statGood;
   if (value < 3) return styles.statWarning;
@@ -203,6 +220,11 @@ export default function DistortionValidatorPage() {
   const [undistortedDataUrl, setUndistortedDataUrl] = useState<string | null>(
     null,
   );
+
+  // Compare Zoom Levels mode
+  const [compareZoom, setCompareZoom] = useState(false);
+  const [compareCells, setCompareCells] = useState<ZoomCompareCell[]>([]);
+  const [comparing, setComparing] = useState(false);
 
   // Panning state stored in ref to avoid re-renders during drag
   const panRef = useRef({
@@ -380,6 +402,73 @@ export default function DistortionValidatorPage() {
   }, [coefficients, selectedImage, intrinsics, showStatus]);
 
   const loadCountRef = useRef(0);
+
+  /* ---- Compare Zoom Levels ---- */
+  const canCompareZoom = (calibration?.entries.length ?? 0) > 1;
+
+  const runZoomComparison = useCallback(
+    async (imagePath: string) => {
+    if (!calibration || !imagePath) return;
+    setComparing(true);
+    showStatus('Comparing zoom levels...', 'info');
+
+    const entries = calibration.entries;
+    const results = await Promise.all(
+      entries.map(async (entry): Promise<ZoomCompareCell> => {
+        try {
+          const { data, error } = await client.POST(
+            '/distortion-validator/api/undistort/',
+            {
+              body: {
+                image_path: imagePath,
+                coefficients: entry.coefficients,
+                intrinsics: entry.intrinsics ?? intrinsics,
+                use_opencv: false,
+              },
+            },
+          );
+          if (error || !data) {
+            return {
+              zoomFactor: entry.zoom_factor,
+              validationRmse: entry.validation_rmse,
+              imageUrl: null,
+              error: 'Undistort failed',
+            };
+          }
+          const imageUrl =
+            data.undistorted_url ??
+            'data:image/jpeg;base64,' + (data.undistorted ?? '');
+          return {
+            zoomFactor: entry.zoom_factor,
+            validationRmse: entry.validation_rmse,
+            imageUrl,
+            error: null,
+          };
+        } catch {
+          return {
+            zoomFactor: entry.zoom_factor,
+            validationRmse: entry.validation_rmse,
+            imageUrl: null,
+            error: 'Undistort error',
+          };
+        }
+      }),
+    );
+
+    setCompareCells(results);
+    setComparing(false);
+    const failures = results.filter((r) => r.error !== null).length;
+    if (failures > 0) {
+      showStatus(
+        `Compared ${results.length} zoom levels (${failures} failed)`,
+        failures === results.length ? 'error' : 'info',
+      );
+    } else {
+      showStatus(`Compared ${results.length} zoom levels`, 'success');
+    }
+    },
+    [calibration, intrinsics, showStatus],
+  );
 
   const onImageLoaded = useCallback(() => {
     loadCountRef.current += 1;
@@ -1066,9 +1155,13 @@ export default function DistortionValidatorPage() {
           <label>Image:</label>
           <select
             value={selectedImage}
-            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-              setSelectedImage(e.target.value)
-            }
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+              const val = e.target.value;
+              setSelectedImage(val);
+              if (compareZoom && canCompareZoom && val) {
+                runZoomComparison(val);
+              }
+            }}
           >
             <option value="">-- Select image --</option>
             {images.map((img) => (
@@ -1086,6 +1179,25 @@ export default function DistortionValidatorPage() {
         >
           {applying ? 'Applying...' : 'Apply Undistortion'}
         </button>
+
+        {canCompareZoom && (
+          <label className={styles.compareToggle}>
+            <input
+              type="checkbox"
+              checked={compareZoom}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const on = e.target.checked;
+                setCompareZoom(on);
+                if (on && selectedImage) {
+                  runZoomComparison(selectedImage);
+                } else if (!on) {
+                  setCompareCells([]);
+                }
+              }}
+            />
+            Compare Zoom Levels
+          </label>
+        )}
       </div>
 
       {/* -------- Main content -------- */}
@@ -1145,9 +1257,64 @@ export default function DistortionValidatorPage() {
             </div>
           </div>
 
+          {compareZoom && canCompareZoom ? (
+            <div className={styles.compareWrapper}>
+              {!selectedImage ? (
+                <div className={styles.emptyState}>
+                  Select an image to compare zoom levels
+                </div>
+              ) : comparing ? (
+                <div className={styles.emptyState}>
+                  Comparing zoom levels...
+                </div>
+              ) : (
+                <div className={styles.compareGrid}>
+                  {compareCells.map((cell, i) => {
+                    const q = rmseQuality(cell.validationRmse);
+                    return (
+                      <div key={i} className={styles.compareCell}>
+                        <div className={styles.compareCellHeader}>
+                          <span className={styles.compareCellZoom}>
+                            {cell.zoomFactor}x
+                          </span>
+                          <span
+                            className={styles.compareCellRmse}
+                            style={{ color: q.color }}
+                          >
+                            RMSE:{' '}
+                            {cell.validationRmse !== undefined
+                              ? cell.validationRmse.toFixed(3)
+                              : 'N/A'}{' '}
+                            ({q.label})
+                          </span>
+                        </div>
+                        <div className={styles.compareCellImage}>
+                          {cell.error ? (
+                            <div className={styles.compareCellError}>
+                              {cell.error}
+                            </div>
+                          ) : cell.imageUrl ? (
+                            <img
+                              alt={`Undistorted at ${cell.zoomFactor}x`}
+                              src={cell.imageUrl}
+                            />
+                          ) : (
+                            <div className={styles.compareCellError}>
+                              No image
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : null}
           <div
             ref={wrapperRef}
             className={styles.imageWrapper}
+            style={{ display: compareZoom && canCompareZoom ? 'none' : undefined }}
             onWheel={handleWheel}
             onMouseDown={handleWrapperMouseDown}
           >

--- a/spa/src/pages/LensCalibrationPage.module.css
+++ b/spa/src/pages/LensCalibrationPage.module.css
@@ -466,3 +466,132 @@
 .validationResult {
   margin-top: 12px;
 }
+
+/* ---------- Multi-zoom mode toggle bar ---------- */
+.modeToggleBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 12px 16px;
+  margin-bottom: 20px;
+}
+
+/* ---------- Resume session banner ---------- */
+.resumeBanner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: #e3f2fd;
+  color: #1565c0;
+  border: 1px solid #90caf9;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.resumeBannerActions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ---------- Zoom configurator chips ---------- */
+.zoomChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 8px 0 12px;
+}
+
+.zoomChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #e3f2fd;
+  color: #1565c0;
+  border-radius: 16px;
+  padding: 4px 6px 4px 12px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.zoomChipRemove {
+  border: none;
+  background: rgba(21, 101, 192, 0.15);
+  color: #1565c0;
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  line-height: 1;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+}
+
+.zoomChipRemove:hover {
+  background: rgba(21, 101, 192, 0.3);
+}
+
+.zoomConfigRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.zoomAddInput {
+  width: 110px;
+  padding: 6px 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.zoomAddEntryRow {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* ---------- Zoom status dots ---------- */
+.zoomDot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.zoomDotPending {
+  background: #9e9e9e;
+}
+
+.zoomDotCalibrating {
+  background: #2196f3;
+}
+
+.zoomDotSuccess {
+  background: #4caf50;
+}
+
+.zoomDotFailed {
+  background: #c62828;
+}
+
+.zoomDotSkipped {
+  background: #cfd8dc;
+}
+
+.zoomFailMsg {
+  color: #c62828;
+  font-size: 11px;
+}

--- a/spa/src/pages/LensCalibrationPage.tsx
+++ b/spa/src/pages/LensCalibrationPage.tsx
@@ -55,6 +55,49 @@ interface ValidationResult {
   num_lines: number;
 }
 
+// -- Multi-zoom batch types --
+// NOTE: multi-zoom mode uses the annotated line-trace sets as its ONLY input,
+// mirroring issue #214's decision that manual lines feed single-zoom only.
+type ZoomStatus = 'pending' | 'calibrating' | 'success' | 'failed' | 'skipped';
+
+interface ZoomResult {
+  status: ZoomStatus;
+  coefficients?: DistortionCoefficients;
+  intrinsics?: Intrinsics;
+  rmse?: number;
+  num_lines?: number;
+  message?: string;
+  loaded?: boolean; // came from a loaded camera (vs freshly calibrated)
+  loadedRmse?: number; // original loaded RMSE, for overwrite confirmation
+}
+
+interface PersistedSession {
+  multiZoomMode: boolean;
+  zoomLevels: number[];
+  results: Record<string, ZoomResult>;
+  cameraId: string;
+}
+
+const ZOOM_STATUS_CLASSES: Record<ZoomStatus, string> = {
+  pending: styles.zoomDotPending,
+  calibrating: styles.zoomDotCalibrating,
+  success: styles.zoomDotSuccess,
+  failed: styles.zoomDotFailed,
+  skipped: styles.zoomDotSkipped,
+};
+
+const SESSION_KEY_PREFIX = 'lens_calibration_session_';
+const LAST_SESSION_KEY = 'lens_calibration_session_last';
+
+function parseZoomList(raw: string): number[] {
+  const seen = new Set<number>();
+  for (const part of raw.split(',')) {
+    const n = parseFloat(part.trim());
+    if (!Number.isNaN(n) && n > 0) seen.add(n);
+  }
+  return Array.from(seen).sort((a, b) => a - b);
+}
+
 // ------------------------------------------------------------------ helpers
 
 const STATUS_CLASSES: Record<string, string> = {
@@ -103,6 +146,48 @@ export default function LensCalibrationPage() {
   // -- Results --
   const [currentResults, setCurrentResults] = useState<CalibrationResult | null>(null);
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+
+  // -- Multi-zoom batch state --
+  // Restore the toggle preference from localStorage via a lazy initializer
+  // (avoids a setState-in-effect on mount).
+  const [multiZoomMode, setMultiZoomMode] = useState<boolean>(() => {
+    try {
+      const raw = localStorage.getItem(LAST_SESSION_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as PersistedSession;
+        if (typeof parsed.multiZoomMode === 'boolean') return parsed.multiZoomMode;
+      }
+    } catch {
+      // ignore malformed session
+    }
+    return true;
+  });
+  const [zoomLevels, setZoomLevels] = useState<number[]>([1, 5, 10, 15, 20, 25]);
+  const [zoomLevelsInput, setZoomLevelsInput] = useState('1, 5, 10, 15, 20, 25');
+  const [addZoomValue, setAddZoomValue] = useState('');
+  const [zoomResults, setZoomResults] = useState<Record<string, ZoomResult>>({});
+  const [batchRunning, setBatchRunning] = useState(false);
+  const [batchProgress, setBatchProgress] = useState<{ current: number; total: number; zoom: number } | null>(null);
+  // Detect a resumable session at mount-time via a lazy initializer (avoids
+  // setState-in-effect). The banner is dismissed/resumed by user action.
+  const [resumePrompt, setResumePrompt] = useState<PersistedSession | null>(() => {
+    try {
+      const raw = localStorage.getItem(LAST_SESSION_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as PersistedSession;
+        if (
+          (parsed.zoomLevels && parsed.zoomLevels.length > 0) ||
+          (parsed.results && Object.keys(parsed.results).length > 0)
+        ) {
+          return parsed;
+        }
+      }
+    } catch {
+      // ignore malformed session
+    }
+    return null;
+  });
+  const sessionLoadedRef = useRef(false);
 
   // -- Annotation rows --
   const [lineTraceSetNames, setLineTraceSetNames] = useState<string[]>([]);
@@ -337,6 +422,237 @@ export default function LensCalibrationPage() {
     }, 1000);
   }, [annotationRows, fx, fy, cx, cy, trainSplitRatio, radialOnly, showStatus]);
 
+  // ---------------------------------------------------------------- multi-zoom batch
+
+  // Collect all loaded annotation line traces (the single input method this page has).
+  const collectAnnotationLines = useCallback((): Array<{ line_id: string; points: number[][] }> => {
+    const all: Array<{ line_id: string; points: number[][] }> = [];
+    for (const row of annotationRows) all.push(...row.lineData);
+    return all;
+  }, [annotationRows]);
+
+  // Calibrate a single zoom: auto-compute intrinsics then calibrate annotated lines.
+  // Returns a ZoomResult (success or failed). Pure-ish: does not mutate batch state itself.
+  const calibrateSingleZoom = useCallback(
+    async (zoomValue: number): Promise<ZoomResult> => {
+      const lines = collectAnnotationLines();
+      if (lines.length === 0) {
+        return { status: 'failed', message: 'No annotation lines loaded' };
+      }
+
+      try {
+        // 1. compute intrinsics for this zoom
+        const { data: ci, error: ciErr } = await client.POST(
+          '/lens-calibration/api/compute-intrinsics/',
+          {
+            body: {
+              zoom: zoomValue,
+              image_width: Math.round((cx || 960) * 2),
+              image_height: Math.round((cy || 540) * 2),
+            },
+          },
+        );
+        if (ciErr || !ci) {
+          return {
+            status: 'failed',
+            message: (ciErr as { detail?: string })?.detail ?? 'Failed to compute intrinsics',
+          };
+        }
+        const perZoomIntrinsics: Intrinsics = {
+          fx: ci.fx,
+          fy: ci.fy,
+          cx: ci.cx,
+          cy: ci.cy,
+        };
+
+        // 2. calibrate annotated lines using freshly computed intrinsics
+        const { data, error } = await client.POST(
+          '/lens-calibration/api/calibrate-annotated-lines/',
+          {
+            body: {
+              camera_line_annotations: lines,
+              intrinsics: {
+                fx: perZoomIntrinsics.fx,
+                fy: perZoomIntrinsics.fy,
+                cx: perZoomIntrinsics.cx,
+                cy: perZoomIntrinsics.cy,
+                image_width: Math.round(perZoomIntrinsics.cx * 2),
+                image_height: Math.round(perZoomIntrinsics.cy * 2),
+              },
+              auto_intrinsics: false,
+              config: {
+                train_split_ratio: trainSplitRatio,
+                use_radial_only: radialOnly,
+              },
+            },
+          },
+        );
+
+        if (error || !data) {
+          return {
+            status: 'failed',
+            message: (error as { detail?: string })?.detail ?? 'Calibration request failed',
+          };
+        }
+        if (!data.success) {
+          return { status: 'failed', message: data.message || 'Solver reported failure' };
+        }
+
+        const numLines =
+          typeof data.line_errors === 'object' && Array.isArray(data.line_errors)
+            ? data.line_errors.length
+            : lines.length;
+
+        return {
+          status: 'success',
+          coefficients: data.coefficients,
+          intrinsics: data.intrinsics_used ?? perZoomIntrinsics,
+          rmse: data.overall_rmse,
+          num_lines: numLines,
+          message: data.message,
+        };
+      } catch (e) {
+        return { status: 'failed', message: e instanceof Error ? e.message : String(e) };
+      }
+    },
+    [collectAnnotationLines, cx, cy, trainSplitRatio, radialOnly],
+  );
+
+  // Run the full sequential batch over all configured zoom levels.
+  const runMultiZoomCalibration = useCallback(async () => {
+    const lines = collectAnnotationLines();
+    if (lines.length === 0) {
+      showStatus('Load annotation lines before running multi-zoom calibration', 'warning');
+      return;
+    }
+    // Active zoom levels are those not skipped.
+    const active = zoomLevels.filter((z) => zoomResults[String(z)]?.status !== 'skipped');
+    if (active.length === 0) {
+      showStatus('No active zoom levels to calibrate', 'warning');
+      return;
+    }
+
+    setBatchRunning(true);
+    // mark all active zooms pending up front
+    setZoomResults((prev) => {
+      const next = { ...prev };
+      for (const z of active) {
+        if (next[String(z)]?.status === 'skipped') continue;
+        next[String(z)] = { status: 'pending' };
+      }
+      return next;
+    });
+
+    for (let i = 0; i < active.length; i++) {
+      const z = active[i];
+      setBatchProgress({ current: i + 1, total: active.length, zoom: z });
+      setZoomResults((prev) => ({ ...prev, [String(z)]: { status: 'calibrating' } }));
+      showStatus(`Calibrating zoom ${z}x (${i + 1} of ${active.length})`, 'info');
+
+      const result = await calibrateSingleZoom(z);
+      setZoomResults((prev) => ({ ...prev, [String(z)]: result }));
+    }
+
+    setBatchProgress(null);
+    setBatchRunning(false);
+    showStatus('Multi-zoom calibration batch complete', 'success');
+  }, [collectAnnotationLines, zoomLevels, zoomResults, calibrateSingleZoom, showStatus]);
+
+  // Re-run a single zoom (from progress-table action or "Add Zoom Entry" path).
+  const rerunSingleZoom = useCallback(
+    async (zoomValue: number) => {
+      const lines = collectAnnotationLines();
+      if (lines.length === 0) {
+        showStatus('Load annotation lines before calibrating', 'warning');
+        return;
+      }
+      setZoomResults((prev) => ({ ...prev, [String(zoomValue)]: { status: 'calibrating' } }));
+      showStatus(`Calibrating zoom ${zoomValue}x...`, 'info');
+      const result = await calibrateSingleZoom(zoomValue);
+      // preserve loadedRmse so overwrite-confirm can compare against the original
+      setZoomResults((prev) => {
+        const prior = prev[String(zoomValue)];
+        return {
+          ...prev,
+          [String(zoomValue)]: {
+            ...result,
+            loadedRmse: prior?.loaded ? prior.loadedRmse ?? prior.rmse : prior?.loadedRmse,
+          },
+        };
+      });
+      showStatus(
+        result.status === 'success'
+          ? `Zoom ${zoomValue}x calibrated (RMSE ${result.rmse?.toFixed(3) ?? '---'} px)`
+          : `Zoom ${zoomValue}x failed: ${result.message ?? 'unknown'}`,
+        result.status === 'success' ? 'success' : 'error',
+      );
+    },
+    [collectAnnotationLines, calibrateSingleZoom, showStatus],
+  );
+
+  // Mark a zoom as skipped (removed from the batch).
+  const skipZoom = useCallback((zoomValue: number) => {
+    setZoomResults((prev) => ({ ...prev, [String(zoomValue)]: { status: 'skipped' } }));
+  }, []);
+
+  // ---------------------------------------------------------------- zoom configurator
+
+  const applyZoomLevels = useCallback((levels: number[]) => {
+    const sorted = Array.from(new Set(levels.filter((n) => !Number.isNaN(n) && n > 0))).sort(
+      (a, b) => a - b,
+    );
+    setZoomLevels(sorted);
+    setZoomLevelsInput(sorted.join(', '));
+  }, []);
+
+  const onZoomLevelsInputChange = useCallback(
+    (raw: string) => {
+      setZoomLevelsInput(raw);
+      applyZoomLevels(parseZoomList(raw));
+    },
+    [applyZoomLevels],
+  );
+
+  const removeZoomLevel = useCallback(
+    (zoomValue: number) => {
+      applyZoomLevels(zoomLevels.filter((z) => z !== zoomValue));
+      setZoomResults((prev) => {
+        const next = { ...prev };
+        delete next[String(zoomValue)];
+        return next;
+      });
+    },
+    [zoomLevels, applyZoomLevels],
+  );
+
+  const addZoomLevel = useCallback(
+    (raw: string) => {
+      const n = parseFloat(raw);
+      if (Number.isNaN(n) || n <= 0) {
+        showStatus('Enter a positive zoom value to add', 'warning');
+        return;
+      }
+      applyZoomLevels([...zoomLevels, n]);
+      setAddZoomValue('');
+    },
+    [zoomLevels, applyZoomLevels, showStatus],
+  );
+
+  // "Add Zoom Entry": append a new zoom AND immediately calibrate it (single-zoom path).
+  const addZoomEntry = useCallback(
+    async (raw: string) => {
+      const n = parseFloat(raw);
+      if (Number.isNaN(n) || n <= 0) {
+        showStatus('Enter a positive zoom value to add', 'warning');
+        return;
+      }
+      applyZoomLevels([...zoomLevels, n]);
+      setAddZoomValue('');
+      await rerunSingleZoom(n);
+    },
+    [zoomLevels, applyZoomLevels, rerunSingleZoom, showStatus],
+  );
+
   // ---------------------------------------------------------------- validate
 
   const validateResults = useCallback(async () => {
@@ -456,6 +772,91 @@ export default function LensCalibrationPage() {
     setSaving(false);
   }, [currentResults, cameraId, zoom, getIntrinsics, showStatus]);
 
+  // ---------------------------------------------------------------- unified multi-zoom save
+
+  const saveAllZoomEntries = useCallback(async () => {
+    // Collect all success entries (freshly calibrated + loaded-and-kept).
+    const successZooms = zoomLevels.filter(
+      (z) => zoomResults[String(z)]?.status === 'success',
+    );
+    if (successZooms.length === 0) {
+      showStatus('No successful zoom entries to save', 'warning');
+      return;
+    }
+
+    // Overwrite confirmation: loaded zoom re-calibrated with a different RMSE.
+    const conflicts: Array<{ zoom: number; oldRmse: number; newRmse: number }> = [];
+    for (const z of successZooms) {
+      const r = zoomResults[String(z)];
+      if (
+        r.loadedRmse !== undefined &&
+        r.rmse !== undefined &&
+        Math.abs(r.loadedRmse - r.rmse) > 1e-6
+      ) {
+        conflicts.push({ zoom: z, oldRmse: r.loadedRmse, newRmse: r.rmse });
+      }
+    }
+    if (conflicts.length > 0) {
+      const lines = conflicts
+        .map(
+          (c) =>
+            `  zoom ${c.zoom}x: loaded RMSE ${c.oldRmse.toFixed(3)} -> new RMSE ${c.newRmse.toFixed(3)}`,
+        )
+        .join('\n');
+      const ok = window.confirm(
+        `The following zoom entries already exist and will be overwritten:\n\n${lines}\n\nProceed with save?`,
+      );
+      if (!ok) {
+        showStatus('Save cancelled', 'warning');
+        return;
+      }
+    }
+
+    setSaving(true);
+    showStatus('Saving all zoom entries...', 'info');
+
+    try {
+      const zoom_entries = successZooms.map((z) => {
+        const r = zoomResults[String(z)];
+        return {
+          zoom: z,
+          coefficients: r.coefficients,
+          intrinsics: r.intrinsics ?? null,
+          validation_rmse: r.rmse ?? 0,
+          num_lines: r.num_lines ?? 0,
+        };
+      });
+
+      const { data, error } = await client.POST('/lens-calibration/api/save/', {
+        body: {
+          camera_id: cameraId || 'unknown_camera',
+          // Base single-zoom fields are required by the schema; the server uses
+          // `zoom_entries` for the multi-zoom batch and ignores these placeholders.
+          zoom: zoom_entries[0]?.zoom ?? 1,
+          validation_rmse: 0,
+          num_lines: 0,
+          zoom_entries,
+        },
+      });
+
+      if (error || !data) {
+        throw new Error((error as { detail?: string })?.detail ?? 'Save failed');
+      }
+
+      showStatus(
+        `Saved ${zoom_entries.length} zoom entries for camera "${cameraId}"`,
+        'success',
+      );
+      loadCalibrationIds();
+    } catch (e) {
+      showStatus(`Save failed: ${e instanceof Error ? e.message : String(e)}`, 'error');
+    }
+
+    setSaving(false);
+    // loadCalibrationIds is defined below and stable; mirrors saveCalibration's pattern.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zoomLevels, zoomResults, cameraId, showStatus]);
+
   // ---------------------------------------------------------------- load calibration IDs
 
   const loadCalibrationIds = useCallback(async () => {
@@ -494,6 +895,34 @@ export default function LensCalibrationPage() {
       setCameraId(data.camera_id);
 
       const entries = (data.entries ?? []) as Array<Record<string, unknown>>;
+
+      // Populate the multi-zoom results map from ALL loaded entries (append/merge semantics).
+      const loadedResults: Record<string, ZoomResult> = {};
+      const loadedZooms: number[] = [];
+      for (const entry of entries) {
+        const zf = (entry.zoom_factor as number) ?? (entry.zoom as number);
+        if (zf === undefined || Number.isNaN(zf)) continue;
+        const coeffs = entry.coefficients as DistortionCoefficients | undefined;
+        const rmse = (entry.validation_rmse as number) ?? 0;
+        const numLines = (entry.num_lines_used as number) ?? (entry.num_lines as number) ?? 0;
+        const intr = entry.intrinsics as Intrinsics | undefined;
+        loadedResults[String(zf)] = {
+          status: 'success',
+          coefficients: coeffs,
+          intrinsics: intr,
+          rmse,
+          num_lines: numLines,
+          message: 'Loaded from repo',
+          loaded: true,
+          loadedRmse: rmse,
+        };
+        loadedZooms.push(zf);
+      }
+      if (loadedZooms.length > 0) {
+        applyZoomLevels(loadedZooms);
+        setZoomResults(loadedResults);
+      }
+
       if (entries.length > 0) {
         const last = entries[entries.length - 1];
         const zoomFactor = (last.zoom_factor as number) ?? 1;
@@ -543,7 +972,7 @@ export default function LensCalibrationPage() {
     }
 
     setLoadingCalibration(false);
-  }, [selectedCameraId, getIntrinsics, showStatus]);
+  }, [selectedCameraId, getIntrinsics, showStatus, applyZoomLevels]);
 
   // ---------------------------------------------------------------- copy coefficients
 
@@ -569,6 +998,53 @@ export default function LensCalibrationPage() {
       showStatus('Optimized intrinsics applied to input fields', 'success');
     }
   }, [currentResults, showStatus]);
+
+  // ---------------------------------------------------------------- session persistence
+
+  const sessionKey = useCallback(
+    (id: string) => `${SESSION_KEY_PREFIX}${id || 'unknown_camera'}`,
+    [],
+  );
+
+  const persistSession = useCallback(() => {
+    try {
+      const payload: PersistedSession = {
+        multiZoomMode,
+        zoomLevels,
+        results: zoomResults,
+        cameraId,
+      };
+      const json = JSON.stringify(payload);
+      localStorage.setItem(sessionKey(cameraId), json);
+      localStorage.setItem(LAST_SESSION_KEY, json);
+    } catch {
+      // localStorage unavailable / quota — non-fatal
+    }
+  }, [multiZoomMode, zoomLevels, zoomResults, cameraId, sessionKey]);
+
+  const applySession = useCallback(
+    (s: PersistedSession) => {
+      setMultiZoomMode(s.multiZoomMode);
+      applyZoomLevels(s.zoomLevels);
+      setZoomResults(s.results ?? {});
+      if (s.cameraId) setCameraId(s.cameraId);
+    },
+    [applyZoomLevels],
+  );
+
+  const clearSession = useCallback(() => {
+    try {
+      localStorage.removeItem(sessionKey(cameraId));
+      localStorage.removeItem(LAST_SESSION_KEY);
+    } catch {
+      // ignore
+    }
+    setZoomResults({});
+    setBatchProgress(null);
+    applyZoomLevels([1, 5, 10, 15, 20, 25]);
+    setResumePrompt(null);
+    showStatus('Session cleared', 'info');
+  }, [cameraId, sessionKey, applyZoomLevels, showStatus]);
 
   // ---------------------------------------------------------------- effects
 
@@ -606,6 +1082,17 @@ export default function LensCalibrationPage() {
     prevZoomRef.current = zoom;
   }, [zoom, intrinsicsInfo, computeIntrinsics]);
 
+  // Auto-save the session whenever zoom levels, results, or the toggle change.
+  // Skip the very first render so we don't immediately re-write the restored
+  // session (and so we never overwrite before the user has interacted).
+  useEffect(() => {
+    if (!sessionLoadedRef.current) {
+      sessionLoadedRef.current = true;
+      return;
+    }
+    persistSession();
+  }, [zoomLevels, zoomResults, multiZoomMode, persistSession]);
+
   // ---------------------------------------------------------------- render helpers
 
   const numLines =
@@ -625,6 +1112,58 @@ export default function LensCalibrationPage() {
           &larr; Back to Tools
         </Link>
       </header>
+
+      {/* Resume previous session banner (non-blocking) */}
+      {resumePrompt && (
+        <div className={styles.resumeBanner}>
+          <span>
+            Resume previous calibration session
+            {resumePrompt.cameraId ? ` for "${resumePrompt.cameraId}"` : ''}?
+          </span>
+          <div className={styles.resumeBannerActions}>
+            <button
+              className={`${styles.btnPrimary} ${styles.btnSmall}`}
+              type="button"
+              onClick={() => {
+                applySession(resumePrompt);
+                setResumePrompt(null);
+                showStatus('Previous session resumed', 'success');
+              }}
+            >
+              Resume
+            </button>
+            <button
+              className={`${styles.btnSecondary} ${styles.btnSmall}`}
+              type="button"
+              onClick={() => setResumePrompt(null)}
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Multi-Zoom Mode toggle */}
+      <div className={styles.modeToggleBar}>
+        <label className={styles.checkboxLabel}>
+          <input
+            type="checkbox"
+            checked={multiZoomMode}
+            onChange={(e) => setMultiZoomMode(e.target.checked)}
+          />
+          <strong>Multi-Zoom Mode</strong>
+          <span className={styles.intrinsicsInfo}>
+            (batch-calibrate multiple zoom levels from the same annotated lines)
+          </span>
+        </label>
+        <button
+          className={`${styles.btnSecondary} ${styles.btnSmall}`}
+          type="button"
+          onClick={clearSession}
+        >
+          Clear Session
+        </button>
+      </div>
 
       <div className={styles.grid}>
         {/* ======================== Camera Intrinsics ======================== */}
@@ -806,15 +1345,18 @@ export default function LensCalibrationPage() {
               </div>
             )}
 
-            <button
-              className={styles.btnPrimary}
-              style={{ marginTop: 12 }}
-              type="button"
-              disabled={!hasAnnotationLines || calibrating}
-              onClick={runCalibration}
-            >
-              {calibrating ? 'Running...' : 'Run Annotated Lines Calibration'}
-            </button>
+            {/* Single-zoom run button only when multi-zoom mode is OFF (fallback path). */}
+            {!multiZoomMode && (
+              <button
+                className={styles.btnPrimary}
+                style={{ marginTop: 12 }}
+                type="button"
+                disabled={!hasAnnotationLines || calibrating}
+                onClick={runCalibration}
+              >
+                {calibrating ? 'Running...' : 'Run Annotated Lines Calibration'}
+              </button>
+            )}
 
             <p className={styles.helpText}>
               Load line annotation files with N-point traces of lines that should be
@@ -825,6 +1367,217 @@ export default function LensCalibrationPage() {
             </p>
           </div>
         </div>
+
+        {/* ======================== Multi-Zoom Batch Wizard ======================== */}
+        {multiZoomMode && (
+          <div className={`${styles.card} ${styles.cardFullwidth}`}>
+            <div className={styles.cardHeader}>Multi-Zoom Batch Calibration</div>
+            <div className={styles.cardBody}>
+              {/* --- Zoom configurator --- */}
+              <h4 className={styles.sectionTitle}>Zoom Levels</h4>
+              <div className={styles.formGroup}>
+                <label className={styles.formLabel} htmlFor="lc-zoom-levels">
+                  Comma-separated zoom values
+                </label>
+                <input
+                  className={styles.formInput}
+                  id="lc-zoom-levels"
+                  type="text"
+                  value={zoomLevelsInput}
+                  placeholder="1, 5, 10, 15, 20, 25"
+                  onChange={(e) => onZoomLevelsInputChange(e.target.value)}
+                />
+              </div>
+
+              {/* Chips */}
+              <div className={styles.zoomChips}>
+                {zoomLevels.length === 0 && (
+                  <span className={styles.intrinsicsInfo}>No zoom levels configured</span>
+                )}
+                {zoomLevels.map((z) => (
+                  <span key={z} className={styles.zoomChip}>
+                    {z}x
+                    <button
+                      type="button"
+                      className={styles.zoomChipRemove}
+                      aria-label={`Remove zoom ${z}`}
+                      onClick={() => removeZoomLevel(z)}
+                    >
+                      &times;
+                    </button>
+                  </span>
+                ))}
+              </div>
+
+              {/* Add zoom level + presets */}
+              <div className={styles.zoomConfigRow}>
+                <input
+                  className={styles.zoomAddInput}
+                  type="number"
+                  step={0.1}
+                  min={0.1}
+                  value={addZoomValue}
+                  placeholder="e.g. 30"
+                  onChange={(e) => setAddZoomValue(e.target.value)}
+                />
+                <button
+                  className={`${styles.btnSecondary} ${styles.btnSmall}`}
+                  type="button"
+                  onClick={() => addZoomLevel(addZoomValue)}
+                >
+                  Add Zoom Level
+                </button>
+                <button
+                  className={`${styles.btnSecondary} ${styles.btnSmall}`}
+                  type="button"
+                  onClick={() => applyZoomLevels([1, 5, 10, 15, 20, 25])}
+                >
+                  1-25x Standard
+                </button>
+                <button
+                  className={`${styles.btnSecondary} ${styles.btnSmall}`}
+                  type="button"
+                  onClick={() => applyZoomLevels([1, 5, 10, 15, 20, 25, 30, 35, 40])}
+                >
+                  1-40x Extended
+                </button>
+              </div>
+
+              {/* --- Run batch --- */}
+              <div className={styles.actions} style={{ marginTop: 16 }}>
+                <button
+                  className={styles.btnPrimary}
+                  type="button"
+                  disabled={!hasAnnotationLines || batchRunning || zoomLevels.length === 0}
+                  onClick={runMultiZoomCalibration}
+                >
+                  {batchRunning ? 'Calibrating...' : 'Run Multi-Zoom Calibration'}
+                </button>
+                <div className={styles.zoomAddEntryRow}>
+                  <input
+                    className={styles.zoomAddInput}
+                    type="number"
+                    step={0.1}
+                    min={0.1}
+                    value={addZoomValue}
+                    placeholder="new zoom"
+                    onChange={(e) => setAddZoomValue(e.target.value)}
+                  />
+                  <button
+                    className={styles.btnSecondary}
+                    type="button"
+                    disabled={!hasAnnotationLines || batchRunning}
+                    onClick={() => addZoomEntry(addZoomValue)}
+                  >
+                    Add Zoom Entry
+                  </button>
+                </div>
+              </div>
+
+              {!hasAnnotationLines && (
+                <div className={styles.statusWarning} style={{ marginTop: 12 }}>
+                  Load annotation lines (above) to enable multi-zoom calibration.
+                </div>
+              )}
+
+              {/* --- Progress header --- */}
+              {batchProgress && (
+                <div className={styles.statusInfo} style={{ marginTop: 12 }}>
+                  Calibrating zoom {batchProgress.zoom}x ({batchProgress.current} of{' '}
+                  {batchProgress.total})
+                </div>
+              )}
+
+              {/* --- Progress table --- */}
+              {zoomLevels.length > 0 && (
+                <div className={styles.linesList} style={{ marginTop: 12, maxHeight: 'none' }}>
+                  <table className={styles.linesTable}>
+                    <thead>
+                      <tr>
+                        <th>Zoom</th>
+                        <th>Status</th>
+                        <th>RMSE</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {zoomLevels.map((z) => {
+                        const r = zoomResults[String(z)] ?? { status: 'pending' as ZoomStatus };
+                        const quality =
+                          r.status === 'success' && r.rmse !== undefined
+                            ? qualityFromRmse(r.rmse)
+                            : null;
+                        return (
+                          <tr key={z}>
+                            <td className={styles.mono}>{z}x</td>
+                            <td>
+                              <span
+                                className={`${styles.zoomDot} ${ZOOM_STATUS_CLASSES[r.status]}`}
+                              />
+                              {r.status}
+                              {r.status === 'failed' && r.message ? (
+                                <span className={styles.zoomFailMsg}> — {r.message}</span>
+                              ) : null}
+                            </td>
+                            <td className={styles.mono}>
+                              {r.status === 'success' && r.rmse !== undefined ? (
+                                <>
+                                  {r.rmse.toFixed(3)}{' '}
+                                  {quality && (
+                                    <span className={QUALITY_CLASSES[quality] ?? styles.qualityBadge}>
+                                      {quality}
+                                    </span>
+                                  )}
+                                </>
+                              ) : (
+                                '—'
+                              )}
+                            </td>
+                            <td>
+                              {(r.status === 'success' || r.status === 'failed') && (
+                                <button
+                                  className={`${styles.btnSecondary} ${styles.btnSmall}`}
+                                  type="button"
+                                  disabled={batchRunning || !hasAnnotationLines}
+                                  onClick={() => rerunSingleZoom(z)}
+                                >
+                                  Re-run
+                                </button>
+                              )}
+                              {(r.status === 'pending' || r.status === 'failed') && (
+                                <button
+                                  className={`${styles.btnSecondary} ${styles.btnSmall}`}
+                                  style={{ marginLeft: 6 }}
+                                  type="button"
+                                  disabled={batchRunning}
+                                  onClick={() => skipZoom(z)}
+                                >
+                                  Skip
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {/* --- Unified save --- */}
+              <div className={styles.actions} style={{ marginTop: 16 }}>
+                <button
+                  className={styles.btnSuccess}
+                  type="button"
+                  disabled={saving || batchRunning}
+                  onClick={saveAllZoomEntries}
+                >
+                  {saving ? 'Saving...' : 'Save All Zoom Entries'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* ======================== Calibration Status ======================== */}
         <div className={`${styles.card} ${styles.cardFullwidth}`}>

--- a/spa/src/pages/LensCalibrationPage.tsx
+++ b/spa/src/pages/LensCalibrationPage.tsx
@@ -605,13 +605,17 @@ export default function LensCalibrationPage() {
     setZoomLevelsInput(sorted.join(', '));
   }, []);
 
-  const onZoomLevelsInputChange = useCallback(
-    (raw: string) => {
-      setZoomLevelsInput(raw);
-      applyZoomLevels(parseZoomList(raw));
-    },
-    [applyZoomLevels],
-  );
+  // While typing, keep the field bound to the RAW keystrokes (so decimals like
+  // "1.5" and unsorted/partial entry remain editable) and only derive the parsed
+  // zoom list. Normalization (sort/dedupe/reformat the text) happens on blur.
+  const onZoomLevelsInputChange = useCallback((raw: string) => {
+    setZoomLevelsInput(raw);
+    setZoomLevels(parseZoomList(raw));
+  }, []);
+
+  const onZoomLevelsInputBlur = useCallback(() => {
+    applyZoomLevels(parseZoomList(zoomLevelsInput));
+  }, [applyZoomLevels, zoomLevelsInput]);
 
   const removeZoomLevel = useCallback(
     (zoomValue: number) => {
@@ -896,7 +900,9 @@ export default function LensCalibrationPage() {
 
       const entries = (data.entries ?? []) as Array<Record<string, unknown>>;
 
-      // Populate the multi-zoom results map from ALL loaded entries (append/merge semantics).
+      // Loading a camera seeds the session with ALL of its stored entries (marked
+      // `loaded`), replacing any prior session state. New zoom levels are then
+      // appended via "Add Zoom Entry"; the unified save writes loaded + new together.
       const loadedResults: Record<string, ZoomResult> = {};
       const loadedZooms: number[] = [];
       for (const entry of entries) {
@@ -1386,6 +1392,7 @@ export default function LensCalibrationPage() {
                   value={zoomLevelsInput}
                   placeholder="1, 5, 10, 15, 20, 25"
                   onChange={(e) => onZoomLevelsInputChange(e.target.value)}
+                  onBlur={onZoomLevelsInputBlur}
                 />
               </div>
 

--- a/spa/src/pages/LensCalibrationPage.tsx
+++ b/spa/src/pages/LensCalibrationPage.tsx
@@ -86,8 +86,17 @@ const ZOOM_STATUS_CLASSES: Record<ZoomStatus, string> = {
   skipped: styles.zoomDotSkipped,
 };
 
-const SESSION_KEY_PREFIX = 'lens_calibration_session_';
 const LAST_SESSION_KEY = 'lens_calibration_session_last';
+
+function readLastSession(): PersistedSession | null {
+  try {
+    const raw = localStorage.getItem(LAST_SESSION_KEY);
+    if (raw) return JSON.parse(raw) as PersistedSession;
+  } catch {
+    // ignore malformed / unavailable session
+  }
+  return null;
+}
 
 function parseZoomList(raw: string): number[] {
   const seen = new Set<number>();
@@ -151,39 +160,26 @@ export default function LensCalibrationPage() {
   // Restore the toggle preference from localStorage via a lazy initializer
   // (avoids a setState-in-effect on mount).
   const [multiZoomMode, setMultiZoomMode] = useState<boolean>(() => {
-    try {
-      const raw = localStorage.getItem(LAST_SESSION_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as PersistedSession;
-        if (typeof parsed.multiZoomMode === 'boolean') return parsed.multiZoomMode;
-      }
-    } catch {
-      // ignore malformed session
-    }
-    return true;
+    const parsed = readLastSession();
+    return typeof parsed?.multiZoomMode === 'boolean' ? parsed.multiZoomMode : true;
   });
   const [zoomLevels, setZoomLevels] = useState<number[]>([1, 5, 10, 15, 20, 25]);
   const [zoomLevelsInput, setZoomLevelsInput] = useState('1, 5, 10, 15, 20, 25');
-  const [addZoomValue, setAddZoomValue] = useState('');
+  const [addZoomValue, setAddZoomValue] = useState(''); // "Add Zoom Level" (configurator)
+  const [addEntryValue, setAddEntryValue] = useState(''); // "Add Zoom Entry" (post-batch)
   const [zoomResults, setZoomResults] = useState<Record<string, ZoomResult>>({});
   const [batchRunning, setBatchRunning] = useState(false);
   const [batchProgress, setBatchProgress] = useState<{ current: number; total: number; zoom: number } | null>(null);
   // Detect a resumable session at mount-time via a lazy initializer (avoids
   // setState-in-effect). The banner is dismissed/resumed by user action.
   const [resumePrompt, setResumePrompt] = useState<PersistedSession | null>(() => {
-    try {
-      const raw = localStorage.getItem(LAST_SESSION_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as PersistedSession;
-        if (
-          (parsed.zoomLevels && parsed.zoomLevels.length > 0) ||
-          (parsed.results && Object.keys(parsed.results).length > 0)
-        ) {
-          return parsed;
-        }
-      }
-    } catch {
-      // ignore malformed session
+    const parsed = readLastSession();
+    if (
+      parsed &&
+      ((parsed.zoomLevels && parsed.zoomLevels.length > 0) ||
+        (parsed.results && Object.keys(parsed.results).length > 0))
+    ) {
+      return parsed;
     }
     return null;
   });
@@ -434,8 +430,13 @@ export default function LensCalibrationPage() {
   // Calibrate a single zoom: auto-compute intrinsics then calibrate annotated lines.
   // Returns a ZoomResult (success or failed). Pure-ish: does not mutate batch state itself.
   const calibrateSingleZoom = useCallback(
-    async (zoomValue: number): Promise<ZoomResult> => {
-      const lines = collectAnnotationLines();
+    async (
+      zoomValue: number,
+      presetLines?: Array<{ line_id: string; points: number[][] }>,
+    ): Promise<ZoomResult> => {
+      // Reuse already-collected lines when the caller has them (the batch loop
+      // collects once for all zooms); otherwise gather them for a one-off run.
+      const lines = presetLines ?? collectAnnotationLines();
       if (lines.length === 0) {
         return { status: 'failed', message: 'No annotation lines loaded' };
       }
@@ -498,10 +499,7 @@ export default function LensCalibrationPage() {
           return { status: 'failed', message: data.message || 'Solver reported failure' };
         }
 
-        const numLines =
-          typeof data.line_errors === 'object' && Array.isArray(data.line_errors)
-            ? data.line_errors.length
-            : lines.length;
+        const numLines = Array.isArray(data.line_errors) ? data.line_errors.length : lines.length;
 
         return {
           status: 'success',
@@ -549,7 +547,7 @@ export default function LensCalibrationPage() {
       setZoomResults((prev) => ({ ...prev, [String(z)]: { status: 'calibrating' } }));
       showStatus(`Calibrating zoom ${z}x (${i + 1} of ${active.length})`, 'info');
 
-      const result = await calibrateSingleZoom(z);
+      const result = await calibrateSingleZoom(z, lines);
       setZoomResults((prev) => ({ ...prev, [String(z)]: result }));
     }
 
@@ -568,7 +566,7 @@ export default function LensCalibrationPage() {
       }
       setZoomResults((prev) => ({ ...prev, [String(zoomValue)]: { status: 'calibrating' } }));
       showStatus(`Calibrating zoom ${zoomValue}x...`, 'info');
-      const result = await calibrateSingleZoom(zoomValue);
+      const result = await calibrateSingleZoom(zoomValue, lines);
       // preserve loadedRmse so overwrite-confirm can compare against the original
       setZoomResults((prev) => {
         const prior = prev[String(zoomValue)];
@@ -651,7 +649,7 @@ export default function LensCalibrationPage() {
         return;
       }
       applyZoomLevels([...zoomLevels, n]);
-      setAddZoomValue('');
+      setAddEntryValue('');
       await rerunSingleZoom(n);
     },
     [zoomLevels, applyZoomLevels, rerunSingleZoom, showStatus],
@@ -1007,11 +1005,6 @@ export default function LensCalibrationPage() {
 
   // ---------------------------------------------------------------- session persistence
 
-  const sessionKey = useCallback(
-    (id: string) => `${SESSION_KEY_PREFIX}${id || 'unknown_camera'}`,
-    [],
-  );
-
   const persistSession = useCallback(() => {
     try {
       const payload: PersistedSession = {
@@ -1020,13 +1013,11 @@ export default function LensCalibrationPage() {
         results: zoomResults,
         cameraId,
       };
-      const json = JSON.stringify(payload);
-      localStorage.setItem(sessionKey(cameraId), json);
-      localStorage.setItem(LAST_SESSION_KEY, json);
+      localStorage.setItem(LAST_SESSION_KEY, JSON.stringify(payload));
     } catch {
       // localStorage unavailable / quota — non-fatal
     }
-  }, [multiZoomMode, zoomLevels, zoomResults, cameraId, sessionKey]);
+  }, [multiZoomMode, zoomLevels, zoomResults, cameraId]);
 
   const applySession = useCallback(
     (s: PersistedSession) => {
@@ -1040,7 +1031,6 @@ export default function LensCalibrationPage() {
 
   const clearSession = useCallback(() => {
     try {
-      localStorage.removeItem(sessionKey(cameraId));
       localStorage.removeItem(LAST_SESSION_KEY);
     } catch {
       // ignore
@@ -1050,7 +1040,7 @@ export default function LensCalibrationPage() {
     applyZoomLevels([1, 5, 10, 15, 20, 25]);
     setResumePrompt(null);
     showStatus('Session cleared', 'info');
-  }, [cameraId, sessionKey, applyZoomLevels, showStatus]);
+  }, [applyZoomLevels, showStatus]);
 
   // ---------------------------------------------------------------- effects
 
@@ -1466,15 +1456,15 @@ export default function LensCalibrationPage() {
                     type="number"
                     step={0.1}
                     min={0.1}
-                    value={addZoomValue}
+                    value={addEntryValue}
                     placeholder="new zoom"
-                    onChange={(e) => setAddZoomValue(e.target.value)}
+                    onChange={(e) => setAddEntryValue(e.target.value)}
                   />
                   <button
                     className={styles.btnSecondary}
                     type="button"
                     disabled={!hasAnnotationLines || batchRunning}
-                    onClick={() => addZoomEntry(addZoomValue)}
+                    onClick={() => addZoomEntry(addEntryValue)}
                   >
                     Add Zoom Entry
                   </button>

--- a/tests/test_api/test_lens_calibration.py
+++ b/tests/test_api/test_lens_calibration.py
@@ -1,0 +1,152 @@
+"""Integration tests for the lens-calibration save endpoint (issue #214).
+
+The SPA's multi-zoom batch calibration flow posts an array of per-zoom entries
+that must persist as a single multi-entry ``CameraCalibrationTable``, while the
+legacy single-entry body stays fully backward-compatible. These tests patch the
+router's ``sync_to_ddd_repo_pg`` collaborator to capture the table without a
+real database.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+SAVE_URL = "/lens-calibration/api/save/"
+
+
+class TestSaveCalibration:
+    """Tests for ``POST /lens-calibration/api/save/``."""
+
+    @patch("api.routers.lens_calibration.sync_to_ddd_repo_pg")
+    def test_multi_entry_save(
+        self,
+        mock_sync: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """A multi-zoom batch persists one table with one entry per zoom."""
+        resp = client.post(
+            SAVE_URL,
+            json={
+                "camera_id": "cam-multi",
+                "zoom_entries": [
+                    {
+                        "zoom": 1.0,
+                        "coefficients": {"k1": -0.1, "k2": 0.01, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                        "intrinsics": {"fx": 1000.0, "fy": 1000.0, "cx": 960.0, "cy": 540.0},
+                        "validation_rmse": 1.5,
+                        "num_lines": 12,
+                    },
+                    {
+                        "zoom": 2.0,
+                        "coefficients": {"k1": -0.2, "k2": 0.02, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                        "intrinsics": {"fx": 2000.0, "fy": 2000.0, "cx": 961.0, "cy": 541.0},
+                        "validation_rmse": 2.5,
+                        "num_lines": 8,
+                    },
+                    {
+                        "zoom": 3.0,
+                        "coefficients": {"k1": -0.3, "k2": 0.03, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                        "validation_rmse": 0.0,
+                        "num_lines": 0,
+                    },
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "camera_id": "cam-multi"}
+
+        mock_sync.assert_called_once()
+        table = mock_sync.call_args.args[0]
+        assert table.camera_id == "cam-multi"
+        assert len(table.entries) == 3
+        assert sorted(table.entries.keys()) == [1.0, 2.0, 3.0]
+
+        e1 = table.entries[1.0]
+        assert e1.k1 == -0.1
+        assert e1.k2 == 0.01
+        assert e1.fx == 1000.0
+        assert e1.cy == 540.0
+        assert e1.validation_rmse == 1.5
+        assert e1.num_lines_used == 12
+
+        e2 = table.entries[2.0]
+        assert e2.k1 == -0.2
+        assert e2.fx == 2000.0
+
+        # No intrinsics provided -> zeroed focal/principal point.
+        e3 = table.entries[3.0]
+        assert e3.k1 == -0.3
+        assert e3.fx == 0.0
+        assert e3.cx == 0.0
+
+    @patch("api.routers.lens_calibration.sync_to_ddd_repo_pg")
+    def test_single_entry_back_compat(
+        self,
+        mock_sync: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """The legacy single-entry body persists exactly one entry, unchanged."""
+        resp = client.post(
+            SAVE_URL,
+            json={
+                "camera_id": "cam-legacy",
+                "zoom": 1.5,
+                "coefficients": {"k1": -0.05, "k2": 0.0, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                "intrinsics": {"fx": 1500.0, "fy": 1500.0, "cx": 960.0, "cy": 540.0},
+                "validation_rmse": 0.9,
+                "num_lines": 5,
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "camera_id": "cam-legacy"}
+
+        mock_sync.assert_called_once()
+        table = mock_sync.call_args.args[0]
+        assert len(table.entries) == 1
+        entry = table.entries[1.5]
+        assert entry.k1 == -0.05
+        assert entry.fx == 1500.0
+        assert entry.num_lines_used == 5
+
+    @patch("api.routers.lens_calibration.sync_to_ddd_repo_pg")
+    def test_duplicate_zoom_last_wins(
+        self,
+        mock_sync: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Two entries at the same zoom collapse to one — the last one wins."""
+        resp = client.post(
+            SAVE_URL,
+            json={
+                "camera_id": "cam-dup",
+                "zoom_entries": [
+                    {
+                        "zoom": 2.0,
+                        "coefficients": {"k1": -0.1, "k2": 0.0, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                        "validation_rmse": 1.0,
+                        "num_lines": 3,
+                    },
+                    {
+                        "zoom": 2.0,
+                        "coefficients": {"k1": -0.9, "k2": 0.0, "k3": 0.0, "p1": 0.0, "p2": 0.0},
+                        "validation_rmse": 4.0,
+                        "num_lines": 7,
+                    },
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        mock_sync.assert_called_once()
+        table = mock_sync.call_args.args[0]
+        assert len(table.entries) == 1
+        entry = table.entries[2.0]
+        assert entry.k1 == -0.9
+        assert entry.validation_rmse == 4.0
+        assert entry.num_lines_used == 7


### PR DESCRIPTION
## Summary

Adds a multi-zoom batch calibration workflow to the live FastAPI+React stack. Backend: the /lens-calibration/api/save/ endpoint now accepts an optional zoom_entries[] array, building one CameraCalibrationTable with one ZoomCalibrationEntry per zoom (single-entry body stays fully backward-compatible; duplicate zooms last-win). SPA LensCalibrationPage gains a Multi-Zoom Mode (default on) with a comma-separated zoom configurator (default 1,5,10,15,20,25 + removable chips + presets), sequential per-zoom calibration that auto-computes intrinsics per zoom, a color-coded progress table (status/RMSE/quality, Re-run/Skip), Add Zoom Entry, unified save of all entries, load+append from existing calibrations with an overwrite confirmation comparing current vs new RMSE, and localStorage session persistence with resume/clear. DistortionValidatorPage gains a Compare Zoom Levels grid that undistorts the selected image with every loaded zoom entry side-by-side, labeled with zoom + RMSE. Single-zoom paths preserved when toggles are off. OpenAPI types regenerated. Note: this page's only input method is annotated line-trace sets, so multi-zoom is wired to that input, mirroring the issue's manual-lines->single-zoom decision.

## Test plan

uv run poe ci: 1263 passed, 155 skipped (env-gated). New tests/test_api/test_lens_calibration.py (3 tests) pass. spa: npx tsc -b clean; eslint introduces zero new problems vs HEAD baseline.
