### PR TITLE
refactor(ddd): resolve deferred DDD items L1–L5 (extract precision service + typed annotation DTOs) [#296]

### DIFF
--- a/poc_homography/application/__init__.py
+++ b/poc_homography/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application-layer services (framework-agnostic orchestration)."""

--- a/poc_homography/application/homography_precision.py
+++ b/poc_homography/application/homography_precision.py
@@ -1,0 +1,557 @@
+"""Application-layer service for homography precision computation.
+
+Framework-agnostic orchestration of homography computation plus metric and
+error aggregation for the precision-visualization endpoints.  This module must
+not import Django or anything from ``webapp/`` so it can be reused and unit
+tested without HTTP machinery.
+
+The domain raises ``ValueError``/``RuntimeError`` on computation failures; the
+service propagates them unchanged so the calling view can map them to the
+existing HTTP error responses.  Result types are frozen dataclasses that carry
+the exact response payload via ``to_payload()``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+import numpy as np
+
+from poc_homography.calibration.lens_distortion.calibration_table import (
+    load_calibration_for_camera,
+)
+from poc_homography.domain.vo import PixelPoint
+from poc_homography.homography.map_points import MapPointHomography
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from poc_homography.map_points.gcp_registry import GCPRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class HomographyProjection(Protocol):
+    """Minimal projection interface used by the error-aggregation services.
+
+    Implemented by ``MapPointHomography``; declared as a protocol so unit tests
+    can inject identity-like stubs without RANSAC data.
+    """
+
+    def camera_to_map(self, camera_pixel: PixelPoint, point_id: str = ...) -> Any:
+        """Project a camera pixel to map coordinates (``.pixel_x``/``.pixel_y``)."""
+        ...
+
+    def map_to_camera(self, map_coord: PixelPoint) -> PixelPoint:
+        """Project a map coordinate to a camera pixel (``.x``/``.y``)."""
+        ...
+
+
+class LineNotInRegistryError(Exception):
+    """Raised when a line annotation references a line id absent from the registry.
+
+    Carries the offending ``line_id`` so the caller can reproduce the existing
+    ``f"Line {line_id} not found in line registry"`` error response.
+    """
+
+    def __init__(self, line_id: str) -> None:
+        """Store the missing ``line_id`` and build the message."""
+        self.line_id = line_id
+        super().__init__(f"Line {line_id} not found in line registry")
+
+
+def perpendicular_distance(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> float:
+    """Calculate perpendicular distance from point p to line defined by points a and b.
+
+    Args:
+        p: Point as numpy array [x, y].
+        a: Line start point as numpy array [x, y].
+        b: Line end point as numpy array [x, y].
+
+    Returns:
+        Perpendicular distance in pixels.
+    """
+    # Line vector
+    v = b - a
+    # Point vector from a to p
+    w = p - a
+
+    # Project w onto v
+    c1 = np.dot(w, v)
+    c2 = np.dot(v, v)
+
+    if c2 == 0:
+        # Line has zero length (a and b are the same point)
+        return float(np.linalg.norm(w))
+
+    # Perpendicular distance = |w - proj_v(w)|
+    b_param = c1 / c2
+    proj = a + b_param * v
+    return float(np.linalg.norm(p - proj))
+
+
+def build_distortion_params(
+    camera_name: str,
+    zoom: float,
+    calibrations_dir: Path,
+) -> dict[str, float]:
+    """Build distortion + intrinsic kwargs for ``MapPointHomography``.
+
+    Loads the calibration table for ``camera_name``, interpolates the
+    distortion coefficients and intrinsics at ``zoom``, and returns a dict with
+    keys k1,k2,k3,p1,p2,fx,fy,cx,cy.  Returns an empty dict if any piece is
+    unavailable, preserving the broad try/except + debug-logging behaviour of
+    the original view helper.
+
+    Args:
+        camera_name: Camera identifier used to locate the calibration table.
+        zoom: Zoom factor at which to interpolate coefficients/intrinsics.
+        calibrations_dir: Directory containing per-camera calibration tables.
+
+    Returns:
+        Mapping of distortion + intrinsic parameters, or ``{}`` on any failure.
+    """
+    try:
+        table = load_calibration_for_camera(camera_name, calibrations_dir)
+        if table is None:
+            return {}
+        coeffs = table.get_coefficients(zoom)
+        intrinsics = table.get_intrinsics(zoom)
+        if intrinsics is None:
+            return {}
+        return {
+            "k1": float(coeffs.k1),
+            "k2": float(coeffs.k2),
+            "k3": float(coeffs.k3),
+            "p1": float(coeffs.p1),
+            "p2": float(coeffs.p2),
+            **intrinsics,
+        }
+    except Exception:
+        logger.debug("Failed to load distortion params for %s", camera_name, exc_info=True)
+        return {}
+
+
+@dataclass(frozen=True)
+class GcpPrecisionResult:
+    """Aggregated GCP homography precision metrics, per-point errors and overlays."""
+
+    num_gcps: int
+    num_inliers: int
+    inlier_ratio: float
+    mean_reproj_error: float
+    max_reproj_error: float
+    rmse: float
+    per_point_errors: list[dict[str, Any]]
+    camera_annotations: list[dict[str, Any]]
+    camera_reprojected: list[dict[str, Any]]
+    map_gcps: list[dict[str, Any]]
+    map_projected: list[dict[str, Any]]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Build the HTTP response payload (keys/rounding identical to the view)."""
+        return {
+            "success": True,
+            "metrics": {
+                "num_gcps": self.num_gcps,
+                "num_inliers": self.num_inliers,
+                "inlier_ratio": round(self.inlier_ratio, 2),
+                "mean_reproj_error": round(self.mean_reproj_error, 2),
+                "max_reproj_error": round(self.max_reproj_error, 2),
+                "rmse": round(self.rmse, 2),
+            },
+            "per_point_errors": self.per_point_errors,
+            "overlays": {
+                "camera": {
+                    "annotations": self.camera_annotations,
+                    "reprojected_gcps": self.camera_reprojected,
+                },
+                "map": {
+                    "gcps": self.map_gcps,
+                    "projected_annotations": self.map_projected,
+                },
+            },
+        }
+
+
+def compute_gcp_precision(
+    annotations: list[dict[str, Any]],
+    registry: GCPRegistry,
+    distortion: dict[str, float],
+    ransac_threshold: float = 50.0,
+    min_inlier_ratio: float = 0.5,
+) -> GcpPrecisionResult:
+    """Compute a GCP homography and aggregate per-point errors, overlays and metrics.
+
+    Args:
+        annotations: Camera GCP annotations (``gcp_id``, ``pixel_x``, ``pixel_y``).
+        registry: GCP registry providing map coordinates per ``gcp_id``.
+        distortion: Distortion/intrinsic kwargs for ``MapPointHomography``.
+        ransac_threshold: RANSAC inlier threshold forwarded to the domain.
+        min_inlier_ratio: Minimum inlier ratio forwarded to the domain.
+
+    Returns:
+        Aggregated result carrying the response payload.
+
+    Raises:
+        ValueError: Propagated from the domain on invalid input.
+        RuntimeError: Propagated from the domain on computation failure.
+    """
+    homography = MapPointHomography(map_id=registry.map_id, **distortion)
+    result = homography.compute_from_gcps(
+        gcps=annotations,
+        map_registry=registry,
+        ransac_threshold=ransac_threshold,
+        min_inlier_ratio=min_inlier_ratio,
+    )
+
+    per_point_errors: list[dict[str, Any]] = []
+    camera_annotations: list[dict[str, Any]] = []
+    camera_reprojected: list[dict[str, Any]] = []
+    map_gcps: list[dict[str, Any]] = []
+    map_projected: list[dict[str, Any]] = []
+
+    for annotation in annotations:
+        gcp_id = annotation["gcp_id"]
+
+        # Get original camera pixel (annotation position)
+        camera_x = annotation["pixel_x"]
+        camera_y = annotation["pixel_y"]
+        camera_pixel = PixelPoint.create(camera_x, camera_y)
+
+        # Get GCP map coordinate from registry
+        gcp = registry.points[gcp_id]
+        map_x = gcp.pixel_x
+        map_y = gcp.pixel_y
+
+        # Project annotation to map using camera_to_map()
+        projected_map = homography.camera_to_map(camera_pixel)
+
+        # Reproject GCP back to camera using map_to_camera()
+        gcp_coord = PixelPoint.create(map_x, map_y)
+        reprojected_camera = homography.map_to_camera(gcp_coord)
+
+        # Calculate per-point error (Euclidean distance between original annotation
+        # and reprojected GCP)
+        original = np.array([camera_x, camera_y])
+        reprojected = np.array([reprojected_camera.x, reprojected_camera.y])
+        error_px = float(np.linalg.norm(reprojected - original))
+
+        # Calculate per-axis errors for camera frame
+        camera_dx = reprojected_camera.x - camera_x
+        camera_dy = reprojected_camera.y - camera_y
+
+        # Calculate per-axis errors for map frame
+        map_dx = projected_map.pixel_x - map_x
+        map_dy = projected_map.pixel_y - map_y
+
+        per_point_errors.append(
+            {
+                "gcp_id": gcp_id,
+                "error_px": round(error_px, 2),
+                "camera_dx": round(camera_dx, 2),
+                "camera_dy": round(camera_dy, 2),
+                "map_dx": round(map_dx, 2),
+                "map_dy": round(map_dy, 2),
+                "camera_original": [round(camera_x, 2), round(camera_y, 2)],
+                "camera_reprojected": [
+                    round(reprojected_camera.x, 2),
+                    round(reprojected_camera.y, 2),
+                ],
+                "map_original": [round(map_x, 2), round(map_y, 2)],
+                "map_projected": [round(projected_map.pixel_x, 2), round(projected_map.pixel_y, 2)],
+            }
+        )
+
+        # Collect overlay data
+        camera_annotations.append(
+            {
+                "gcp_id": gcp_id,
+                "x": round(camera_x, 2),
+                "y": round(camera_y, 2),
+            }
+        )
+        camera_reprojected.append(
+            {
+                "gcp_id": gcp_id,
+                "x": round(reprojected_camera.x, 2),
+                "y": round(reprojected_camera.y, 2),
+            }
+        )
+        map_gcps.append(
+            {
+                "gcp_id": gcp_id,
+                "x": round(map_x, 2),
+                "y": round(map_y, 2),
+            }
+        )
+        map_projected.append(
+            {
+                "gcp_id": gcp_id,
+                "x": round(projected_map.pixel_x, 2),
+                "y": round(projected_map.pixel_y, 2),
+            }
+        )
+
+    return GcpPrecisionResult(
+        num_gcps=result.num_gcps,
+        num_inliers=result.num_inliers,
+        inlier_ratio=result.inlier_ratio,
+        mean_reproj_error=result.mean_reproj_error,
+        max_reproj_error=result.max_reproj_error,
+        rmse=result.rmse,
+        per_point_errors=per_point_errors,
+        camera_annotations=camera_annotations,
+        camera_reprojected=camera_reprojected,
+        map_gcps=map_gcps,
+        map_projected=map_projected,
+    )
+
+
+@dataclass(frozen=True)
+class LineHomographyResult:
+    """Line-based homography metrics plus the resulting matrix."""
+
+    num_lines: int
+    num_inliers: int
+    inlier_ratio: float
+    mean_perp_error: float
+    max_perp_error: float
+    rmse: float
+    homography_matrix: np.ndarray
+
+    def to_payload(self) -> dict[str, Any]:
+        """Build the HTTP response payload (keys/rounding identical to the view)."""
+        return {
+            "success": True,
+            "homography_source": "lines",
+            "metrics": {
+                "num_lines": self.num_lines,
+                "num_inliers": self.num_inliers,
+                "inlier_ratio": round(self.inlier_ratio, 2),
+                "mean_perp_error": round(self.mean_perp_error, 2),
+                "max_perp_error": round(self.max_perp_error, 2),
+                "rmse": round(self.rmse, 2),
+            },
+            "homography_matrix": self.homography_matrix.tolist(),
+        }
+
+
+def compute_line_homography(
+    line_annotations: list[dict[str, Any]],
+    line_registry: dict[str, dict[str, float]],
+    distortion: dict[str, float],
+    map_id: str,
+    ransac_threshold: float = 50.0,
+    min_inlier_ratio: float = 0.3,
+) -> LineHomographyResult:
+    """Compute a line-based homography and assemble its metrics.
+
+    Args:
+        line_annotations: Camera line annotations.
+        line_registry: Map-coordinate line definitions keyed by ``line_id``.
+        distortion: Distortion/intrinsic kwargs for ``MapPointHomography``.
+        map_id: Map identifier for the homography.
+        ransac_threshold: RANSAC inlier threshold forwarded to the domain.
+        min_inlier_ratio: Minimum inlier ratio forwarded to the domain.
+
+    Returns:
+        Aggregated result carrying the response payload.
+
+    Raises:
+        ValueError: Propagated from the domain on invalid input.
+        RuntimeError: Propagated from the domain on computation failure.
+    """
+    homography = MapPointHomography(map_id=map_id, **distortion)
+    result = homography.compute_from_lines(
+        line_annotations=line_annotations,
+        line_registry=line_registry,
+        ransac_threshold=ransac_threshold,
+        min_inlier_ratio=min_inlier_ratio,
+    )
+    return LineHomographyResult(
+        num_lines=result.num_lines,
+        num_inliers=result.num_inliers,
+        inlier_ratio=result.inlier_ratio,
+        mean_perp_error=result.mean_perp_error,
+        max_perp_error=result.max_perp_error,
+        rmse=result.rmse,
+        homography_matrix=result.homography_matrix,
+    )
+
+
+@dataclass(frozen=True)
+class LineErrorsResult:
+    """Aggregated per-line errors and overlays for a precomputed homography."""
+
+    num_lines: int
+    mean_line_error: float
+    max_line_error: float
+    per_line_errors: list[dict[str, Any]]
+    camera_annotations: list[dict[str, Any]]
+    camera_reprojected_lines: list[dict[str, Any]]
+    map_gcp_lines: list[dict[str, Any]]
+    map_projected_lines: list[dict[str, Any]]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Build the HTTP response payload (keys/rounding identical to the view)."""
+        return {
+            "success": True,
+            "metrics": {
+                "num_lines": self.num_lines,
+                "mean_line_error": round(self.mean_line_error, 2),
+                "max_line_error": round(self.max_line_error, 2),
+            },
+            "per_line_errors": self.per_line_errors,
+            "line_overlays": {
+                "camera": {
+                    "annotations": self.camera_annotations,
+                    "reprojected_lines": self.camera_reprojected_lines,
+                },
+                "map": {
+                    "gcp_lines": self.map_gcp_lines,
+                    "projected_lines": self.map_projected_lines,
+                },
+            },
+        }
+
+
+def compute_line_errors(
+    homography: HomographyProjection,
+    line_annotations: list[dict[str, Any]],
+    line_registry: dict[str, dict[str, float]],
+) -> LineErrorsResult:
+    """Aggregate per-line errors and overlays for a precomputed homography.
+
+    Args:
+        homography: Projection object exposing ``camera_to_map``/``map_to_camera``.
+        line_annotations: Camera line annotations to evaluate.
+        line_registry: Map-coordinate line definitions keyed by ``line_id``.
+
+    Returns:
+        Aggregated result carrying the response payload.
+
+    Raises:
+        LineNotInRegistryError: If an annotation references an unknown ``line_id``.
+    """
+    per_line_errors: list[dict[str, Any]] = []
+    camera_annotations: list[dict[str, Any]] = []
+    camera_reprojected_lines: list[dict[str, Any]] = []
+    map_gcp_lines: list[dict[str, Any]] = []
+    map_projected_lines: list[dict[str, Any]] = []
+
+    total_error = 0.0
+    max_error = 0.0
+
+    for line_annotation in line_annotations:
+        line_id = line_annotation["line_id"]
+
+        # Get line definition from registry
+        if line_id not in line_registry:
+            raise LineNotInRegistryError(line_id)
+
+        line_def = line_registry[line_id]
+
+        # Ground truth line in map coordinates (directly from line registry)
+        map_start = np.array([line_def["start_x"], line_def["start_y"]])
+        map_end = np.array([line_def["end_x"], line_def["end_y"]])
+
+        # Annotated line in camera coordinates
+        camera_start = np.array(
+            [line_annotation["start_pixel_x"], line_annotation["start_pixel_y"]]
+        )
+        camera_end = np.array([line_annotation["end_pixel_x"], line_annotation["end_pixel_y"]])
+
+        # Project camera line endpoints to map
+        projected_start = homography.camera_to_map(
+            PixelPoint.create(camera_start[0], camera_start[1])
+        )
+        projected_end = homography.camera_to_map(PixelPoint.create(camera_end[0], camera_end[1]))
+        projected_start_map = np.array([projected_start.pixel_x, projected_start.pixel_y])
+        projected_end_map = np.array([projected_end.pixel_x, projected_end.pixel_y])
+
+        # Compute errors: perpendicular distance from projected points to ground truth line
+        start_error = perpendicular_distance(projected_start_map, map_start, map_end)
+        end_error = perpendicular_distance(projected_end_map, map_start, map_end)
+
+        # Also compute reverse: project GCP line to camera and compare
+        reprojected_start = homography.map_to_camera(PixelPoint.create(map_start[0], map_start[1]))
+        reprojected_end = homography.map_to_camera(PixelPoint.create(map_end[0], map_end[1]))
+        reprojected_start_camera = np.array([reprojected_start.x, reprojected_start.y])
+        reprojected_end_camera = np.array([reprojected_end.x, reprojected_end.y])
+
+        # Compute errors in camera space
+        camera_start_error = perpendicular_distance(
+            camera_start, reprojected_start_camera, reprojected_end_camera
+        )
+        camera_end_error = perpendicular_distance(
+            camera_end, reprojected_start_camera, reprojected_end_camera
+        )
+
+        # Average error for this line (using camera space errors as primary metric)
+        line_error = (camera_start_error + camera_end_error) / 2.0
+
+        total_error += line_error
+        max_error = max(max_error, line_error)
+
+        per_line_errors.append(
+            {
+                "line_id": line_id,
+                "error_px": round(line_error, 2),
+                "start_error": round(camera_start_error, 2),
+                "end_error": round(camera_end_error, 2),
+                "map_start_error": round(start_error, 2),
+                "map_end_error": round(end_error, 2),
+            }
+        )
+
+        # Collect overlay data for camera frame
+        camera_annotations.append(
+            {
+                "line_id": line_id,
+                "start": [round(camera_start[0], 2), round(camera_start[1], 2)],
+                "end": [round(camera_end[0], 2), round(camera_end[1], 2)],
+            }
+        )
+        camera_reprojected_lines.append(
+            {
+                "line_id": line_id,
+                "start": [
+                    round(reprojected_start_camera[0], 2),
+                    round(reprojected_start_camera[1], 2),
+                ],
+                "end": [round(reprojected_end_camera[0], 2), round(reprojected_end_camera[1], 2)],
+            }
+        )
+
+        # Collect overlay data for map frame
+        map_gcp_lines.append(
+            {
+                "line_id": line_id,
+                "start": [round(map_start[0], 2), round(map_start[1], 2)],
+                "end": [round(map_end[0], 2), round(map_end[1], 2)],
+            }
+        )
+        map_projected_lines.append(
+            {
+                "line_id": line_id,
+                "start": [round(projected_start_map[0], 2), round(projected_start_map[1], 2)],
+                "end": [round(projected_end_map[0], 2), round(projected_end_map[1], 2)],
+            }
+        )
+
+    num_lines = len(line_annotations)
+    mean_line_error = total_error / num_lines if num_lines > 0 else 0.0
+
+    return LineErrorsResult(
+        num_lines=num_lines,
+        mean_line_error=mean_line_error,
+        max_line_error=max_error,
+        per_line_errors=per_line_errors,
+        camera_annotations=camera_annotations,
+        camera_reprojected_lines=camera_reprojected_lines,
+        map_gcp_lines=map_gcp_lines,
+        map_projected_lines=map_projected_lines,
+    )

--- a/tests/application/test_homography_precision.py
+++ b/tests/application/test_homography_precision.py
@@ -215,6 +215,45 @@ class TestComputeLineErrors:
         assert exc_info.value.line_id == "MISSING"
         assert "MISSING" in str(exc_info.value)
 
+    def test_to_payload_golden_structure(self):
+        """Lock the full nested payload shape (keys + overlay structure) byte-for-byte.
+
+        A single line that matches its registry definition under identity
+        projection yields all-zero errors, so the entire payload is exactly
+        predictable. This guards against silent drift in key names, nesting, or
+        overlay layout that the key-set assertions above would not catch.
+        """
+        registry = {"L1": {"start_x": 0.0, "start_y": 0.0, "end_x": 10.0, "end_y": 0.0}}
+        annotations = [
+            {
+                "line_id": "L1",
+                "start_pixel_x": 0.0,
+                "start_pixel_y": 0.0,
+                "end_pixel_x": 10.0,
+                "end_pixel_y": 0.0,
+            }
+        ]
+        payload = svc.compute_line_errors(_IdentityHomography(), annotations, registry).to_payload()
+        line = {"line_id": "L1", "start": [0.0, 0.0], "end": [10.0, 0.0]}
+        assert payload == {
+            "success": True,
+            "metrics": {"num_lines": 1, "mean_line_error": 0.0, "max_line_error": 0.0},
+            "per_line_errors": [
+                {
+                    "line_id": "L1",
+                    "error_px": 0.0,
+                    "start_error": 0.0,
+                    "end_error": 0.0,
+                    "map_start_error": 0.0,
+                    "map_end_error": 0.0,
+                }
+            ],
+            "line_overlays": {
+                "camera": {"annotations": [line], "reprojected_lines": [line]},
+                "map": {"gcp_lines": [line], "projected_lines": [line]},
+            },
+        }
+
 
 class TestComputeGcpPrecision:
     """Tests for ``compute_gcp_precision`` aggregation over a real homography."""

--- a/tests/application/test_homography_precision.py
+++ b/tests/application/test_homography_precision.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Unit tests for the homography-precision application service.
+
+These tests exercise the framework-agnostic service extracted from the
+``homography_precision`` Django views.  They use synthetic data and stubs so no
+DVC-backed fixtures are required.
+
+Run with: python -m pytest tests/application/test_homography_precision.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from poc_homography.application import homography_precision as svc
+from poc_homography.domain.vo import PixelPoint
+from poc_homography.map_points import GCPRegistry, MapPoint
+
+
+class TestPerpendicularDistance:
+    """Tests for ``perpendicular_distance``."""
+
+    def test_point_off_horizontal_line(self):
+        """Perpendicular distance to a horizontal segment equals the vertical offset."""
+        p = np.array([1.0, 3.0])
+        a = np.array([0.0, 0.0])
+        b = np.array([10.0, 0.0])
+        assert svc.perpendicular_distance(p, a, b) == pytest.approx(3.0)
+
+    def test_point_on_line_is_zero(self):
+        """A point lying on the line has zero perpendicular distance."""
+        p = np.array([5.0, 0.0])
+        a = np.array([0.0, 0.0])
+        b = np.array([10.0, 0.0])
+        assert svc.perpendicular_distance(p, a, b) == pytest.approx(0.0)
+
+    def test_zero_length_line_returns_distance_to_point(self):
+        """When a == b the result is the Euclidean distance from p to that point."""
+        p = np.array([3.0, 4.0])
+        a = np.array([0.0, 0.0])
+        b = np.array([0.0, 0.0])
+        assert svc.perpendicular_distance(p, a, b) == pytest.approx(5.0)
+
+
+class _FakeCoeffs:
+    """Minimal stand-in for lens-distortion coefficients."""
+
+    k1 = -0.1
+    k2 = 0.2
+    k3 = 0.0
+    p1 = 0.01
+    p2 = -0.02
+
+
+class _FakeTable:
+    """Minimal stand-in for a per-camera calibration table."""
+
+    def get_coefficients(self, zoom_factor: float) -> _FakeCoeffs:
+        return _FakeCoeffs()
+
+    def get_intrinsics(self, zoom_factor: float) -> dict[str, float]:
+        return {"fx": 1800.0, "fy": 1810.0, "cx": 1280.0, "cy": 720.0}
+
+
+class TestBuildDistortionParams:
+    """Tests for ``build_distortion_params``."""
+
+    def test_returns_empty_when_table_missing(self, monkeypatch):
+        """No calibration table -> empty dict."""
+        monkeypatch.setattr(svc, "load_calibration_for_camera", lambda name, d: None)
+        result = svc.build_distortion_params("cam1", 1.0, Path("/nope"))
+        assert result == {}
+
+    def test_returns_empty_when_intrinsics_missing(self, monkeypatch):
+        """Table present but no intrinsics -> empty dict."""
+
+        class _NoIntrinsics(_FakeTable):
+            def get_intrinsics(self, zoom_factor: float):
+                return None
+
+        monkeypatch.setattr(svc, "load_calibration_for_camera", lambda name, d: _NoIntrinsics())
+        assert svc.build_distortion_params("cam1", 1.0, Path("/x")) == {}
+
+    def test_returns_empty_on_exception(self, monkeypatch):
+        """A raising calibration loader is swallowed -> empty dict."""
+
+        def _boom(name, d):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(svc, "load_calibration_for_camera", _boom)
+        assert svc.build_distortion_params("cam1", 1.0, Path("/x")) == {}
+
+    def test_maps_coefficients_and_intrinsics(self, monkeypatch):
+        """Coefficients + intrinsics are merged into the expected dict."""
+        monkeypatch.setattr(svc, "load_calibration_for_camera", lambda name, d: _FakeTable())
+        result = svc.build_distortion_params("cam1", 2.5, Path("/x"))
+        assert result == {
+            "k1": -0.1,
+            "k2": 0.2,
+            "k3": 0.0,
+            "p1": 0.01,
+            "p2": -0.02,
+            "fx": 1800.0,
+            "fy": 1810.0,
+            "cx": 1280.0,
+            "cy": 720.0,
+        }
+
+
+class _IdentityMapPoint:
+    """Projection target exposing ``pixel_x``/``pixel_y`` like a ``MapPoint``."""
+
+    def __init__(self, x: float, y: float) -> None:
+        self.pixel_x = x
+        self.pixel_y = y
+
+
+class _IdentityHomography:
+    """Identity projection stub for line-error aggregation tests."""
+
+    def camera_to_map(self, camera_pixel: PixelPoint, point_id: str = "") -> _IdentityMapPoint:
+        return _IdentityMapPoint(float(camera_pixel.x), float(camera_pixel.y))
+
+    def map_to_camera(self, map_coord: PixelPoint) -> PixelPoint:
+        return PixelPoint.create(float(map_coord.x), float(map_coord.y))
+
+
+class TestComputeLineErrors:
+    """Tests for ``compute_line_errors`` aggregation."""
+
+    def _registry(self) -> dict[str, dict[str, float]]:
+        return {
+            "L1": {"start_x": 0.0, "start_y": 0.0, "end_x": 10.0, "end_y": 0.0},
+            "L2": {"start_x": 0.0, "start_y": 5.0, "end_x": 10.0, "end_y": 5.0},
+        }
+
+    def _annotations(self) -> list[dict[str, float | str]]:
+        return [
+            {
+                "line_id": "L1",
+                "start_pixel_x": 0.0,
+                "start_pixel_y": 0.0,
+                "end_pixel_x": 10.0,
+                "end_pixel_y": 0.0,
+            },
+            {
+                "line_id": "L2",
+                "start_pixel_x": 0.0,
+                "start_pixel_y": 5.0,
+                "end_pixel_x": 10.0,
+                "end_pixel_y": 5.0,
+            },
+        ]
+
+    def test_identity_projection_yields_zero_error(self):
+        """With identity projection and matching geometry, all errors are zero."""
+        result = svc.compute_line_errors(
+            _IdentityHomography(), self._annotations(), self._registry()
+        )
+        payload = result.to_payload()
+        assert payload["success"] is True
+        assert payload["metrics"] == {
+            "num_lines": 2,
+            "mean_line_error": 0.0,
+            "max_line_error": 0.0,
+        }
+        assert len(payload["per_line_errors"]) == 2
+        first = payload["per_line_errors"][0]
+        assert set(first) == {
+            "line_id",
+            "error_px",
+            "start_error",
+            "end_error",
+            "map_start_error",
+            "map_end_error",
+        }
+        overlays = payload["line_overlays"]
+        assert set(overlays["camera"]) == {"annotations", "reprojected_lines"}
+        assert set(overlays["map"]) == {"gcp_lines", "projected_lines"}
+
+    def test_rounding_applied(self):
+        """Per-line errors are rounded to two decimals."""
+        registry = {"L1": {"start_x": 0.0, "start_y": 0.0, "end_x": 10.0, "end_y": 0.0}}
+        annotations = [
+            {
+                "line_id": "L1",
+                "start_pixel_x": 0.0,
+                "start_pixel_y": 1.23456,
+                "end_pixel_x": 10.0,
+                "end_pixel_y": 1.23456,
+            }
+        ]
+        result = svc.compute_line_errors(_IdentityHomography(), annotations, registry)
+        per_line = result.to_payload()["per_line_errors"][0]
+        # Camera-space perpendicular error of a parallel offset line == the offset.
+        assert per_line["error_px"] == round(1.23456, 2)
+        assert per_line["map_start_error"] == round(1.23456, 2)
+
+    def test_missing_line_raises(self):
+        """An annotation referencing an unknown line id raises with the line id."""
+        annotations = [
+            {
+                "line_id": "MISSING",
+                "start_pixel_x": 0.0,
+                "start_pixel_y": 0.0,
+                "end_pixel_x": 1.0,
+                "end_pixel_y": 0.0,
+            }
+        ]
+        with pytest.raises(svc.LineNotInRegistryError) as exc_info:
+            svc.compute_line_errors(_IdentityHomography(), annotations, self._registry())
+        assert exc_info.value.line_id == "MISSING"
+        assert "MISSING" in str(exc_info.value)
+
+
+class TestComputeGcpPrecision:
+    """Tests for ``compute_gcp_precision`` aggregation over a real homography."""
+
+    def test_identity_correspondences(self):
+        """4 coincident camera/map points yield an identity-like homography.
+
+        ``compute_from_gcps`` runs cv2.findHomography on synthetic data, so no
+        DVC fixtures are required.  With camera == map coordinates the result is
+        near-identity and all reprojection errors round to zero.
+        """
+        coords = {
+            "G1": (0.0, 0.0),
+            "G2": (100.0, 0.0),
+            "G3": (100.0, 100.0),
+            "G4": (0.0, 100.0),
+            "G5": (50.0, 25.0),
+        }
+        registry = GCPRegistry(
+            map_id="map-test",
+            points={gid: MapPoint(pixel_x=x, pixel_y=y) for gid, (x, y) in coords.items()},
+        )
+        annotations = [
+            {"gcp_id": gid, "pixel_x": x, "pixel_y": y} for gid, (x, y) in coords.items()
+        ]
+
+        result = svc.compute_gcp_precision(
+            annotations=annotations,
+            registry=registry,
+            distortion={},
+            ransac_threshold=50.0,
+            min_inlier_ratio=0.5,
+        )
+        payload = result.to_payload()
+
+        assert payload["success"] is True
+        assert payload["metrics"]["num_gcps"] == 5
+        assert set(payload["metrics"]) == {
+            "num_gcps",
+            "num_inliers",
+            "inlier_ratio",
+            "mean_reproj_error",
+            "max_reproj_error",
+            "rmse",
+        }
+        assert len(payload["per_point_errors"]) == 5
+        first = payload["per_point_errors"][0]
+        assert set(first) == {
+            "gcp_id",
+            "error_px",
+            "camera_dx",
+            "camera_dy",
+            "map_dx",
+            "map_dy",
+            "camera_original",
+            "camera_reprojected",
+            "map_original",
+            "map_projected",
+        }
+        # Identity correspondences -> negligible reprojection error.
+        assert payload["metrics"]["mean_reproj_error"] == pytest.approx(0.0, abs=0.01)
+        overlays = payload["overlays"]
+        assert set(overlays["camera"]) == {"annotations", "reprojected_gcps"}
+        assert set(overlays["map"]) == {"gcps", "projected_annotations"}

--- a/tests/test_frame_annotation_view_models.py
+++ b/tests/test_frame_annotation_view_models.py
@@ -1,0 +1,55 @@
+"""Tests for the presentation DTOs that replaced raw-dict annotation returns (issue #296, L2).
+
+These lock in the byte-identical legacy JSON shape produced by ``to_dict()`` —
+in particular the line DTO's ``points`` key, which must appear ONLY when the
+annotation carries polyline points.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add webapp to path so the presentation DTOs are importable.
+PROJECT_ROOT = Path(__file__).parent.parent
+WEBAPP_DIR = PROJECT_ROOT / "webapp"
+if str(WEBAPP_DIR) not in sys.path:
+    sys.path.insert(0, str(WEBAPP_DIR))
+
+from homography_web.view_models import FrameAnnotation, LineAnnotationView
+
+
+def test_frame_annotation_to_dict_exact_shape() -> None:
+    dto = FrameAnnotation(gcp_id="PS1", pixel_x=1.0, pixel_y=2.0)
+    assert dto.to_dict() == {"gcp_id": "PS1", "pixel_x": 1.0, "pixel_y": 2.0}
+
+
+def test_line_annotation_to_dict_omits_points_when_none() -> None:
+    dto = LineAnnotationView(
+        line_id="L1",
+        start_pixel_x=1.0,
+        start_pixel_y=2.0,
+        end_pixel_x=3.0,
+        end_pixel_y=4.0,
+    )
+    payload = dto.to_dict()
+    assert "points" not in payload
+    assert payload == {
+        "line_id": "L1",
+        "start_pixel_x": 1.0,
+        "start_pixel_y": 2.0,
+        "end_pixel_x": 3.0,
+        "end_pixel_y": 4.0,
+    }
+
+
+def test_line_annotation_to_dict_includes_points_when_present() -> None:
+    dto = LineAnnotationView(
+        line_id="L2",
+        start_pixel_x=1.0,
+        start_pixel_y=2.0,
+        end_pixel_x=3.0,
+        end_pixel_y=4.0,
+        points=[[5.0, 6.0], [7.0, 8.0]],
+    )
+    assert dto.to_dict()["points"] == [[5.0, 6.0], [7.0, 8.0]]

--- a/webapp/camera_annotator/views.py
+++ b/webapp/camera_annotator/views.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 from django.http import FileResponse, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
@@ -23,6 +24,9 @@ from homography_web.frame_utils import (
 from homography_web.frame_utils import (
     get_current_image as _get_current_image,
 )
+
+if TYPE_CHECKING:
+    from homography_web.view_models import FrameAnnotation
 
 # Session key for current image
 SESSION_IMAGE_KEY = "camera_annotator_image"
@@ -56,8 +60,11 @@ def load_gcps(tenant_id: str) -> list[dict]:
     ]
 
 
-def load_existing_annotations(image_filename: str) -> list[dict]:
-    """Load existing annotations for a specific image from the CapturedFrame repo."""
+def load_existing_annotations(image_filename: str) -> list[FrameAnnotation]:
+    """Load existing annotations for a specific image from the CapturedFrame repo.
+
+    Returns presentation DTOs; convert via ``.to_dict()`` at the JSON boundary.
+    """
     frame = image_filename_to_frame(image_filename)
     if frame is None:
         return []
@@ -129,7 +136,7 @@ def api_annotations(request: HttpRequest) -> JsonResponse:
         return JsonResponse([], safe=False)
 
     try:
-        annotations = load_existing_annotations(current_image)
+        annotations = [a.to_dict() for a in load_existing_annotations(current_image)]
         return JsonResponse(annotations, safe=False)
     except Exception as e:
         return JsonResponse({"error": f"Failed to load annotations: {e}"}, status=500)
@@ -172,7 +179,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
 
     request.session[SESSION_IMAGE_KEY] = filename  # pyright: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
-    annotations = load_existing_annotations(filename)
+    annotations = [a.to_dict() for a in load_existing_annotations(filename)]
 
     return JsonResponse(
         {

--- a/webapp/camera_line_annotator/views.py
+++ b/webapp/camera_line_annotator/views.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.http import FileResponse, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
@@ -28,6 +28,9 @@ from homography_web.frame_utils import (
 from homography_web.frame_utils import (
     get_line_annotation_repo as _get_line_annotation_repo,
 )
+
+if TYPE_CHECKING:
+    from homography_web.view_models import LineAnnotationView
 
 # Session keys
 SESSION_IMAGE_KEY = "camera_line_annotator_image"
@@ -91,8 +94,11 @@ def _validate_line_id(line_id: str) -> bool:
     return bool(line_id and _LINE_ID_RE.fullmatch(line_id))
 
 
-def _load_line_annotations_from_repo(image_filename: str) -> list[dict]:
-    """Load line annotations from the DDD LineAnnotation repository."""
+def _load_line_annotations_from_repo(image_filename: str) -> list[LineAnnotationView]:
+    """Load line annotations from the DDD LineAnnotation repository.
+
+    Returns presentation DTOs; convert via ``.to_dict()`` at the JSON boundary.
+    """
     frame = image_filename_to_frame(image_filename)
     if frame is None:
         return []
@@ -141,8 +147,11 @@ def _save_line_annotations_to_repo(
         repo.save(line_ann)
 
 
-def load_existing_line_annotations(image_filename: str) -> list[dict]:
-    """Load existing line annotations for a specific image from the DDD repo."""
+def load_existing_line_annotations(image_filename: str) -> list[LineAnnotationView]:
+    """Load existing line annotations for a specific image from the DDD repo.
+
+    Returns presentation DTOs; convert via ``.to_dict()`` at the JSON boundary.
+    """
     return _load_line_annotations_from_repo(image_filename)
 
 
@@ -195,7 +204,7 @@ def api_switch_image(request: HttpRequest) -> JsonResponse:
 
     request.session[SESSION_IMAGE_KEY] = filename  # pyright: ignore[reportAttributeAccessIssue]  # session injected by Django SessionMiddleware
 
-    image_annotations = load_existing_line_annotations(filename)
+    image_annotations = [a.to_dict() for a in load_existing_line_annotations(filename)]
 
     camera_status = {
         "pan": float(frame.ptz_state.pan_raw),
@@ -243,7 +252,10 @@ def api_annotations(request: HttpRequest) -> JsonResponse:
     if not current_image:
         return JsonResponse([], safe=False)
 
-    return JsonResponse(load_existing_line_annotations(current_image), safe=False)
+    return JsonResponse(
+        [a.to_dict() for a in load_existing_line_annotations(current_image)],
+        safe=False,
+    )
 
 
 @csrf_exempt

--- a/webapp/homography_precision/views.py
+++ b/webapp/homography_precision/views.py
@@ -315,7 +315,7 @@ def _load_test_case_by_name(name: str, map_id: str | None = None) -> dict | None
     for frame in list_frames(map_id):
         if frame.image_path.stem != name:
             continue
-        annotations = load_annotations_for_frame(frame.id)
+        annotations = [a.to_dict() for a in load_annotations_for_frame(frame.id)]
         if not annotations:
             continue
         tc: dict = {
@@ -352,7 +352,7 @@ def _load_line_test_case_by_name(name: str, map_id: str | None = None) -> dict |
     for frame in list_frames(map_id):
         if frame.image_path.stem != stem:
             continue
-        line_anns = load_line_annotations_for_frame(frame.id)
+        line_anns = [a.to_dict() for a in load_line_annotations_for_frame(frame.id)]
         if not line_anns:
             continue
         # Find the point-annotations reference (same frame, for point-based homography)

--- a/webapp/homography_precision/views.py
+++ b/webapp/homography_precision/views.py
@@ -45,8 +45,13 @@ from homography_web.frame_utils import (
 from line_picker.state import Line, from_line_repo
 from PIL import Image
 
-from poc_homography.calibration.lens_distortion.calibration_table import load_calibration_for_camera
-from poc_homography.domain.vo import PixelPoint
+from poc_homography.application.homography_precision import (
+    LineNotInRegistryError,
+    build_distortion_params,
+    compute_gcp_precision,
+    compute_line_errors,
+    compute_line_homography,
+)
 from poc_homography.homography.map_points import MapPointHomography
 from poc_homography.map_points.gcp_registry import from_gcp_repo
 
@@ -71,12 +76,11 @@ def _require_map_id(tenant_id: str) -> str | None:
 
 
 def _distortion_kwargs(test_case: dict) -> dict[str, float]:
-    """Build distortion kwargs for MapPointHomography from a test case.
+    """Resolve camera_name + zoom from a test case and build distortion kwargs.
 
-    Extracts camera_name and zoom from the test case, loads the calibration
-    table, and returns interpolated distortion + intrinsic parameters as a dict
-    with keys k1,k2,k3,p1,p2,fx,fy,cx,cy.  Returns empty dict if any piece
-    is unavailable.
+    Returns an empty dict if the test case lacks an image, the frame cannot be
+    resolved, or no zoom is present; otherwise delegates to the application-layer
+    ``build_distortion_params`` service.
     """
     image_filename = test_case.get("image")
     if not image_filename:
@@ -87,26 +91,7 @@ def _distortion_kwargs(test_case: dict) -> dict[str, float]:
     zoom = test_case.get("camera_status", {}).get("zoom")
     if zoom is None:
         return {}
-
-    try:
-        table = load_calibration_for_camera(frame.camera_name, CALIBRATIONS_DIR)
-        if table is None:
-            return {}
-        coeffs = table.get_coefficients(zoom)
-        intrinsics = table.get_intrinsics(zoom)
-        if intrinsics is None:
-            return {}
-        return {
-            "k1": float(coeffs.k1),
-            "k2": float(coeffs.k2),
-            "k3": float(coeffs.k3),
-            "p1": float(coeffs.p1),
-            "p2": float(coeffs.p2),
-            **intrinsics,
-        }
-    except Exception:
-        logger.debug("Failed to load distortion params for %s", frame.camera_name, exc_info=True)
-        return {}
+    return build_distortion_params(frame.camera_name, zoom, CALIBRATIONS_DIR)
 
 
 def _get_map_geotiff_file(tenant_id: str) -> Path | None:
@@ -151,36 +136,6 @@ _image_info_cache: dict[str, ImageInfoCache] = {}
 
 register_invalidation_callback(_line_registry_cache.clear)
 register_invalidation_callback(_image_info_cache.clear)
-
-
-def _perpendicular_distance(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> float:
-    """Calculate perpendicular distance from point p to line defined by points a and b.
-
-    Args:
-        p: Point as numpy array [x, y].
-        a: Line start point as numpy array [x, y].
-        b: Line end point as numpy array [x, y].
-
-    Returns:
-        Perpendicular distance in pixels.
-    """
-    # Line vector
-    v = b - a
-    # Point vector from a to p
-    w = p - a
-
-    # Project w onto v
-    c1 = np.dot(w, v)
-    c2 = np.dot(v, v)
-
-    if c2 == 0:
-        # Line has zero length (a and b are the same point)
-        return float(np.linalg.norm(w))
-
-    # Perpendicular distance = |w - proj_v(w)|
-    b_param = c1 / c2
-    proj = a + b_param * v
-    return float(np.linalg.norm(p - proj))
 
 
 def _get_camera_image_path(test_case_name: str, map_id: str | None = None) -> Path | None:
@@ -476,12 +431,12 @@ def api_compute_homography(request: HttpRequest) -> JsonResponse:
             status=500,
         )
 
-    # Compute homography
+    # Compute homography + aggregate per-point errors, overlays and metrics
     try:
-        homography = MapPointHomography(map_id=registry.map_id, **_distortion_kwargs(test_case))
-        result = homography.compute_from_gcps(
-            gcps=annotations,
-            map_registry=registry,
+        result = compute_gcp_precision(
+            annotations=annotations,
+            registry=registry,
+            distortion=_distortion_kwargs(test_case),
             ransac_threshold=50.0,
             min_inlier_ratio=0.5,
         )
@@ -491,119 +446,7 @@ def api_compute_homography(request: HttpRequest) -> JsonResponse:
             status=500,
         )
 
-    # Compute per-point errors and overlay data
-    per_point_errors = []
-    camera_annotations = []
-    camera_reprojected = []
-    map_gcps = []
-    map_projected = []
-
-    for annotation in annotations:
-        gcp_id = annotation["gcp_id"]
-
-        # Get original camera pixel (annotation position)
-        camera_x = annotation["pixel_x"]
-        camera_y = annotation["pixel_y"]
-        camera_pixel = PixelPoint.create(camera_x, camera_y)
-
-        # Get GCP map coordinate from registry
-        gcp = registry.points[gcp_id]
-        map_x = gcp.pixel_x
-        map_y = gcp.pixel_y
-
-        # Project annotation to map using camera_to_map()
-        projected_map = homography.camera_to_map(camera_pixel)
-
-        # Reproject GCP back to camera using map_to_camera()
-        gcp_coord = PixelPoint.create(map_x, map_y)
-        reprojected_camera = homography.map_to_camera(gcp_coord)
-
-        # Calculate per-point error (Euclidean distance between original annotation
-        # and reprojected GCP)
-        original = np.array([camera_x, camera_y])
-        reprojected = np.array([reprojected_camera.x, reprojected_camera.y])
-        error_px = float(np.linalg.norm(reprojected - original))
-
-        # Calculate per-axis errors for camera frame
-        camera_dx = reprojected_camera.x - camera_x
-        camera_dy = reprojected_camera.y - camera_y
-
-        # Calculate per-axis errors for map frame
-        map_dx = projected_map.pixel_x - map_x
-        map_dy = projected_map.pixel_y - map_y
-
-        per_point_errors.append(
-            {
-                "gcp_id": gcp_id,
-                "error_px": round(error_px, 2),
-                "camera_dx": round(camera_dx, 2),
-                "camera_dy": round(camera_dy, 2),
-                "map_dx": round(map_dx, 2),
-                "map_dy": round(map_dy, 2),
-                "camera_original": [round(camera_x, 2), round(camera_y, 2)],
-                "camera_reprojected": [
-                    round(reprojected_camera.x, 2),
-                    round(reprojected_camera.y, 2),
-                ],
-                "map_original": [round(map_x, 2), round(map_y, 2)],
-                "map_projected": [round(projected_map.pixel_x, 2), round(projected_map.pixel_y, 2)],
-            }
-        )
-
-        # Collect overlay data
-        camera_annotations.append(
-            {
-                "gcp_id": gcp_id,
-                "x": round(camera_x, 2),
-                "y": round(camera_y, 2),
-            }
-        )
-        camera_reprojected.append(
-            {
-                "gcp_id": gcp_id,
-                "x": round(reprojected_camera.x, 2),
-                "y": round(reprojected_camera.y, 2),
-            }
-        )
-        map_gcps.append(
-            {
-                "gcp_id": gcp_id,
-                "x": round(map_x, 2),
-                "y": round(map_y, 2),
-            }
-        )
-        map_projected.append(
-            {
-                "gcp_id": gcp_id,
-                "x": round(projected_map.pixel_x, 2),
-                "y": round(projected_map.pixel_y, 2),
-            }
-        )
-
-    return JsonResponse(
-        {
-            "success": True,
-            "metrics": {
-                "num_gcps": result.num_gcps,
-                "num_inliers": result.num_inliers,
-                "inlier_ratio": round(result.inlier_ratio, 2),
-                "mean_reproj_error": round(result.mean_reproj_error, 2),
-                "max_reproj_error": round(result.max_reproj_error, 2),
-                "rmse": round(result.rmse, 2),
-            },
-            "per_point_errors": per_point_errors,
-            "overlays": {
-                "camera": {
-                    "annotations": camera_annotations,
-                    "reprojected_gcps": camera_reprojected,
-                },
-                "map": {
-                    "gcps": map_gcps,
-                    "projected_annotations": map_projected,
-                },
-            },
-        }
-    )
+    return JsonResponse(result.to_payload())
 
 
 @require_GET
@@ -807,10 +650,11 @@ def api_compute_homography_from_lines(request: HttpRequest) -> JsonResponse:
         return _no_map_error()
     try:
         dist_kw = _distortion_kwargs(line_test_case) if test_case_name else {}
-        homography = MapPointHomography(map_id=map_id, **dist_kw)
-        result = homography.compute_from_lines(
+        result = compute_line_homography(
             line_annotations=line_annotations,
             line_registry=line_registry,
+            distortion=dist_kw,
+            map_id=map_id,
             ransac_threshold=50.0,
             min_inlier_ratio=0.3,
         )
@@ -820,21 +664,7 @@ def api_compute_homography_from_lines(request: HttpRequest) -> JsonResponse:
             status=500,
         )
 
-    return JsonResponse(
-        {
-            "success": True,
-            "homography_source": "lines",
-            "metrics": {
-                "num_lines": result.num_lines,
-                "num_inliers": result.num_inliers,
-                "inlier_ratio": round(result.inlier_ratio, 2),
-                "mean_perp_error": round(result.mean_perp_error, 2),
-                "max_perp_error": round(result.max_perp_error, 2),
-                "rmse": round(result.rmse, 2),
-            },
-            "homography_matrix": result.homography_matrix.tolist(),
-        }
-    )
+    return JsonResponse(result.to_payload())
 
 
 @csrf_exempt
@@ -994,139 +824,19 @@ def api_compute_line_errors(request: HttpRequest) -> JsonResponse:
             )
 
     # Compute per-line errors (line_registry already loaded above)
-    per_line_errors = []
-    camera_annotations = []
-    camera_reprojected_lines = []
-    map_gcp_lines = []
-    map_projected_lines = []
-
-    total_error = 0.0
-    max_error = 0.0
-
-    for line_annotation in line_annotations:
-        line_id = line_annotation["line_id"]
-
-        # Get line definition from registry
-        if line_id not in line_registry:
-            return JsonResponse(
-                {"success": False, "error": f"Line {line_id} not found in line registry"},
-                status=400,
-            )
-
-        line_def = line_registry[line_id]
-
-        # Ground truth line in map coordinates (directly from line registry)
-        map_start = np.array([line_def["start_x"], line_def["start_y"]])
-        map_end = np.array([line_def["end_x"], line_def["end_y"]])
-
-        # Annotated line in camera coordinates
-        camera_start = np.array(
-            [line_annotation["start_pixel_x"], line_annotation["start_pixel_y"]]
+    try:
+        line_errors = compute_line_errors(
+            homography=homography,
+            line_annotations=line_annotations,
+            line_registry=line_registry,
         )
-        camera_end = np.array([line_annotation["end_pixel_x"], line_annotation["end_pixel_y"]])
-
-        # Project camera line endpoints to map
-        projected_start = homography.camera_to_map(
-            PixelPoint.create(camera_start[0], camera_start[1])
-        )
-        projected_end = homography.camera_to_map(PixelPoint.create(camera_end[0], camera_end[1]))
-        projected_start_map = np.array([projected_start.pixel_x, projected_start.pixel_y])
-        projected_end_map = np.array([projected_end.pixel_x, projected_end.pixel_y])
-
-        # Compute errors: perpendicular distance from projected points to ground truth line
-        start_error = _perpendicular_distance(projected_start_map, map_start, map_end)
-        end_error = _perpendicular_distance(projected_end_map, map_start, map_end)
-
-        # Also compute reverse: project GCP line to camera and compare
-        reprojected_start = homography.map_to_camera(PixelPoint.create(map_start[0], map_start[1]))
-        reprojected_end = homography.map_to_camera(PixelPoint.create(map_end[0], map_end[1]))
-        reprojected_start_camera = np.array([reprojected_start.x, reprojected_start.y])
-        reprojected_end_camera = np.array([reprojected_end.x, reprojected_end.y])
-
-        # Compute errors in camera space
-        camera_start_error = _perpendicular_distance(
-            camera_start, reprojected_start_camera, reprojected_end_camera
-        )
-        camera_end_error = _perpendicular_distance(
-            camera_end, reprojected_start_camera, reprojected_end_camera
+    except LineNotInRegistryError as e:
+        return JsonResponse(
+            {"success": False, "error": f"Line {e.line_id} not found in line registry"},
+            status=400,
         )
 
-        # Average error for this line (using camera space errors as primary metric)
-        line_error = (camera_start_error + camera_end_error) / 2.0
-
-        total_error += line_error
-        max_error = max(max_error, line_error)
-
-        per_line_errors.append(
-            {
-                "line_id": line_id,
-                "error_px": round(line_error, 2),
-                "start_error": round(camera_start_error, 2),
-                "end_error": round(camera_end_error, 2),
-                "map_start_error": round(start_error, 2),
-                "map_end_error": round(end_error, 2),
-            }
-        )
-
-        # Collect overlay data for camera frame
-        camera_annotations.append(
-            {
-                "line_id": line_id,
-                "start": [round(camera_start[0], 2), round(camera_start[1], 2)],
-                "end": [round(camera_end[0], 2), round(camera_end[1], 2)],
-            }
-        )
-        camera_reprojected_lines.append(
-            {
-                "line_id": line_id,
-                "start": [
-                    round(reprojected_start_camera[0], 2),
-                    round(reprojected_start_camera[1], 2),
-                ],
-                "end": [round(reprojected_end_camera[0], 2), round(reprojected_end_camera[1], 2)],
-            }
-        )
-
-        # Collect overlay data for map frame
-        map_gcp_lines.append(
-            {
-                "line_id": line_id,
-                "start": [round(map_start[0], 2), round(map_start[1], 2)],
-                "end": [round(map_end[0], 2), round(map_end[1], 2)],
-            }
-        )
-        map_projected_lines.append(
-            {
-                "line_id": line_id,
-                "start": [round(projected_start_map[0], 2), round(projected_start_map[1], 2)],
-                "end": [round(projected_end_map[0], 2), round(projected_end_map[1], 2)],
-            }
-        )
-
-    num_lines = len(line_annotations)
-    mean_line_error = total_error / num_lines if num_lines > 0 else 0.0
-
-    return JsonResponse(
-        {
-            "success": True,
-            "metrics": {
-                "num_lines": num_lines,
-                "mean_line_error": round(mean_line_error, 2),
-                "max_line_error": round(max_error, 2),
-            },
-            "per_line_errors": per_line_errors,
-            "line_overlays": {
-                "camera": {
-                    "annotations": camera_annotations,
-                    "reprojected_lines": camera_reprojected_lines,
-                },
-                "map": {
-                    "gcp_lines": map_gcp_lines,
-                    "projected_lines": map_projected_lines,
-                },
-            },
-        }
-    )
+    return JsonResponse(line_errors.to_payload())
 
 
 @require_GET

--- a/webapp/homography_web/frame_utils.py
+++ b/webapp/homography_web/frame_utils.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 from django.http import FileResponse, HttpResponse
 
+from homography_web.view_models import FrameAnnotation, LineAnnotationView
 from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
 from poc_homography.infrastructure.repositories import (
     RepoYamlAnnotation,
@@ -326,18 +327,20 @@ def image_filename_to_frame(filename: str) -> CapturedFrame | None:
     return _get_image_to_frame().get(filename)
 
 
-def load_annotations_for_frame(frame_id: str) -> list[dict]:
-    """Load point annotations for a frame in legacy dict format.
+def load_annotations_for_frame(frame_id: str) -> list[FrameAnnotation]:
+    """Load point annotations for a frame as presentation DTOs.
 
-    Returns list of ``{gcp_id, pixel_x, pixel_y}`` dicts.
+    Returns a list of :class:`FrameAnnotation` (``gcp_id``, ``pixel_x``,
+    ``pixel_y``); pixel coords rounded to 1 decimal. Call ``.to_dict()`` at the
+    JSON/legacy boundary to recover the prior ``{gcp_id, pixel_x, pixel_y}`` shape.
     """
     annotations = get_frame_repo().get_annotations(frame_id)
     return [
-        {
-            "gcp_id": ann.gcp_id,
-            "pixel_x": round(float(ann.pixel.x), 1),
-            "pixel_y": round(float(ann.pixel.y), 1),
-        }
+        FrameAnnotation(
+            gcp_id=ann.gcp_id,
+            pixel_x=round(float(ann.pixel.x), 1),
+            pixel_y=round(float(ann.pixel.y), 1),
+        )
         for ann in annotations
     ]
 
@@ -353,24 +356,27 @@ def _get_line_anns_by_frame() -> dict[str, list]:
     return _line_anns_by_frame
 
 
-def load_line_annotations_for_frame(frame_id: str) -> list[dict]:
-    """Load line annotations for a frame in legacy dict format.
+def load_line_annotations_for_frame(frame_id: str) -> list[LineAnnotationView]:
+    """Load line annotations for a frame as presentation DTOs.
 
-    Returns list of dicts with ``line_id``, pixel endpoints, and optional
-    ``points`` array for n-point polylines.
+    Returns a list of :class:`LineAnnotationView` with ``line_id``, pixel
+    endpoints, and an optional ``points`` array for n-point polylines (present
+    only when the annotation has points). Call ``.to_dict()`` at the JSON/legacy
+    boundary to recover the prior dict shape.
     """
-    results: list[dict] = []
+    results: list[LineAnnotationView] = []
     for ann in _get_line_anns_by_frame().get(frame_id, []):
-        entry: dict = {
-            "line_id": ann.line_id,
-            "start_pixel_x": float(ann.start_pixel.x),
-            "start_pixel_y": float(ann.start_pixel.y),
-            "end_pixel_x": float(ann.end_pixel.x),
-            "end_pixel_y": float(ann.end_pixel.y),
-        }
-        if ann.points is not None:
-            entry["points"] = [[float(p.x), float(p.y)] for p in ann.points]
-        results.append(entry)
+        points = [[float(p.x), float(p.y)] for p in ann.points] if ann.points is not None else None
+        results.append(
+            LineAnnotationView(
+                line_id=ann.line_id,
+                start_pixel_x=float(ann.start_pixel.x),
+                start_pixel_y=float(ann.start_pixel.y),
+                end_pixel_x=float(ann.end_pixel.x),
+                end_pixel_y=float(ann.end_pixel.y),
+                points=points,
+            )
+        )
     return results
 
 

--- a/webapp/homography_web/view_models.py
+++ b/webapp/homography_web/view_models.py
@@ -1,0 +1,61 @@
+"""Presentation DTOs (view models) for frame annotations.
+
+These typed frozen dataclasses replace the raw-dict passthrough returns of the
+legacy loaders in ``frame_utils.py``. Each DTO exposes a ``to_dict()`` that
+reproduces the exact legacy JSON shape at the serialization boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FrameAnnotation:
+    """A point annotation (GCP) in legacy presentation form.
+
+    ``pixel_x``/``pixel_y`` are expected to already be rounded to 1 decimal by
+    the loader, matching the prior dict behavior.
+    """
+
+    gcp_id: str
+    pixel_x: float
+    pixel_y: float
+
+    def to_dict(self) -> dict:
+        """Return the exact legacy dict shape ``{gcp_id, pixel_x, pixel_y}``."""
+        return {
+            "gcp_id": self.gcp_id,
+            "pixel_x": self.pixel_x,
+            "pixel_y": self.pixel_y,
+        }
+
+
+@dataclass(frozen=True)
+class LineAnnotationView:
+    """A line annotation in legacy presentation form.
+
+    The ``points`` key is included in :meth:`to_dict` only when ``points`` is
+    not ``None`` (matching the prior conditional dict behavior for n-point
+    polylines).
+    """
+
+    line_id: str
+    start_pixel_x: float
+    start_pixel_y: float
+    end_pixel_x: float
+    end_pixel_y: float
+    points: list[list[float]] | None = None
+
+    def to_dict(self) -> dict:
+        """Return the legacy dict; include ``points`` only when not ``None``."""
+        entry: dict = {
+            "line_id": self.line_id,
+            "start_pixel_x": self.start_pixel_x,
+            "start_pixel_y": self.start_pixel_y,
+            "end_pixel_x": self.end_pixel_x,
+            "end_pixel_y": self.end_pixel_y,
+        }
+        if self.points is not None:
+            entry["points"] = self.points
+        return entry


### PR DESCRIPTION
Resolves the deferred LOW-severity DDD items L1–L5 from parent #226 (workstream D).

## What changed

**L1 — extract computation from the precision view (`44ef1ef`)**
Moved homography computation + metric/error aggregation out of `webapp/homography_precision/views.py` into a new framework-agnostic application service `poc_homography/application/homography_precision.py` (`perpendicular_distance`, `build_distortion_params`, `compute_gcp_precision`, `compute_line_homography`, `compute_line_errors`, with frozen-dataclass results exposing `to_payload()`). Views now parse/load/delegate/serialize only. HTTP payloads, error strings and status codes are byte-identical. Added 11 unit tests.

**L2 — typed annotation DTOs (`2c16f0b`)**
`frame_utils.load_annotations_for_frame` / `load_line_annotations_for_frame` now return frozen presentation DTOs (`FrameAnnotation`, `LineAnnotationView`) instead of raw dicts. Consumers convert via `.to_dict()` only at JSON-serialization and domain/service-call boundaries, so every payload and every dict fed to the homography services/domain is byte-identical. The line DTO emits `points` only when present. Added 3 DTO unit tests.

## L3 / L4 / L5 — verified already-satisfied (no code change)

Investigation showed intervening work (S3/map-asset + domain-model refactors) already absorbed these, and L4 as literally worded conflicts with the codebase. Verified on this branch:

- **L3** — `grep MAP_GEOTIFF_FILE` → **0 matches**; the constant no longer exists. The map GeoTIFF path is already resolved from the `Map` entity via `MapRepository` (`get_map_repo().get_by_tenant(...)` → `map_entity.photo.path`). DoD met.
- **L4** — `camera_annotator/views.py` already has a **single** annotation path: reads via `load_annotations_for_frame` → `RepoYamlCapturedFrame.get_annotations`, writes via `get_frame_repo().save_annotations`. **Deviation (approved):** kept the CapturedFrame-embedded path rather than routing through `RepoYamlAnnotation` — reads and writes both target the CapturedFrame store, and switching reads to the separate `data/annotations/` store would diverge reads from writes (a regression). Single-path DoD met via the canonical store.
- **L5** — `grep -E "os.listdir|.glob(|.iterdir(|os.walk|os.scandir" webapp/camera_survey/` → **0 matches**; survey enumeration already goes exclusively through `RepoYamlSurveySession`. DoD met.

## Definition of Done

- [x] **L1** — `homography_precision/views.py` contains no homography computation/metric logic; it lives in `poc_homography/application/homography_precision.py`
- [x] **L2** — `homography_web/frame_utils.py` legacy paths return typed dataclasses (`FrameAnnotation`, `LineAnnotationView`), not raw dicts
- [x] **L3** — `MAP_GEOTIFF_FILE` is no longer a hardcoded path constant; resolved from the `Map` entity via `MapRepository` (verified: 0 grep matches)
- [x] **L4** — `camera_annotator/views.py` loads annotations via a single path (CapturedFrame repo; deviation from literal `RepoYamlAnnotation` documented above to avoid read/write divergence)
- [x] **L5** — `camera_survey/` enumerates survey images exclusively via `RepoYamlSurveySession` (verified: 0 direct-FS-traversal grep matches)
- [x] All existing tests pass (**1288 passed, 157 skipped**)

## Test plan

`uv run poe ci` (lint, format-check, typecheck, pylint, vulture, pytest). Locally: **1288 passed / 157 skipped**; pre-commit hooks green on every commit. New tests: `tests/application/test_homography_precision.py` (11), `tests/test_frame_annotation_view_models.py` (3). No behavior change — refactor preserves all HTTP responses byte-for-byte.

Closes #296
Part of #226
