### PR TITLE
feat(s3): serve map image + tiles from S3-backed GeoTIFF assets [#292]

### DIFF
--- a/api/routers/homography_precision.py
+++ b/api/routers/homography_precision.py
@@ -6,7 +6,9 @@ Ported from ``webapp/homography_precision/views.py``.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from pathlib import (
+    Path,  # noqa: TC003 — kept at runtime; FastAPI introspects annotations in this module
+)
 from typing import TypedDict
 
 import numpy as np
@@ -15,7 +17,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import JSONResponse
 from line_picker.state import Line, from_line_repo_pg
 from PIL import Image
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import (
+    Session,  # noqa: TC002 — runtime import; FastAPI resolves Depends() param annotations at runtime
+)
 
 from api.deps import get_current_user, get_db_session
 from api.schemas.homography_precision import (
@@ -45,7 +49,6 @@ from api.schemas.homography_precision import (
 )
 from api.utils.frame_helpers import (
     CALIBRATIONS_DIR,
-    DATA_MAPS_DIR,
     extract_geotiff,
     get_frame_image_path,
     get_map_for_tenant,
@@ -54,11 +57,14 @@ from api.utils.frame_helpers import (
     load_annotations_for_frame,
     load_line_annotations_for_frame,
 )
+from api.utils.map_assets import resolve_map_geotiff
 from api.utils.tiles import render_tile
 from poc_homography.calibration.lens_distortion.calibration_table import load_calibration_for_camera
 from poc_homography.domain.vo import PixelPoint
 from poc_homography.homography.map_points import MapPointHomography
-from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.models.user import (
+    UserModel,  # noqa: TC001 — runtime import; FastAPI resolves Depends() param annotations at runtime
+)
 from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
 logger = logging.getLogger(__name__)
@@ -146,14 +152,15 @@ def _distortion_kwargs(test_case: dict, session: Session) -> dict[str, float]:
 
 
 def _get_map_geotiff_file(tenant_id: str, session: Session) -> Path | None:
-    """Return path to the GeoTIFF file for the tenant's map, or None."""
+    """Return a local path to the tenant's map GeoTIFF, or None.
+
+    Materialises the asset from object storage when the map carries an
+    ``asset_key`` (cached under ``/tmp``); falls back to ``data/maps`` otherwise.
+    """
     map_entity = get_map_for_tenant(tenant_id, session)
     if map_entity is None:
         return None
-    resolved = DATA_MAPS_DIR / map_entity.photo.path
-    if not resolved.exists():
-        return None
-    return resolved
+    return resolve_map_geotiff(map_entity)
 
 
 def _load_line_registry(tenant_id: str, session: Session) -> list[Line]:
@@ -220,7 +227,9 @@ def _load_line_test_case_by_name(name: str, map_id: str | None, session: Session
     return None
 
 
-def _get_camera_image_path(test_case_name: str, map_id: str | None, session: Session) -> Path | None:
+def _get_camera_image_path(
+    test_case_name: str, map_id: str | None, session: Session
+) -> Path | None:
     """Get the path to the camera image for a test case."""
     test_case = _load_test_case_by_name(test_case_name, map_id, session)
     if test_case is None:
@@ -359,9 +368,7 @@ def api_compute_homography(
     # Load test case
     test_case = _load_test_case_by_name(test_case_name, map_id, session)
     if test_case is None:
-        raise HTTPException(
-            status_code=404, detail=f"Test case not found: {test_case_name}"
-        )
+        raise HTTPException(status_code=404, detail=f"Test case not found: {test_case_name}")
 
     annotations = test_case.get("annotations", [])
     if len(annotations) < 4:
@@ -374,13 +381,13 @@ def api_compute_homography(
     try:
         registry = from_gcp_repo_pg(session, map_id)
     except (KeyError, ValueError, OSError) as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to load GCP registry: {e}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to load GCP registry: {e}")
 
     # Compute homography
     try:
-        homography = MapPointHomography(map_id=registry.map_id, **_distortion_kwargs(test_case, session))
+        homography = MapPointHomography(
+            map_id=registry.map_id, **_distortion_kwargs(test_case, session)
+        )
         result = homography.compute_from_gcps(
             gcps=annotations,
             map_registry=registry,
@@ -388,9 +395,7 @@ def api_compute_homography(
             min_inlier_ratio=0.5,
         )
     except (ValueError, RuntimeError) as e:
-        raise HTTPException(
-            status_code=500, detail=f"Homography computation failed: {e}"
-        )
+        raise HTTPException(status_code=500, detail=f"Homography computation failed: {e}")
 
     # Compute per-point errors and overlay data
     per_point_errors: list[PerPointError] = []
@@ -453,9 +458,7 @@ def api_compute_homography(
                 "y": round(reprojected_camera.y, 2),
             }
         )
-        map_gcps.append(
-            {"gcp_id": gcp_id, "x": round(map_x, 2), "y": round(map_y, 2)}
-        )
+        map_gcps.append({"gcp_id": gcp_id, "x": round(map_x, 2), "y": round(map_y, 2)})
         map_projected.append(
             {
                 "gcp_id": gcp_id,
@@ -632,7 +635,9 @@ def api_compute_homography_from_lines(
     if map_id is None:
         return _no_map_error()
     try:
-        dist_kw = _distortion_kwargs(line_test_case, session) if test_case_name and line_test_case else {}
+        dist_kw = (
+            _distortion_kwargs(line_test_case, session) if test_case_name and line_test_case else {}
+        )
         homography = MapPointHomography(map_id=map_id, **dist_kw)
         result = homography.compute_from_lines(
             line_annotations=line_annotations,
@@ -680,22 +685,16 @@ def api_compute_line_errors(
     map_id = _require_map_id(tenant_id, session)
     line_test_case = _load_line_test_case_by_name(test_case_name, map_id, session)
     if line_test_case is None:
-        raise HTTPException(
-            status_code=404, detail=f"Line test case not found: {test_case_name}"
-        )
+        raise HTTPException(status_code=404, detail=f"Line test case not found: {test_case_name}")
 
     line_annotations = line_test_case.get("line_annotations", [])
     if not line_annotations:
-        raise HTTPException(
-            status_code=400, detail="No line annotations found in test case"
-        )
+        raise HTTPException(status_code=400, detail="No line annotations found in test case")
 
     # Load line registry (needed for both approaches)
     lines = _load_line_registry(tenant_id, session)
     if not lines:
-        raise HTTPException(
-            status_code=500, detail="No lines found in line registry"
-        )
+        raise HTTPException(status_code=500, detail="No lines found in line registry")
 
     line_registry = {line.line_id: line.to_dict() for line in lines}
 
@@ -752,9 +751,7 @@ def api_compute_line_errors(
         try:
             gcp_registry = from_gcp_repo_pg(session, map_id)
         except (KeyError, ValueError, OSError) as e:
-            raise HTTPException(
-                status_code=500, detail=f"Failed to load GCP registry: {e}"
-            )
+            raise HTTPException(status_code=500, detail=f"Failed to load GCP registry: {e}")
 
         try:
             homography = MapPointHomography(
@@ -767,9 +764,7 @@ def api_compute_line_errors(
                 min_inlier_ratio=0.5,
             )
         except (ValueError, RuntimeError) as e:
-            raise HTTPException(
-                status_code=500, detail=f"Homography computation failed: {e}"
-            )
+            raise HTTPException(status_code=500, detail=f"Homography computation failed: {e}")
 
     # Compute per-line errors
     per_line_errors: list[PerLineError] = []
@@ -798,28 +793,20 @@ def api_compute_line_errors(
         camera_start = np.array(
             [line_annotation["start_pixel_x"], line_annotation["start_pixel_y"]]
         )
-        camera_end = np.array(
-            [line_annotation["end_pixel_x"], line_annotation["end_pixel_y"]]
-        )
+        camera_end = np.array([line_annotation["end_pixel_x"], line_annotation["end_pixel_y"]])
 
         projected_start = homography.camera_to_map(
             PixelPoint.create(camera_start[0], camera_start[1])
         )
-        projected_end = homography.camera_to_map(
-            PixelPoint.create(camera_end[0], camera_end[1])
-        )
+        projected_end = homography.camera_to_map(PixelPoint.create(camera_end[0], camera_end[1]))
         projected_start_map = np.array([projected_start.pixel_x, projected_start.pixel_y])
         projected_end_map = np.array([projected_end.pixel_x, projected_end.pixel_y])
 
         start_error = _perpendicular_distance(projected_start_map, map_start, map_end)
         end_error = _perpendicular_distance(projected_end_map, map_start, map_end)
 
-        reprojected_start = homography.map_to_camera(
-            PixelPoint.create(map_start[0], map_start[1])
-        )
-        reprojected_end = homography.map_to_camera(
-            PixelPoint.create(map_end[0], map_end[1])
-        )
+        reprojected_start = homography.map_to_camera(PixelPoint.create(map_start[0], map_start[1]))
+        reprojected_end = homography.map_to_camera(PixelPoint.create(map_end[0], map_end[1]))
         reprojected_start_camera = np.array([reprojected_start.x, reprojected_start.y])
         reprojected_end_camera = np.array([reprojected_end.x, reprojected_end.y])
 
@@ -987,7 +974,10 @@ def api_camera_tile(
         image_path=image_path,
         width=info["width"],
         height=info["height"],
-        x=x, y=y, z=z, size=size,
+        x=x,
+        y=y,
+        z=z,
+        size=size,
     )
     return Response(content=png_bytes, media_type="image/png")
 
@@ -1027,6 +1017,9 @@ def api_map_tile(
         image_path=geotiff_path,
         width=info["width"],
         height=info["height"],
-        x=x, y=y, z=z, size=size,
+        x=x,
+        y=y,
+        z=z,
+        size=size,
     )
     return Response(content=png_bytes, media_type="image/png")

--- a/api/utils/frame_helpers.py
+++ b/api/utils/frame_helpers.py
@@ -7,7 +7,7 @@ constants are re-exported from ``frame_utils`` for convenience.
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path  # noqa: TC003 — kept at runtime; re-exported and used by API route modules
 from typing import TYPE_CHECKING
 
 from homography_web.frame_utils import (
@@ -20,6 +20,7 @@ from homography_web.frame_utils import (
     validate_image_filename,
 )
 
+from api.utils.map_assets import resolve_map_geotiff
 from poc_homography.infrastructure.repositories import (
     RepoPostgresCapturedFrame,
     RepoPostgresLineAnnotation,
@@ -72,9 +73,9 @@ def resolve_map_for_tenant(tenant_id: str, session: Session) -> tuple[Map, Path]
     if map_entity is None:
         raise RuntimeError(f"No map configured for tenant: {tenant_id}")
 
-    map_file = DATA_MAPS_DIR / map_entity.photo.path
-    if not map_file.exists():
-        raise RuntimeError(f"Map file not found: {map_file}")
+    map_file = resolve_map_geotiff(map_entity)
+    if map_file is None:
+        raise RuntimeError(f"Map asset not found for tenant: {tenant_id}")
 
     return map_entity, map_file
 

--- a/api/utils/map_assets.py
+++ b/api/utils/map_assets.py
@@ -16,6 +16,7 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from botocore.exceptions import ClientError
 from homography_web.frame_utils import DATA_MAPS_DIR
 
 from poc_homography.infrastructure.clients.minio_map_store import MinioMapStore
@@ -28,11 +29,26 @@ if TYPE_CHECKING:
 # reuse across requests and across worker restarts.
 _CACHE_DIR = Path(tempfile.gettempdir()) / "poc_homography_map_assets"
 
+# S3/MinIO error codes that mean "the object simply is not there" — treated as a
+# missing asset (``None`` -> 404) rather than a server error.
+_MISSING_OBJECT_CODES = frozenset({"NoSuchKey", "NoSuchBucket", "404"})
+
 
 def _cache_path(asset_key: str) -> Path:
-    """Local cache path mirroring ``asset_key`` under the cache directory."""
-    # Strip any leading slash so the key stays *inside* the cache dir.
-    return _CACHE_DIR / asset_key.lstrip("/")
+    """Local cache path for ``asset_key``, kept strictly inside the cache dir.
+
+    Raises:
+        ValueError: If ``asset_key`` would escape the cache directory (e.g. via
+            ``..`` segments) — defence-in-depth against a malformed/poisoned key.
+    """
+    base = _CACHE_DIR.resolve()
+    target = (base / asset_key.lstrip("/")).resolve()
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        msg = f"asset_key escapes the cache directory: {asset_key!r}"
+        raise ValueError(msg) from exc
+    return target
 
 
 def _materialise(asset_key: str, store: MinioMapStore) -> Path:
@@ -42,11 +58,18 @@ def _materialise(asset_key: str, store: MinioMapStore) -> Path:
         return target
     target.parent.mkdir(parents=True, exist_ok=True)
     data = store.get_map(asset_key)
-    # Write to a unique temp file then atomically replace, so concurrent tile
-    # requests never observe a half-written GeoTIFF.
-    tmp = target.with_name(f"{target.name}.{os.getpid()}.partial")
-    tmp.write_bytes(data)
-    tmp.replace(target)
+    # Write to a per-writer temp file then atomically replace, so concurrent tile
+    # requests never observe a half-written GeoTIFF. ``mkstemp`` gives a unique
+    # name across threads and processes; the temp is unlinked if anything fails
+    # before the atomic replace (and is a no-op afterwards, since it was renamed).
+    fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=f"{target.name}.", suffix=".partial")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        tmp.replace(target)
+    finally:
+        tmp.unlink(missing_ok=True)
     return target
 
 
@@ -56,11 +79,21 @@ def resolve_map_geotiff(map_entity: Map, *, store: MinioMapStore | None = None) 
     When the map carries an ``asset_key`` the GeoTIFF is materialised from object
     storage into a ``/tmp`` cache (the store is built from the environment when
     not injected). Otherwise the legacy ``data/maps`` path is used. Returns
-    ``None`` only when no asset key is set *and* the local file is absent.
+    ``None`` when the asset is absent in object storage *or* (no asset key) the
+    local file is absent — preserving the legacy "missing map -> 404" behaviour.
     """
     if map_entity.asset_key:
         store = store or MinioMapStore.from_env()
-        return _materialise(map_entity.asset_key, store)
+        try:
+            return _materialise(map_entity.asset_key, store)
+        except ClientError as exc:
+            # A map row that references an object missing from storage is a
+            # "no map asset" condition (404), not a 500. Other S3 errors
+            # (auth, connectivity) are genuine server faults and propagate.
+            code = exc.response.get("Error", {}).get("Code")
+            if code in _MISSING_OBJECT_CODES:
+                return None
+            raise
 
     local = DATA_MAPS_DIR / map_entity.photo.path
     return local if local.is_file() else None

--- a/api/utils/map_assets.py
+++ b/api/utils/map_assets.py
@@ -1,0 +1,69 @@
+"""Resolve a map's GeoTIFF to a local path, materialising it from object storage.
+
+Maps may be backed by an object-storage asset (``Map.asset_key``, populated by
+the upload pipeline — see #290/#291) rather than a file under ``data/maps``. The
+tile/info endpoints need a *local* path to tile with ``tifffile``/PIL, so when a
+map has an ``asset_key`` we download the GeoTIFF bytes once into a process-wide
+``/tmp`` cache and reuse that path across the many per-tile requests. Maps
+without an ``asset_key`` fall back to the legacy filesystem path so existing
+local-only setups keep working.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from homography_web.frame_utils import DATA_MAPS_DIR
+
+from poc_homography.infrastructure.clients.minio_map_store import MinioMapStore
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.map import Map
+
+# Process-wide cache for downloaded GeoTIFF assets. Asset keys are immutable (a
+# fresh upload gets a fresh key), so caching key -> bytes on disk is safe to
+# reuse across requests and across worker restarts.
+_CACHE_DIR = Path(tempfile.gettempdir()) / "poc_homography_map_assets"
+
+
+def _cache_path(asset_key: str) -> Path:
+    """Local cache path mirroring ``asset_key`` under the cache directory."""
+    # Strip any leading slash so the key stays *inside* the cache dir.
+    return _CACHE_DIR / asset_key.lstrip("/")
+
+
+def _materialise(asset_key: str, store: MinioMapStore) -> Path:
+    """Download ``asset_key`` into the cache (idempotent) and return its path."""
+    target = _cache_path(asset_key)
+    if target.is_file() and target.stat().st_size > 0:
+        return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    data = store.get_map(asset_key)
+    # Write to a unique temp file then atomically replace, so concurrent tile
+    # requests never observe a half-written GeoTIFF.
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.partial")
+    tmp.write_bytes(data)
+    tmp.replace(target)
+    return target
+
+
+def resolve_map_geotiff(map_entity: Map, *, store: MinioMapStore | None = None) -> Path | None:
+    """Resolve ``map_entity`` to a local GeoTIFF path.
+
+    When the map carries an ``asset_key`` the GeoTIFF is materialised from object
+    storage into a ``/tmp`` cache (the store is built from the environment when
+    not injected). Otherwise the legacy ``data/maps`` path is used. Returns
+    ``None`` only when no asset key is set *and* the local file is absent.
+    """
+    if map_entity.asset_key:
+        store = store or MinioMapStore.from_env()
+        return _materialise(map_entity.asset_key, store)
+
+    local = DATA_MAPS_DIR / map_entity.photo.path
+    return local if local.is_file() else None
+
+
+__all__ = ["resolve_map_geotiff"]

--- a/poc_homography/infrastructure/clients/minio_map_store.py
+++ b/poc_homography/infrastructure/clients/minio_map_store.py
@@ -133,5 +133,15 @@ class MinioMapStore:
             ExpiresIn=expires_in,
         )
 
+    def get_map(self, key: str) -> bytes:
+        """Download and return the raw GeoTIFF bytes stored under ``key``.
+
+        Used by the API to materialise a map asset locally (e.g. under ``/tmp``)
+        before tiling. Propagates whatever the underlying S3 client raises when
+        the object is absent (boto3 ``ClientError`` with code ``NoSuchKey``).
+        """
+        resp = self._client.get_object(Bucket=self.bucket, Key=key)
+        return resp["Body"].read()
+
 
 __all__ = ["DEFAULT_BUCKET", "MinioMapStore", "PutResult"]

--- a/tests/infrastructure/test_minio_map_store.py
+++ b/tests/infrastructure/test_minio_map_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 
 import pytest
 from botocore.exceptions import ClientError
@@ -16,11 +17,14 @@ from poc_homography.infrastructure.clients.minio_map_store import (
 class FakeS3:
     """Records boto3 S3 client calls; ``head_missing`` makes head_bucket 404."""
 
-    def __init__(self, *, head_missing: bool = False) -> None:
+    def __init__(self, *, head_missing: bool = False, objects: dict | None = None) -> None:
         self.head_missing = head_missing
         self.puts: list[dict] = []
         self.created: list[str] = []
         self.heads: list[str] = []
+        # key -> bytes, served by get_object.
+        self.objects: dict[str, bytes] = dict(objects or {})
+        self.gets: list[str] = []
 
     def head_bucket(self, Bucket: str) -> None:
         self.heads.append(Bucket)
@@ -35,6 +39,12 @@ class FakeS3:
 
     def generate_presigned_url(self, op: str, Params: dict, ExpiresIn: int) -> str:
         return f"https://minio/{op}/{Params['Bucket']}/{Params['Key']}?e={ExpiresIn}"
+
+    def get_object(self, Bucket: str, Key: str) -> dict:
+        self.gets.append(Key)
+        if Key not in self.objects:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(self.objects[Key])}
 
 
 def _store(client: FakeS3, bucket: str = "map-assets") -> MinioMapStore:
@@ -82,6 +92,21 @@ def test_presign_get_delegates_to_client() -> None:
     client = FakeS3()
     url = _store(client).presign_get("valte/Cartografia_valencia.tif", expires_in=120)
     assert url == "https://minio/get_object/map-assets/valte/Cartografia_valencia.tif?e=120"
+
+
+def test_get_map_returns_bytes() -> None:
+    data = b"II*\x00 geotiff bytes"
+    client = FakeS3(objects={"icozee/icozee-cropped.tif": data})
+    store = _store(client)
+
+    assert store.get_map("icozee/icozee-cropped.tif") == data
+    assert client.gets == ["icozee/icozee-cropped.tif"]
+
+
+def test_get_map_propagates_missing_object() -> None:
+    client = FakeS3()
+    with pytest.raises(ClientError):
+        _store(client).get_map("missing/key.tif")
 
 
 def test_from_env_reads_minio_map_bucket() -> None:

--- a/tests/test_api/test_map_assets.py
+++ b/tests/test_api/test_map_assets.py
@@ -1,0 +1,112 @@
+"""Unit + end-to-end tests for object-storage-backed map GeoTIFF resolution.
+
+``resolve_map_geotiff`` materialises a map's GeoTIFF from object storage into a
+``/tmp`` cache when the map carries an ``asset_key``, and falls back to the
+legacy ``data/maps`` path otherwise. These tests inject a fake store (the
+``client`` DI pattern mirrored at the resolver level) so they run fully offline.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import numpy as np
+import tifffile
+from api.utils import map_assets
+from api.utils.map_assets import resolve_map_geotiff
+from api.utils.tiles import render_tile
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _FakeStore:
+    """Records ``get_map`` calls and serves bytes from an in-memory mapping."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.calls: list[str] = []
+
+    def get_map(self, key: str) -> bytes:
+        self.calls.append(key)
+        return self.objects[key]
+
+
+def _map(*, asset_key: str | None = None, path: str = "tenant/map.tif") -> SimpleNamespace:
+    """Lightweight stand-in for a ``Map`` entity (only the fields used here)."""
+    return SimpleNamespace(asset_key=asset_key, photo=SimpleNamespace(path=Path(path)))
+
+
+def _tiny_geotiff_bytes(width: int = 64, height: int = 48) -> bytes:
+    """Encode a small RGB TIFF in-memory (stands in for a map asset)."""
+    arr = np.random.default_rng(0).integers(0, 255, (height, width, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    tifffile.imwrite(buf, arr)
+    return buf.getvalue()
+
+
+def test_resolves_asset_key_via_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(map_assets, "_CACHE_DIR", tmp_path / "cache")
+    data = b"II*\x00 geotiff bytes"
+    store = _FakeStore({"tenant/map.tif": data})
+
+    resolved = resolve_map_geotiff(_map(asset_key="tenant/map.tif"), store=store)
+
+    assert resolved is not None
+    assert resolved.read_bytes() == data
+    assert store.calls == ["tenant/map.tif"]
+
+
+def test_caches_download_across_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(map_assets, "_CACHE_DIR", tmp_path / "cache")
+    store = _FakeStore({"tenant/map.tif": b"bytes"})
+    entity = _map(asset_key="tenant/map.tif")
+
+    first = resolve_map_geotiff(entity, store=store)
+    second = resolve_map_geotiff(entity, store=store)
+
+    assert first == second
+    # Second resolution is served from the /tmp cache — no extra download.
+    assert store.calls == ["tenant/map.tif"]
+
+
+def test_falls_back_to_local_when_no_asset_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(map_assets, "DATA_MAPS_DIR", tmp_path)
+    local = tmp_path / "tenant" / "map.tif"
+    local.parent.mkdir(parents=True)
+    local.write_bytes(b"local tiff")
+
+    resolved = resolve_map_geotiff(_map(asset_key=None, path="tenant/map.tif"))
+
+    assert resolved == local
+
+
+def test_returns_none_when_no_asset_key_and_local_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(map_assets, "DATA_MAPS_DIR", tmp_path)
+
+    resolved = resolve_map_geotiff(_map(asset_key=None, path="tenant/absent.tif"))
+
+    assert resolved is None
+
+
+def test_tile_serving_end_to_end_from_object_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Download a GeoTIFF from the (fake) store and render a PNG tile from it."""
+    monkeypatch.setattr(map_assets, "_CACHE_DIR", tmp_path / "cache")
+    geotiff = _tiny_geotiff_bytes(width=64, height=48)
+    store = _FakeStore({"tenant/map.tif": geotiff})
+
+    resolved = resolve_map_geotiff(_map(asset_key="tenant/map.tif"), store=store)
+    assert resolved is not None
+
+    png = render_tile(image_path=resolved, width=64, height=48, x=0, y=0, z=0, size=256)
+
+    assert png.startswith(b"\x89PNG\r\n\x1a\n")

--- a/tests/test_api/test_map_assets.py
+++ b/tests/test_api/test_map_assets.py
@@ -11,20 +11,22 @@ from __future__ import annotations
 import io
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 import tifffile
 from api.utils import map_assets
 from api.utils.map_assets import resolve_map_geotiff
 from api.utils.tiles import render_tile
-
-if TYPE_CHECKING:
-    import pytest
+from botocore.exceptions import ClientError
 
 
 class _FakeStore:
-    """Records ``get_map`` calls and serves bytes from an in-memory mapping."""
+    """Records ``get_map`` calls and serves bytes from an in-memory mapping.
+
+    Mirrors :class:`MinioMapStore.get_map`: an absent key raises a boto3
+    ``ClientError`` with code ``NoSuchKey`` (what real S3/MinIO returns).
+    """
 
     def __init__(self, objects: dict[str, bytes]) -> None:
         self.objects = objects
@@ -32,6 +34,8 @@ class _FakeStore:
 
     def get_map(self, key: str) -> bytes:
         self.calls.append(key)
+        if key not in self.objects:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
         return self.objects[key]
 
 
@@ -110,3 +114,22 @@ def test_tile_serving_end_to_end_from_object_storage(
     png = render_tile(image_path=resolved, width=64, height=48, x=0, y=0, z=0, size=256)
 
     assert png.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_missing_object_resolves_to_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A map whose asset_key is absent in storage resolves to None (-> 404)."""
+    monkeypatch.setattr(map_assets, "_CACHE_DIR", tmp_path / "cache")
+    store = _FakeStore({})  # bucket has no objects
+
+    resolved = resolve_map_geotiff(_map(asset_key="tenant/gone.tif"), store=store)
+
+    assert resolved is None
+
+
+def test_asset_key_traversal_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An asset_key escaping the cache dir raises rather than writing outside it."""
+    monkeypatch.setattr(map_assets, "_CACHE_DIR", tmp_path / "cache")
+    store = _FakeStore({"../../etc/evil.tif": b"x"})
+
+    with pytest.raises(ValueError, match="escapes the cache directory"):
+        resolve_map_geotiff(_map(asset_key="../../etc/evil.tif"), store=store)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -258,6 +258,7 @@ _.world_to_cell  # cleanplate-surface (poc_homography/cleanplate/raster.py:129)
 _.cell_to_world  # cleanplate-surface (poc_homography/cleanplate/raster.py:150)
 time_bucket  # cleanplate-surface (poc_homography/cleanplate/reconstruct.py:64)
 _.presign_get  # cleanplate-surface (poc_homography/infrastructure/clients/minio_frame_store.py:129)
+_.get_map  # cleanplate-surface — MinioMapStore GeoTIFF download, consumed by the map tile/info API #292 (poc_homography/infrastructure/clients/minio_map_store.py:136)
 
 # == uncertain-needs-follow-up ==
 # UNCERTAIN — symbol exists but no callers and no test references found; kept to keep vulture green pending a dead-code follow-up (see #226)


### PR DESCRIPTION
## Summary

Make the map image and tile API endpoints serve GeoTIFF-backed map assets from object storage instead of the local filesystem, resolving the asset reference from the Map's Postgres record (`asset_key` added in #291).

When a `Map` carries an `asset_key`, the GeoTIFF is downloaded once from the MinIO map store (`MinioMapStore.get_map`, new) into a process-wide `/tmp` cache and reused across the many per-tile requests; maps without an `asset_key` fall back to the legacy `data/maps` path so local-only setups keep working. A new `api/utils/map_assets.resolve_map_geotiff(map, *, store=None)` centralises this and is wired into both resolution points — `homography_precision._get_map_geotiff_file` and `frame_helpers.resolve_map_for_tenant` — so all five map endpoints serve from S3:

- `/api/map-info/`, `/api/map-tile/` (homography_precision)
- `/api/image/info/`, `/api/image/tile/`, `/api/image/full/` (line_picker)

**Hardening (from code review):** path-traversal containment on `asset_key`; missing-object (`NoSuchKey`) resolves to `None` to preserve the legacy "missing map → 404" contract instead of a 500; per-writer `mkstemp` + `try/finally` for concurrent-write safety and orphan cleanup.

**Scope note:** `/api/camera-tile/` stays filesystem-backed — `CapturedFrame` has no object-storage key (the #290/#291 blockers only added `Map.asset_key`); a camera-frame S3 path needs a follow-up issue.

## Test plan

- `uv run poe validate` (lint, format-check, pyright, pylint, vulture) — green.
- `uv run pytest tests/` — full suite green (1281 passed, 157 env-gated skips).
- `tests/test_api/test_map_assets.py`: asset_key download, `/tmp` cache reuse (single download), legacy fallback, missing-local → `None`, missing S3 object → `None` (404 contract), asset_key traversal rejected, download→`render_tile` end-to-end producing a PNG.
- `tests/infrastructure/test_minio_map_store.py`: `get_map` returns bytes; `get_map` propagates `ClientError` on missing object.

## Definition of Done

- [x] `/api/map-info/`, `/api/map-tile/` resolve assets from Postgres + object storage, not local FS
- [x] `/api/image/info/`, `/api/image/tile/`, `/api/image/full/` serve from object storage
- [x] Tile serving works end-to-end against an S3/MinIO-backed map asset
- [x] No remaining hardcoded local-filesystem reads of GeoTIFF map assets in these endpoints
- [x] Existing tests pass; the S3-backed path is covered (store injected, as `MinioFrameStore` does for tests)

Closes #292
