### PR TITLE
feat(click-to-gps): interactive click-to-GPS on camera frames [#33]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,45 @@ Open http://localhost:8000/:
 - `/capture/` - GCP capture tool (click map to add ground control points)
 - `/debug/` - Debug map visualization
 
+### Interactive Click-to-GPS
+
+The **Click-to-GPS** tool (SPA page `/click-to-gps`, backed by the FastAPI
+`/click-to-gps` router) is the project's primary user-facing feature: click
+anywhere on a camera frame to estimate the GPS coordinate of that point.
+
+1. Pick a camera frame from the dropdown. Only frames with at least four GCP
+   annotations are listed — four correspondences are the minimum needed to fit
+   a homography.
+2. Click anywhere on the frame. The clicked pixel is projected to a WGS84
+   latitude/longitude and rendered as a crosshair marker with its coordinates.
+3. Markers are colour-coded by the homography's confidence (inlier ratio):
+   **green** > 0.7, **yellow** 0.5–0.7, **red** < 0.5. The last five clicks
+   stay on screen; the newest result is also flashed for three seconds.
+
+Keyboard shortcuts:
+
+| Key | Action                                   |
+| --- | ---------------------------------------- |
+| `c` | Copy the most recent GPS to the clipboard |
+| `x` | Clear all markers                         |
+
+Points that project beyond the georeferenced map (the click-to-GPS analog of a
+point on or above the horizon) are flagged rather than reported as a GPS fix.
+
+Under the hood the projection reuses the existing registration services:
+
+```
+clicked camera pixel
+  → MapPointHomography.camera_to_map()   # GCP homography → map pixel
+  → GeoTiff.pixel_to_geo()               # map pixel → UTM easting/northing
+  → GeoTiff.pixel_to_latlon()            # UTM → WGS84 lat/lon (pyproj)
+```
+
+> The original issue (#33) described a desktop OpenCV `VideoAnnotator` and an
+> RTSP stream. That desktop tool was never part of this stack; the feature was
+> translated onto the live `api/` + `spa/` application, serving a saved camera
+> frame instead of a live RTSP feed (camera access stays read-only/mocked).
+
 ## Development
 
 ### Run Tests

--- a/api/main.py
+++ b/api/main.py
@@ -57,6 +57,7 @@ from api.routers import (  # noqa: E402 — routers imported after app + CORS se
     camera_evaluation,
     camera_line_annotator,
     clean_plate_gallery,
+    click_to_gps,
     distortion_validator,
     gcp,
     homography_precision,
@@ -70,6 +71,7 @@ app.include_router(camera_diagnostic.router)
 app.include_router(camera_evaluation.router)
 app.include_router(camera_line_annotator.router)
 app.include_router(clean_plate_gallery.router)
+app.include_router(click_to_gps.router)
 app.include_router(distortion_validator.router)
 app.include_router(gcp.router)
 app.include_router(homography_precision.router)

--- a/api/routers/click_to_gps.py
+++ b/api/routers/click_to_gps.py
@@ -1,0 +1,258 @@
+"""FastAPI router for the interactive click-to-GPS tool (issue #33).
+
+Translates the issue's "click on the live camera stream → GPS" intent onto the
+live api/ + spa/ stack. The desktop ``VideoAnnotator`` described in the issue
+never existed on this stack; instead the SPA serves a saved camera frame, the
+user clicks a pixel, and this endpoint projects that pixel to a WGS84 GPS
+coordinate by reusing the existing registration domain services:
+
+    clicked camera pixel
+      → MapPointHomography.camera_to_map()      (GCP homography → map pixel)
+      → GeoTiff.pixel_to_geo()                  (map pixel → UTM easting/northing)
+      → GeoTiff.pixel_to_latlon()               (UTM → WGS84 lat/lon, via pyproj)
+
+The homography inlier ratio is surfaced as the projection confidence so the UI
+can colour-code each clicked point.
+"""
+
+from __future__ import annotations
+
+import math
+import mimetypes
+from typing import TYPE_CHECKING
+
+import tifffile
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+
+from api.deps import get_current_user, get_db_session
+from api.schemas.click_to_gps import FrameSummary, ProjectRequest, ProjectResponse
+from api.utils.frame_helpers import (
+    DATA_MAPS_DIR,
+    extract_geotiff,
+    get_frame_image_path,
+    get_map_for_tenant,
+    image_filename_to_frame,
+    list_frames,
+    load_annotations_for_frame,
+    validate_image_filename,
+)
+from poc_homography.domain.vo import PixelPoint
+from poc_homography.homography.map_points import MapPointHomography
+from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from sqlalchemy.orm import Session
+
+    from poc_homography.domain.vo.geotiff import GeoTiff
+    from poc_homography.infrastructure.models.user import UserModel
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(prefix="/click-to-gps", tags=["click-to-gps"])
+
+# Minimum GCP annotations required to fit a homography for a frame.
+_MIN_ANNOTATIONS = 4
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_map_id(tenant_id: str, session: Session) -> str | None:
+    """Return the tenant's map_id, or ``None`` when no map is configured."""
+    map_entity = get_map_for_tenant(tenant_id, session)
+    return map_entity.id if map_entity else None
+
+
+def _find_test_case(name: str, map_id: str | None, session: Session) -> dict | None:
+    """Return ``{image, annotations}`` for the frame whose image stem is *name*."""
+    for frame in list_frames(session, map_id):
+        if frame.image_path.stem != name:
+            continue
+        annotations = load_annotations_for_frame(frame.id, session)
+        return {"image": frame.image_path.name, "annotations": annotations}
+    return None
+
+
+def _load_geotiff(tenant_id: str, session: Session) -> tuple[GeoTiff, int, int] | None:
+    """Return ``(geotiff, width, height)`` for the tenant's map GeoTIFF.
+
+    Returns ``None`` when no map is configured, the file is missing, or the
+    raster carries no georeferencing tags (without which GPS is undefined).
+    """
+    map_entity = get_map_for_tenant(tenant_id, session)
+    if map_entity is None:
+        return None
+    geotiff_path: Path = DATA_MAPS_DIR / map_entity.photo.path
+    if not geotiff_path.exists():
+        return None
+
+    with tifffile.TiffFile(geotiff_path) as tif:
+        page = tif.pages[0]
+        width: int = page.imagewidth  # type: ignore[union-attr]
+        height: int = page.imagelength  # type: ignore[union-attr]
+        geotiff = extract_geotiff(tif)
+
+    if geotiff is None:
+        return None
+    return (geotiff, width, height)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/frames/", response_model=list[FrameSummary])
+def list_projectable_frames(
+    tenant_id: str = Query(...),
+    user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> list[FrameSummary]:
+    """List camera frames with enough GCP annotations to project from."""
+    map_id = _resolve_map_id(tenant_id, session)
+    frames: list[FrameSummary] = []
+    for frame in list_frames(session, map_id):
+        annotations = load_annotations_for_frame(frame.id, session)
+        if len(annotations) < _MIN_ANNOTATIONS:
+            continue
+        frames.append(
+            FrameSummary(
+                name=frame.image_path.stem,
+                image=frame.image_path.name,
+                annotation_count=len(annotations),
+            )
+        )
+    return frames
+
+
+@router.post("/api/project/", response_model=ProjectResponse)
+def project_pixel_to_gps(
+    body: ProjectRequest,
+    tenant_id: str = Query(...),
+    user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> ProjectResponse:
+    """Project a clicked camera pixel to a WGS84 GPS coordinate."""
+    map_id = _resolve_map_id(tenant_id, session)
+    if map_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail="No map configured for the current tenant. Upload a GeoTIFF map first.",
+        )
+
+    test_case = _find_test_case(body.test_case_name, map_id, session)
+    if test_case is None:
+        raise HTTPException(status_code=404, detail=f"Frame not found: {body.test_case_name}")
+
+    annotations = test_case["annotations"]
+    if len(annotations) < _MIN_ANNOTATIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Need at least {_MIN_ANNOTATIONS} annotations, got {len(annotations)}",
+        )
+
+    geo = _load_geotiff(tenant_id, session)
+    if geo is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Map GeoTIFF is missing georeferencing; cannot derive GPS.",
+        )
+    geotiff, map_width, map_height = geo
+
+    try:
+        registry = from_gcp_repo_pg(session, map_id)
+    except (KeyError, ValueError, OSError) as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to load GCP registry: {exc}")
+
+    # Fit the GCP homography for this frame. min_inlier_ratio=0 so we always
+    # obtain a transform and report its (possibly low) confidence rather than
+    # rejecting — the UI colour-codes low-confidence projections.
+    try:
+        homography = MapPointHomography(map_id=registry.map_id)
+        result = homography.compute_from_gcps(
+            gcps=annotations,
+            map_registry=registry,
+            ransac_threshold=50.0,
+            min_inlier_ratio=0.0,
+        )
+    except (ValueError, RuntimeError) as exc:
+        return ProjectResponse(success=False, error=f"Homography computation failed: {exc}")
+
+    # Project the clicked pixel: camera pixel → map pixel → UTM → lat/lon.
+    map_point = homography.camera_to_map(PixelPoint.create(body.pixel_x, body.pixel_y))
+    map_x, map_y = map_point.pixel_x, map_point.pixel_y
+
+    # A point near/above the horizon projects far outside the georeferenced map
+    # plane (or to a non-finite coordinate). Reject those rather than emitting a
+    # nonsensical GPS fix.
+    margin_x = map_width
+    margin_y = map_height
+    if (
+        not (math.isfinite(map_x) and math.isfinite(map_y))
+        or map_x < -margin_x
+        or map_x > map_width + margin_x
+        or map_y < -margin_y
+        or map_y > map_height + margin_y
+    ):
+        return ProjectResponse(
+            success=False,
+            on_horizon=True,
+            confidence=round(result.inlier_ratio, 3),
+            error="Point projects beyond the map (likely on or above the horizon).",
+        )
+
+    easting, northing = geotiff.pixel_to_geo(map_x, map_y)
+    latitude, longitude = geotiff.pixel_to_latlon(map_x, map_y)
+
+    return ProjectResponse(
+        success=True,
+        latitude=round(float(latitude), 7),
+        longitude=round(float(longitude), 7),
+        confidence=round(result.inlier_ratio, 3),
+        easting=round(float(easting), 3),
+        northing=round(float(northing), 3),
+        crs=geotiff.crs,
+        map_pixel_x=round(map_x, 2),
+        map_pixel_y=round(map_y, 2),
+    )
+
+
+@router.get("/image/")
+def serve_image(
+    tenant_id: str = Query(...),
+    image_filename: str = Query(...),
+    user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> FileResponse:
+    """Serve a camera frame image file from disk (read-only)."""
+    if not validate_image_filename(image_filename):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    frame = image_filename_to_frame(image_filename, session)
+    if frame is None:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    resolved_path = get_frame_image_path(frame)
+    if not resolved_path.exists():
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    mime_type, _ = mimetypes.guess_type(str(resolved_path))
+    if not mime_type:
+        mime_type = "image/jpeg"
+
+    return FileResponse(
+        path=resolved_path,
+        media_type=mime_type,
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )

--- a/api/routers/click_to_gps.py
+++ b/api/routers/click_to_gps.py
@@ -93,11 +93,16 @@ def _load_geotiff(tenant_id: str, session: Session) -> tuple[GeoTiff, int, int] 
     if not geotiff_path.exists():
         return None
 
-    with tifffile.TiffFile(geotiff_path) as tif:
-        page = tif.pages[0]
-        width: int = page.imagewidth  # type: ignore[union-attr]
-        height: int = page.imagelength  # type: ignore[union-attr]
-        geotiff = extract_geotiff(tif)
+    # A corrupt/truncated raster must degrade to "no GPS available" (handled as
+    # a 422 by the caller) rather than bubbling an opaque 500.
+    try:
+        with tifffile.TiffFile(geotiff_path) as tif:
+            page = tif.pages[0]
+            width: int = page.imagewidth  # type: ignore[union-attr]
+            height: int = page.imagelength  # type: ignore[union-attr]
+            geotiff = extract_geotiff(tif)
+    except (OSError, ValueError):
+        return None
 
     if geotiff is None:
         return None
@@ -117,6 +122,10 @@ def list_projectable_frames(
 ) -> list[FrameSummary]:
     """List camera frames with enough GCP annotations to project from."""
     map_id = _resolve_map_id(tenant_id, session)
+    if map_id is None:
+        # No map for this tenant → no projectable frames. Returning here also
+        # avoids ``list_frames(session, None)`` enumerating every tenant's frames.
+        return []
     frames: list[FrameSummary] = []
     for frame in list_frames(session, map_id):
         annotations = load_annotations_for_frame(frame.id, session)
@@ -142,8 +151,9 @@ def project_pixel_to_gps(
     """Project a clicked camera pixel to a WGS84 GPS coordinate."""
     map_id = _resolve_map_id(tenant_id, session)
     if map_id is None:
+        # 404 matches the sibling routers' "no map for tenant" convention.
         raise HTTPException(
-            status_code=422,
+            status_code=404,
             detail="No map configured for the current tenant. Upload a GeoTIFF map first.",
         )
 
@@ -169,7 +179,7 @@ def project_pixel_to_gps(
     try:
         registry = from_gcp_repo_pg(session, map_id)
     except (KeyError, ValueError, OSError) as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to load GCP registry: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to load GCP registry") from exc
 
     # Fit the GCP homography for this frame. min_inlier_ratio=0 so we always
     # obtain a transform and report its (possibly low) confidence rather than
@@ -208,8 +218,15 @@ def project_pixel_to_gps(
             error="Point projects beyond the map (likely on or above the horizon).",
         )
 
-    easting, northing = geotiff.pixel_to_geo(map_x, map_y)
-    latitude, longitude = geotiff.pixel_to_latlon(map_x, map_y)
+    try:
+        easting, northing = geotiff.pixel_to_geo(map_x, map_y)
+        latitude, longitude = geotiff.pixel_to_latlon(map_x, map_y)
+    except (ValueError, RuntimeError) as exc:
+        return ProjectResponse(
+            success=False,
+            confidence=round(result.inlier_ratio, 3),
+            error=f"Coordinate reprojection failed: {exc}",
+        )
 
     return ProjectResponse(
         success=True,
@@ -235,7 +252,13 @@ def serve_image(
     if not validate_image_filename(image_filename):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    frame = image_filename_to_frame(image_filename, session)
+    # Scope the lookup to the tenant's own map so one tenant cannot read another
+    # tenant's frame by guessing its filename.
+    map_id = _resolve_map_id(tenant_id, session)
+    if map_id is None:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    frame = image_filename_to_frame(image_filename, session, map_id=map_id)
     if frame is None:
         raise HTTPException(status_code=404, detail="Image not found")
 

--- a/api/schemas/click_to_gps.py
+++ b/api/schemas/click_to_gps.py
@@ -1,0 +1,52 @@
+"""Pydantic request/response schemas for click-to-GPS endpoints (issue #33)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class FrameSummary(BaseModel):
+    """A camera frame usable for click-to-GPS projection.
+
+    Only frames with at least four GCP annotations can yield a homography, so
+    ``annotation_count`` lets the UI flag (or hide) frames that cannot project.
+    """
+
+    name: str
+    image: str
+    annotation_count: int
+
+
+class ProjectRequest(BaseModel):
+    """Body for ``POST /click-to-gps/api/project/``.
+
+    A single clicked pixel on a camera frame, identified by its test-case name
+    (the image stem) plus the pixel coordinates in the camera image.
+    """
+
+    test_case_name: str
+    pixel_x: float
+    pixel_y: float
+
+
+class ProjectResponse(BaseModel):
+    """Result of projecting a clicked camera pixel to GPS.
+
+    On success, ``latitude``/``longitude`` carry the WGS84 coordinate and
+    ``confidence`` is the homography inlier ratio [0, 1]. On failure (e.g. a
+    point that projects beyond the georeferenced map, the click-to-GPS analog
+    of a point on/above the horizon), ``success`` is ``False`` and ``error``
+    explains why; ``on_horizon`` marks that specific failure class.
+    """
+
+    success: bool
+    latitude: float | None = None
+    longitude: float | None = None
+    confidence: float | None = None
+    easting: float | None = None
+    northing: float | None = None
+    crs: str | None = None
+    map_pixel_x: float | None = None
+    map_pixel_y: float | None = None
+    on_horizon: bool = False
+    error: str | None = None

--- a/poc_homography/domain/vo/geotiff.py
+++ b/poc_homography/domain/vo/geotiff.py
@@ -3,9 +3,35 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
-from poc_homography.types import Easting, Meters, Northing, PixelsFloat, Unitless
+from pyproj import Transformer
+
+from poc_homography.types import (
+    Easting,
+    Latitude,
+    Longitude,
+    Meters,
+    Northing,
+    PixelsFloat,
+    Unitless,
+)
+
+# WGS84 geographic CRS — the lat/lon datum used for GPS output.
+_WGS84_CRS = "EPSG:4326"
+
+
+@lru_cache(maxsize=8)
+def _to_wgs84_transformer(source_crs: str) -> Transformer:
+    """Return a cached pyproj transformer from *source_crs* to WGS84 lat/lon.
+
+    Building a :class:`pyproj.Transformer` is comparatively expensive, so
+    instances are memoised per source CRS. ``always_xy=True`` keeps the input
+    in (easting, northing) / (lon, lat) axis order regardless of the CRS's
+    declared axis ordering.
+    """
+    return Transformer.from_crs(source_crs, _WGS84_CRS, always_xy=True)
 
 
 @dataclass(frozen=True)
@@ -100,6 +126,26 @@ class GeoTiff:
             gt.origin_northing + pixel_x * gt.col_rotation + pixel_y * float(gt.pixel_height)
         )
         return (easting, northing)
+
+    def pixel_to_latlon(
+        self, pixel_x: PixelsFloat, pixel_y: PixelsFloat
+    ) -> tuple[Latitude, Longitude]:
+        """Convert map pixel coordinates to WGS84 geographic coordinates.
+
+        Chains :meth:`pixel_to_geo` (pixel → projected easting/northing in this
+        GeoTIFF's CRS) with a pyproj reprojection to WGS84 lat/lon, giving the
+        GPS coordinate of a point identified on the georeferenced map.
+
+        Args:
+            pixel_x: Pixel x-coordinate (column).
+            pixel_y: Pixel y-coordinate (row).
+
+        Returns:
+            Tuple of (latitude, longitude) in decimal degrees (WGS84).
+        """
+        easting, northing = self.pixel_to_geo(pixel_x, pixel_y)
+        lon, lat = _to_wgs84_transformer(self.crs).transform(float(easting), float(northing))
+        return (Latitude(float(lat)), Longitude(float(lon)))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""

--- a/poc_homography/types.py
+++ b/poc_homography/types.py
@@ -44,6 +44,12 @@ Easting = NewType("Easting", float)
 Northing = NewType("Northing", float)
 """Y-coordinate in projected CRS (e.g., UTM northing in meters)"""
 
+Latitude = NewType("Latitude", float)
+"""Geographic latitude in decimal degrees (WGS84)"""
+
+Longitude = NewType("Longitude", float)
+"""Geographic longitude in decimal degrees (WGS84)"""
+
 # Image coordinate units
 Pixels = NewType("Pixels", int)
 """Image coordinates or dimensions in pixels (e.g., u, v, width, height)"""

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -10,6 +10,7 @@ import LinePickerPage from './pages/LinePickerPage';
 import CameraAnnotatorPage from './pages/CameraAnnotatorPage';
 import CameraLineAnnotatorPage from './pages/CameraLineAnnotatorPage';
 import HomographyPrecisionPage from './pages/HomographyPrecisionPage';
+import ClickToGpsPage from './pages/ClickToGpsPage';
 import CameraDiagnosticPage from './pages/CameraDiagnosticPage';
 import CameraSurveyPage from './pages/CameraSurveyPage';
 import CameraEvaluationPage from './pages/CameraEvaluationPage';
@@ -46,6 +47,7 @@ export default function App() {
                 path="homography-precision"
                 element={<HomographyPrecisionPage />}
               />
+              <Route path="click-to-gps" element={<ClickToGpsPage />} />
               <Route
                 path="camera-diagnostic"
                 element={<CameraDiagnosticPage />}

--- a/spa/src/api/schema.d.ts
+++ b/spa/src/api/schema.d.ts
@@ -1173,6 +1173,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/click-to-gps/api/frames/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Projectable Frames
+         * @description List camera frames with enough GCP annotations to project from.
+         */
+        get: operations["list_projectable_frames_click_to_gps_api_frames__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/click-to-gps/api/project/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Project Pixel To Gps
+         * @description Project a clicked camera pixel to a WGS84 GPS coordinate.
+         */
+        post: operations["project_pixel_to_gps_click_to_gps_api_project__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/click-to-gps/image/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Serve Image
+         * @description Serve a camera frame image file from disk (read-only).
+         */
+        get: operations["serve_image_click_to_gps_image__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/distortion-validator/api/calibration-files/": {
         parameters: {
             query?: never;
@@ -2208,7 +2268,7 @@ export interface components {
         CalibrateAnnotatedLinesRequest: {
             /** Camera Line Annotations */
             camera_line_annotations: components["schemas"]["CameraLineAnnotationIn"][];
-            intrinsics: components["schemas"]["api__schemas__lens_calibration__IntrinsicsIn"];
+            intrinsics: components["schemas"]["IntrinsicsIn"];
             /**
              * Auto Intrinsics
              * @default false
@@ -2661,6 +2721,21 @@ export interface components {
             p2: number;
         };
         /**
+         * FrameSummary
+         * @description A camera frame usable for click-to-GPS projection.
+         *
+         *     Only frames with at least four GCP annotations can yield a homography, so
+         *     ``annotation_count`` lets the UI flag (or hide) frames that cannot project.
+         */
+        FrameSummary: {
+            /** Name */
+            name: string;
+            /** Image */
+            image: string;
+            /** Annotation Count */
+            annotation_count: number;
+        };
+        /**
          * GCPPointOut
          * @description Single GCP point in the registry.
          */
@@ -2805,10 +2880,32 @@ export interface components {
              * @default 1000
              */
             fy: number;
-            /** Cx */
-            cx?: number | null;
-            /** Cy */
-            cy?: number | null;
+            /**
+             * Cx
+             * @default 960
+             */
+            cx: number;
+            /**
+             * Cy
+             * @default 540
+             */
+            cy: number;
+            /**
+             * Image Width
+             * @default 1920
+             */
+            image_width: number;
+            /**
+             * Image Height
+             * @default 1080
+             */
+            image_height: number;
+            /** Sensor Width Mm */
+            sensor_width_mm?: number | null;
+            /** Base Focal Length Mm */
+            base_focal_length_mm?: number | null;
+            /** Zoom */
+            zoom?: number | null;
         };
         /**
          * IntrinsicsOut
@@ -3051,7 +3148,7 @@ export interface components {
              */
             undistort: boolean;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["IntrinsicsIn"];
+            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
         };
         /**
          * NextIdResponse
@@ -3150,6 +3247,58 @@ export interface components {
             pixel_y: number;
             /** Tag */
             tag: string;
+        };
+        /**
+         * ProjectRequest
+         * @description Body for ``POST /click-to-gps/api/project/``.
+         *
+         *     A single clicked pixel on a camera frame, identified by its test-case name
+         *     (the image stem) plus the pixel coordinates in the camera image.
+         */
+        ProjectRequest: {
+            /** Test Case Name */
+            test_case_name: string;
+            /** Pixel X */
+            pixel_x: number;
+            /** Pixel Y */
+            pixel_y: number;
+        };
+        /**
+         * ProjectResponse
+         * @description Result of projecting a clicked camera pixel to GPS.
+         *
+         *     On success, ``latitude``/``longitude`` carry the WGS84 coordinate and
+         *     ``confidence`` is the homography inlier ratio [0, 1]. On failure (e.g. a
+         *     point that projects beyond the georeferenced map, the click-to-GPS analog
+         *     of a point on/above the horizon), ``success`` is ``False`` and ``error``
+         *     explains why; ``on_horizon`` marks that specific failure class.
+         */
+        ProjectResponse: {
+            /** Success */
+            success: boolean;
+            /** Latitude */
+            latitude?: number | null;
+            /** Longitude */
+            longitude?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Easting */
+            easting?: number | null;
+            /** Northing */
+            northing?: number | null;
+            /** Crs */
+            crs?: string | null;
+            /** Map Pixel X */
+            map_pixel_x?: number | null;
+            /** Map Pixel Y */
+            map_pixel_y?: number | null;
+            /**
+             * On Horizon
+             * @default false
+             */
+            on_horizon: boolean;
+            /** Error */
+            error?: string | null;
         };
         /**
          * RunDiagnosticRequest
@@ -3454,7 +3603,7 @@ export interface components {
              */
             direction: string;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["IntrinsicsIn"];
+            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
         };
         /**
          * TransformPointsResponse
@@ -3474,7 +3623,7 @@ export interface components {
             /** Image Path */
             image_path: string;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["IntrinsicsIn"];
+            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
             /**
              * Use Opencv
              * @default false
@@ -3560,7 +3709,7 @@ export interface components {
          * @description Body for ``POST /api/validate/``.
          */
         ValidateRequest: {
-            intrinsics: components["schemas"]["api__schemas__lens_calibration__IntrinsicsIn"];
+            intrinsics: components["schemas"]["IntrinsicsIn"];
             coefficients?: components["schemas"]["DistortionCoefficients"];
             /** Lines */
             lines?: components["schemas"]["ValidationLineIn"][];
@@ -3660,6 +3809,26 @@ export interface components {
             camera_status: components["schemas"]["CameraStatusOut"];
         };
         /**
+         * IntrinsicsIn
+         * @description Camera intrinsic parameters.
+         */
+        api__schemas__distortion_validator__IntrinsicsIn: {
+            /**
+             * Fx
+             * @default 1000
+             */
+            fx: number;
+            /**
+             * Fy
+             * @default 1000
+             */
+            fy: number;
+            /** Cx */
+            cx?: number | null;
+            /** Cy */
+            cy?: number | null;
+        };
+        /**
          * LoadCalibrationRequest
          * @description Body for ``POST /api/load-calibration/``.
          */
@@ -3678,48 +3847,6 @@ export interface components {
             entries: {
                 [key: string]: unknown;
             }[];
-        };
-        /**
-         * IntrinsicsIn
-         * @description Camera intrinsic parameters.
-         */
-        api__schemas__lens_calibration__IntrinsicsIn: {
-            /**
-             * Fx
-             * @default 1000
-             */
-            fx: number;
-            /**
-             * Fy
-             * @default 1000
-             */
-            fy: number;
-            /**
-             * Cx
-             * @default 960
-             */
-            cx: number;
-            /**
-             * Cy
-             * @default 540
-             */
-            cy: number;
-            /**
-             * Image Width
-             * @default 1920
-             */
-            image_width: number;
-            /**
-             * Image Height
-             * @default 1080
-             */
-            image_height: number;
-            /** Sensor Width Mm */
-            sensor_width_mm?: number | null;
-            /** Base Focal Length Mm */
-            base_focal_length_mm?: number | null;
-            /** Zoom */
-            zoom?: number | null;
         };
         /**
          * LineOut
@@ -5557,6 +5684,104 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RunListResponse"];
+                };
+            };
+        };
+    };
+    list_projectable_frames_click_to_gps_api_frames__get: {
+        parameters: {
+            query: {
+                tenant_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FrameSummary"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_pixel_to_gps_click_to_gps_api_project__post: {
+        parameters: {
+            query: {
+                tenant_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    serve_image_click_to_gps_image__get: {
+        parameters: {
+            query: {
+                tenant_id: string;
+                image_filename: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/spa/src/pages/ClickToGpsPage.module.css
+++ b/spa/src/pages/ClickToGpsPage.module.css
@@ -1,0 +1,217 @@
+/* ---------- Full-viewport layout ---------- */
+.wrapper {
+  display: flex;
+  height: calc(100vh - 56px); /* below AppLayout header */
+  background: #1a1a1a;
+}
+
+.loading,
+.emptyText {
+  color: #aaa;
+  padding: 16px;
+  font-size: 14px;
+}
+
+/* ---------- Left panel: camera frame ---------- */
+.imagePanel {
+  flex: 1;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: #222;
+  overflow: hidden;
+}
+
+.imageContainer {
+  flex: 1;
+  overflow: auto;
+  cursor: crosshair;
+}
+
+.imageWrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.frameImage {
+  display: block;
+  max-width: none;
+}
+
+/* ---------- Clicked-point crosshair markers ---------- */
+.marker {
+  position: absolute;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.markerNewest {
+  z-index: 10;
+}
+
+.crosshair {
+  position: absolute;
+  left: -10px;
+  top: -10px;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #43a047;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.6);
+}
+
+.crosshair::before,
+.crosshair::after {
+  content: '';
+  position: absolute;
+  background: currentColor;
+}
+
+.crosshair::before {
+  left: 50%;
+  top: -6px;
+  width: 1px;
+  height: 32px;
+  margin-left: -0.5px;
+}
+
+.crosshair::after {
+  top: 50%;
+  left: -6px;
+  height: 1px;
+  width: 32px;
+  margin-top: -0.5px;
+}
+
+.markerLabel {
+  position: absolute;
+  left: 14px;
+  top: -8px;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  text-shadow:
+    0 0 3px #000,
+    0 0 3px #000;
+}
+
+.markerNewest .markerLabel {
+  font-size: 13px;
+}
+
+/* ---------- Transient flash banner ---------- */
+.flash {
+  position: absolute;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  z-index: 20;
+}
+
+/* ---------- Right panel: controls ---------- */
+.controlPanel {
+  width: 320px;
+  background: #2a2a2a;
+  color: #eee;
+  overflow-y: auto;
+  border-left: 1px solid #111;
+}
+
+.panelSection {
+  padding: 16px;
+  border-bottom: 1px solid #333;
+}
+
+.panelSection h2 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #bbb;
+}
+
+.instructions {
+  font-size: 13px;
+  line-height: 1.5;
+  color: #ccc;
+}
+
+.instructions kbd {
+  background: #444;
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.frameSelector {
+  width: 100%;
+  padding: 8px;
+  background: #1e1e1e;
+  color: #eee;
+  border: 1px solid #444;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+/* ---------- Clicked-point list ---------- */
+.pointList {
+  margin-bottom: 12px;
+}
+
+.pointRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid #333;
+  font-size: 13px;
+}
+
+.swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.pointGps {
+  flex: 1;
+  font-family: monospace;
+}
+
+.pointConf {
+  color: #aaa;
+}
+
+.copyButton,
+.clearButton {
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.copyButton {
+  background: #1565c0;
+  color: #fff;
+}
+
+.clearButton {
+  background: #444;
+  color: #eee;
+}
+
+.copyStatus {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #8bc34a;
+}

--- a/spa/src/pages/ClickToGpsPage.tsx
+++ b/spa/src/pages/ClickToGpsPage.tsx
@@ -20,6 +20,12 @@ interface FrameSummary {
   annotation_count: number;
 }
 
+/** A transient banner message keyed by a monotonic id. */
+interface Toast {
+  text: string;
+  id: number;
+}
+
 interface ClickedPoint {
   /** Pixel coordinates in the camera image (natural resolution). */
   pixelX: number;
@@ -58,12 +64,23 @@ export default function ClickToGpsPage() {
   const [frames, setFrames] = useState<FrameSummary[]>([]);
   const [currentFrame, setCurrentFrame] = useState<FrameSummary | null>(null);
   const [clickedPoints, setClickedPoints] = useState<ClickedPoint[]>([]);
-  const [flash, setFlash] = useState<string | null>(null);
-  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  // Transient banners carry a monotonic id so two identical consecutive
+  // messages still produce a new object — re-arming the 3 s auto-clear timer.
+  const [flash, setFlash] = useState<Toast | null>(null);
+  const [copyStatus, setCopyStatus] = useState<Toast | null>(null);
 
   const imgRef = useRef<HTMLImageElement>(null);
+  const toastSeq = useRef(0);
   const clickedRef = useRef<ClickedPoint[]>([]);
   clickedRef.current = clickedPoints;
+
+  const showFlash = useCallback((text: string) => {
+    setFlash({ text, id: (toastSeq.current += 1) });
+  }, []);
+
+  const showCopyStatus = useCallback((text: string) => {
+    setCopyStatus({ text, id: (toastSeq.current += 1) });
+  }, []);
 
   /* Select a frame and reset the per-frame marker state. */
   const selectFrame = useCallback((frame: FrameSummary | null) => {
@@ -143,12 +160,12 @@ export default function ClickToGpsPage() {
         };
 
         setClickedPoints((prev) => [...prev, point].slice(-MAX_POINTS));
-        setFlash(point.error ? point.error : `GPS: ${gpsLabel(point)}`);
+        showFlash(point.error ? point.error : `GPS: ${gpsLabel(point)}`);
       } catch (err) {
         console.error('Projection request failed:', err);
       }
     },
-    [currentFrame, selectedTenantId],
+    [currentFrame, selectedTenantId, showFlash],
   );
 
   /* ---- Auto-clear the transient flash banner after 3 s ---- */
@@ -172,17 +189,17 @@ export default function ClickToGpsPage() {
     const points = clickedRef.current;
     const last = [...points].reverse().find((p) => p.latitude !== null);
     if (!last || last.latitude === null || last.longitude === null) {
-      setCopyStatus('No GPS coordinate to copy');
+      showCopyStatus('No GPS coordinate to copy');
       return;
     }
     const text = `${last.latitude.toFixed(6)}, ${last.longitude.toFixed(6)}`;
     try {
       await navigator.clipboard.writeText(text);
-      setCopyStatus(`Copied: ${text}`);
+      showCopyStatus(`Copied: ${text}`);
     } catch {
-      setCopyStatus('Clipboard unavailable');
+      showCopyStatus('Clipboard unavailable');
     }
-  }, []);
+  }, [showCopyStatus]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -253,7 +270,7 @@ export default function ClickToGpsPage() {
           </div>
         </div>
 
-        {flash && <div className={styles.flash}>{flash}</div>}
+        {flash && <div className={styles.flash}>{flash.text}</div>}
       </div>
 
       {/* ---- Right: controls ---- */}
@@ -335,7 +352,9 @@ export default function ClickToGpsPage() {
           >
             Clear markers (x)
           </button>
-          {copyStatus && <div className={styles.copyStatus}>{copyStatus}</div>}
+          {copyStatus && (
+            <div className={styles.copyStatus}>{copyStatus.text}</div>
+          )}
         </div>
       </div>
     </div>

--- a/spa/src/pages/ClickToGpsPage.tsx
+++ b/spa/src/pages/ClickToGpsPage.tsx
@@ -1,0 +1,343 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import client from '../api/client';
+import { useTenant } from '../contexts/TenantContext';
+import { useImageBlob } from '../hooks/useImageBlob';
+import styles from './ClickToGpsPage.module.css';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                             */
+/* ------------------------------------------------------------------ */
+
+interface FrameSummary {
+  name: string;
+  image: string;
+  annotation_count: number;
+}
+
+interface ClickedPoint {
+  /** Pixel coordinates in the camera image (natural resolution). */
+  pixelX: number;
+  pixelY: number;
+  latitude: number | null;
+  longitude: number | null;
+  confidence: number | null;
+  onHorizon: boolean;
+  error: string | null;
+}
+
+/* Confidence colour bands (DoD #33): green > 0.7, yellow 0.5–0.7, red < 0.5. */
+function confidenceColor(point: ClickedPoint): string {
+  if (point.error || point.confidence === null) return '#e53935'; // red
+  if (point.confidence > 0.7) return '#43a047'; // green
+  if (point.confidence >= 0.5) return '#fbc02d'; // yellow
+  return '#e53935'; // red
+}
+
+function gpsLabel(point: ClickedPoint): string {
+  if (point.latitude === null || point.longitude === null) return 'no fix';
+  return `${point.latitude.toFixed(6)}, ${point.longitude.toFixed(6)}`;
+}
+
+const MAX_POINTS = 5;
+const FLASH_MS = 3000;
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                         */
+/* ------------------------------------------------------------------ */
+
+export default function ClickToGpsPage() {
+  const { selectedTenantId } = useTenant();
+  const { imageUrl, loadImage, clearImage } = useImageBlob();
+
+  const [frames, setFrames] = useState<FrameSummary[]>([]);
+  const [currentFrame, setCurrentFrame] = useState<FrameSummary | null>(null);
+  const [clickedPoints, setClickedPoints] = useState<ClickedPoint[]>([]);
+  const [flash, setFlash] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const imgRef = useRef<HTMLImageElement>(null);
+  const clickedRef = useRef<ClickedPoint[]>([]);
+  clickedRef.current = clickedPoints;
+
+  /* Select a frame and reset the per-frame marker state. */
+  const selectFrame = useCallback((frame: FrameSummary | null) => {
+    setCurrentFrame(frame);
+    setClickedPoints([]);
+    setFlash(null);
+  }, []);
+
+  /* ---- Load projectable frames on tenant change ---- */
+  useEffect(() => {
+    if (!selectedTenantId) return;
+    const controller = new AbortController();
+
+    (async () => {
+      const { data } = await client.GET('/click-to-gps/api/frames/', {
+        params: { query: { tenant_id: selectedTenantId } },
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted || !data) return;
+      setFrames(data);
+      selectFrame(data.length > 0 ? data[0] : null);
+    })().catch((err: unknown) => {
+      if (!controller.signal.aborted) console.error('Failed to load frames:', err);
+    });
+
+    return () => controller.abort();
+  }, [selectedTenantId, selectFrame]);
+
+  /* ---- Load the selected frame image ---- */
+  useEffect(() => {
+    if (!currentFrame) {
+      clearImage();
+      return;
+    }
+    loadImage('/click-to-gps/image/', currentFrame.image, true);
+  }, [currentFrame, loadImage, clearImage]);
+
+  /* ================================================================ */
+  /*  Click → project                                                 */
+  /* ================================================================ */
+
+  const handleImageClick = useCallback(
+    async (e: ReactMouseEvent<HTMLImageElement>) => {
+      const img = imgRef.current;
+      if (!img || !currentFrame || !selectedTenantId) return;
+
+      // Map display coordinates to natural image pixels (scale-safe).
+      const rect = img.getBoundingClientRect();
+      const scaleX = img.naturalWidth / rect.width;
+      const scaleY = img.naturalHeight / rect.height;
+      const pixelX = (e.clientX - rect.left) * scaleX;
+      const pixelY = (e.clientY - rect.top) * scaleY;
+
+      try {
+        const { data, error } = await client.POST('/click-to-gps/api/project/', {
+          params: { query: { tenant_id: selectedTenantId } },
+          body: {
+            test_case_name: currentFrame.name,
+            pixel_x: pixelX,
+            pixel_y: pixelY,
+          },
+        });
+
+        if (error || !data) {
+          console.error('Projection request failed:', error);
+          return;
+        }
+
+        const point: ClickedPoint = {
+          pixelX,
+          pixelY,
+          latitude: data.latitude ?? null,
+          longitude: data.longitude ?? null,
+          confidence: data.confidence ?? null,
+          onHorizon: data.on_horizon,
+          error: data.success ? null : (data.error ?? 'Projection failed'),
+        };
+
+        setClickedPoints((prev) => [...prev, point].slice(-MAX_POINTS));
+        setFlash(point.error ? point.error : `GPS: ${gpsLabel(point)}`);
+      } catch (err) {
+        console.error('Projection request failed:', err);
+      }
+    },
+    [currentFrame, selectedTenantId],
+  );
+
+  /* ---- Auto-clear the transient flash banner after 3 s ---- */
+  useEffect(() => {
+    if (flash === null) return;
+    const id = window.setTimeout(() => setFlash(null), FLASH_MS);
+    return () => window.clearTimeout(id);
+  }, [flash]);
+
+  useEffect(() => {
+    if (copyStatus === null) return;
+    const id = window.setTimeout(() => setCopyStatus(null), FLASH_MS);
+    return () => window.clearTimeout(id);
+  }, [copyStatus]);
+
+  /* ================================================================ */
+  /*  Keyboard shortcuts: 'c' copy last GPS, 'x' clear markers        */
+  /* ================================================================ */
+
+  const copyLastGps = useCallback(async () => {
+    const points = clickedRef.current;
+    const last = [...points].reverse().find((p) => p.latitude !== null);
+    if (!last || last.latitude === null || last.longitude === null) {
+      setCopyStatus('No GPS coordinate to copy');
+      return;
+    }
+    const text = `${last.latitude.toFixed(6)}, ${last.longitude.toFixed(6)}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyStatus(`Copied: ${text}`);
+    } catch {
+      setCopyStatus('Clipboard unavailable');
+    }
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'SELECT')) {
+        return;
+      }
+      if (e.key === 'c' || e.key === 'C') {
+        void copyLastGps();
+      } else if (e.key === 'x' || e.key === 'X') {
+        setClickedPoints([]);
+        setFlash(null);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [copyLastGps]);
+
+  /* ================================================================ */
+  /*  Render                                                          */
+  /* ================================================================ */
+
+  if (!selectedTenantId) {
+    return <div className={styles.loading}>Select a tenant to begin.</div>;
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      {/* ---- Left: camera frame ---- */}
+      <div className={styles.imagePanel}>
+        <div className={styles.imageContainer}>
+          <div className={styles.imageWrapper}>
+            {imageUrl ? (
+              <img
+                ref={imgRef}
+                className={styles.frameImage}
+                src={imageUrl}
+                alt="Camera Frame"
+                onClick={handleImageClick}
+                draggable={false}
+              />
+            ) : (
+              <div className={styles.loading}>
+                {currentFrame ? 'Loading image…' : 'No frame available'}
+              </div>
+            )}
+
+            {/* Clicked-point crosshairs + GPS labels */}
+            {clickedPoints.map((p, i) => {
+              const color = confidenceColor(p);
+              const newest = i === clickedPoints.length - 1;
+              return (
+                <div
+                  key={`${p.pixelX}-${p.pixelY}-${i}`}
+                  className={`${styles.marker}${newest ? ` ${styles.markerNewest}` : ''}`}
+                  style={{ left: p.pixelX, top: p.pixelY, color }}
+                >
+                  <span className={styles.crosshair} style={{ borderColor: color }} />
+                  <span className={styles.markerLabel} style={{ color }}>
+                    {p.error ? p.error : gpsLabel(p)}
+                    {p.confidence !== null && !p.error
+                      ? ` (${(p.confidence * 100).toFixed(0)}%)`
+                      : ''}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {flash && <div className={styles.flash}>{flash}</div>}
+      </div>
+
+      {/* ---- Right: controls ---- */}
+      <div className={styles.controlPanel}>
+        <div className={styles.panelSection}>
+          <h2>Click-to-GPS</h2>
+          <p className={styles.instructions}>
+            Click anywhere on the camera frame to estimate its GPS coordinate.
+            Markers are colour-coded by confidence (green &gt; 0.7, yellow
+            0.5–0.7, red &lt; 0.5). Press <kbd>c</kbd> to copy the last GPS,{' '}
+            <kbd>x</kbd> to clear markers.
+          </p>
+        </div>
+
+        <div className={styles.panelSection}>
+          <h2>Frame</h2>
+          {frames.length === 0 ? (
+            <div className={styles.emptyText}>
+              No frames with ≥4 GCP annotations for this tenant.
+            </div>
+          ) : (
+            <select
+              className={styles.frameSelector}
+              value={currentFrame?.name ?? ''}
+              onChange={(e) => {
+                const next = frames.find((f) => f.name === e.target.value);
+                if (next) selectFrame(next);
+              }}
+            >
+              {frames.map((f) => (
+                <option key={f.name} value={f.name}>
+                  {f.name} ({f.annotation_count} GCPs)
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <div className={styles.panelSection}>
+          <h2>Clicked Points ({clickedPoints.length})</h2>
+          <div className={styles.pointList}>
+            {clickedPoints.length === 0 ? (
+              <div className={styles.emptyText}>Click the frame to start.</div>
+            ) : (
+              [...clickedPoints].reverse().map((p, i) => (
+                <div key={`row-${i}`} className={styles.pointRow}>
+                  <span
+                    className={styles.swatch}
+                    style={{ background: confidenceColor(p) }}
+                  />
+                  <span className={styles.pointGps}>{gpsLabel(p)}</span>
+                  <span className={styles.pointConf}>
+                    {p.error
+                      ? p.onHorizon
+                        ? 'horizon'
+                        : 'error'
+                      : p.confidence !== null
+                        ? `${(p.confidence * 100).toFixed(0)}%`
+                        : ''}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+          <button
+            type="button"
+            className={styles.copyButton}
+            onClick={() => void copyLastGps()}
+          >
+            Copy last GPS (c)
+          </button>
+          <button
+            type="button"
+            className={styles.clearButton}
+            onClick={() => {
+              setClickedPoints([]);
+              setFlash(null);
+            }}
+          >
+            Clear markers (x)
+          </button>
+          {copyStatus && <div className={styles.copyStatus}>{copyStatus}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/spa/src/pages/DashboardPage.tsx
+++ b/spa/src/pages/DashboardPage.tsx
@@ -14,6 +14,13 @@ interface ToolCardDef {
 
 const TOOL_CARDS: ToolCardDef[] = [
   {
+    to: '/click-to-gps',
+    title: 'Click-to-GPS',
+    badge: 'Primary',
+    description:
+      'Click anywhere on a camera frame to estimate its GPS coordinate. Confidence-coloured markers, last-5 history, copy-to-clipboard.',
+  },
+  {
     to: '/point-picker',
     title: 'Point Picker',
     badge: 'Primary',

--- a/tests/test_api/test_click_to_gps.py
+++ b/tests/test_api/test_click_to_gps.py
@@ -170,8 +170,8 @@ class TestProject:
         assert resp.status_code == 400
 
     @patch(f"{_MODULE}.get_map_for_tenant")
-    def test_no_map_returns_422(self, mock_map: MagicMock, client: TestClient) -> None:
-        """No configured map → 422 with a helpful message."""
+    def test_no_map_returns_404(self, mock_map: MagicMock, client: TestClient) -> None:
+        """No configured map → 404, matching the sibling routers' convention."""
         mock_map.return_value = None
 
         resp = client.post(
@@ -179,7 +179,7 @@ class TestProject:
             json={"test_case_name": "frame1", "pixel_x": 1.0, "pixel_y": 1.0},
         )
 
-        assert resp.status_code == 422
+        assert resp.status_code == 404
 
 
 class TestListFrames:

--- a/tests/test_api/test_click_to_gps.py
+++ b/tests/test_api/test_click_to_gps.py
@@ -1,0 +1,209 @@
+"""Integration tests for the click-to-GPS endpoints (issue #33).
+
+These patch the router's frame/registry/homography helpers so the endpoint runs
+without a real database, filesystem, or camera. A real :class:`GeoTiff` is used
+so the pixel→UTM→lat/lon chain is exercised end to end.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.map_points.map_point import MapPoint
+from poc_homography.types import Easting, Meters, Northing, Unitless
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+PROJECT_URL = "/click-to-gps/api/project/?tenant_id=t1"
+FRAMES_URL = "/click-to-gps/api/frames/?tenant_id=t1"
+
+_MODULE = "api.routers.click_to_gps"
+
+
+def _valte_geotiff() -> GeoTiff:
+    """A real georeferenced GeoTiff (Valte map params, EPSG:25830)."""
+    return GeoTiff(
+        geotransform=GeoTransform(
+            origin_easting=Easting(737575.05),
+            pixel_width=Meters(0.15),
+            row_rotation=Unitless(0.0),
+            origin_northing=Northing(4391595.45),
+            col_rotation=Unitless(0.0),
+            pixel_height=Meters(-0.15),
+        ),
+        crs="EPSG:25830",
+    )
+
+
+def _frame(stem: str = "frame1") -> MagicMock:
+    """A stand-in CapturedFrame exposing the attributes the router reads."""
+    frame = MagicMock()
+    frame.id = f"id-{stem}"
+    frame.image_path.stem = stem
+    frame.image_path.name = f"{stem}.jpg"
+    return frame
+
+
+def _four_annotations() -> list[dict]:
+    return [
+        {"gcp_id": "G1", "pixel_x": 10.0, "pixel_y": 20.0},
+        {"gcp_id": "G2", "pixel_x": 30.0, "pixel_y": 40.0},
+        {"gcp_id": "G3", "pixel_x": 50.0, "pixel_y": 60.0},
+        {"gcp_id": "G4", "pixel_x": 70.0, "pixel_y": 80.0},
+    ]
+
+
+def _homography_returning(map_x: float, map_y: float, inlier_ratio: float = 0.9) -> MagicMock:
+    """A MapPointHomography mock projecting every click to (map_x, map_y)."""
+    instance = MagicMock()
+    result = MagicMock()
+    result.inlier_ratio = inlier_ratio
+    instance.compute_from_gcps.return_value = result
+    instance.camera_to_map.return_value = MapPoint(pixel_x=map_x, pixel_y=map_y)
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+class TestProject:
+    """Tests for ``POST /click-to-gps/api/project/``."""
+
+    @patch(f"{_MODULE}.MapPointHomography")
+    @patch(f"{_MODULE}.from_gcp_repo_pg")
+    @patch(f"{_MODULE}._load_geotiff")
+    @patch(f"{_MODULE}.load_annotations_for_frame")
+    @patch(f"{_MODULE}.list_frames")
+    @patch(f"{_MODULE}.get_map_for_tenant")
+    def test_project_success_returns_gps(
+        self,
+        mock_map: MagicMock,
+        mock_frames: MagicMock,
+        mock_anns: MagicMock,
+        mock_geotiff: MagicMock,
+        mock_registry: MagicMock,
+        mock_homography: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """A valid click projects to a WGS84 coordinate with confidence."""
+        mock_map.return_value = MagicMock(id="map1")
+        mock_frames.return_value = [_frame("frame1")]
+        mock_anns.return_value = _four_annotations()
+        mock_geotiff.return_value = (_valte_geotiff(), 640, 640)
+        mock_registry.return_value = MagicMock(map_id="map1")
+        # Map pixel (0,0) → the Valte origin GPS (~39.641, -0.231).
+        mock_homography.side_effect = _homography_returning(0.0, 0.0, inlier_ratio=0.82)
+
+        resp = client.post(
+            PROJECT_URL,
+            json={"test_case_name": "frame1", "pixel_x": 123.0, "pixel_y": 456.0},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["latitude"] == pytest.approx(39.6412, abs=1e-3)
+        assert data["longitude"] == pytest.approx(-0.2314, abs=1e-3)
+        assert data["confidence"] == pytest.approx(0.82, abs=1e-6)
+        assert data["crs"] == "EPSG:25830"
+        assert data["on_horizon"] is False
+
+    @patch(f"{_MODULE}.MapPointHomography")
+    @patch(f"{_MODULE}.from_gcp_repo_pg")
+    @patch(f"{_MODULE}._load_geotiff")
+    @patch(f"{_MODULE}.load_annotations_for_frame")
+    @patch(f"{_MODULE}.list_frames")
+    @patch(f"{_MODULE}.get_map_for_tenant")
+    def test_point_beyond_map_is_flagged_on_horizon(
+        self,
+        mock_map: MagicMock,
+        mock_frames: MagicMock,
+        mock_anns: MagicMock,
+        mock_geotiff: MagicMock,
+        mock_registry: MagicMock,
+        mock_homography: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """A pixel projecting far outside the map is reported as on-horizon."""
+        mock_map.return_value = MagicMock(id="map1")
+        mock_frames.return_value = [_frame("frame1")]
+        mock_anns.return_value = _four_annotations()
+        mock_geotiff.return_value = (_valte_geotiff(), 640, 640)
+        mock_registry.return_value = MagicMock(map_id="map1")
+        # Project way outside the 640×640 map → on horizon.
+        mock_homography.side_effect = _homography_returning(99999.0, 99999.0)
+
+        resp = client.post(
+            PROJECT_URL,
+            json={"test_case_name": "frame1", "pixel_x": 1.0, "pixel_y": 1.0},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is False
+        assert data["on_horizon"] is True
+        assert data["latitude"] is None
+
+    @patch(f"{_MODULE}.load_annotations_for_frame")
+    @patch(f"{_MODULE}.list_frames")
+    @patch(f"{_MODULE}.get_map_for_tenant")
+    def test_insufficient_annotations_returns_400(
+        self,
+        mock_map: MagicMock,
+        mock_frames: MagicMock,
+        mock_anns: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """A frame with fewer than four annotations cannot project."""
+        mock_map.return_value = MagicMock(id="map1")
+        mock_frames.return_value = [_frame("frame1")]
+        mock_anns.return_value = _four_annotations()[:2]
+
+        resp = client.post(
+            PROJECT_URL,
+            json={"test_case_name": "frame1", "pixel_x": 1.0, "pixel_y": 1.0},
+        )
+
+        assert resp.status_code == 400
+
+    @patch(f"{_MODULE}.get_map_for_tenant")
+    def test_no_map_returns_422(self, mock_map: MagicMock, client: TestClient) -> None:
+        """No configured map → 422 with a helpful message."""
+        mock_map.return_value = None
+
+        resp = client.post(
+            PROJECT_URL,
+            json={"test_case_name": "frame1", "pixel_x": 1.0, "pixel_y": 1.0},
+        )
+
+        assert resp.status_code == 422
+
+
+class TestListFrames:
+    """Tests for ``GET /click-to-gps/api/frames/``."""
+
+    @patch(f"{_MODULE}.load_annotations_for_frame")
+    @patch(f"{_MODULE}.list_frames")
+    @patch(f"{_MODULE}.get_map_for_tenant")
+    def test_only_frames_with_enough_annotations_listed(
+        self,
+        mock_map: MagicMock,
+        mock_frames: MagicMock,
+        mock_anns: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Frames with fewer than four annotations are excluded."""
+        mock_map.return_value = MagicMock(id="map1")
+        mock_frames.return_value = [_frame("good"), _frame("sparse")]
+        mock_anns.side_effect = lambda frame_id, _session: (
+            _four_annotations() if frame_id == "id-good" else _four_annotations()[:1]
+        )
+
+        resp = client.get(FRAMES_URL)
+
+        assert resp.status_code == 200
+        names = [f["name"] for f in resp.json()]
+        assert names == ["good"]

--- a/tests/test_geotiff_affine_transform.py
+++ b/tests/test_geotiff_affine_transform.py
@@ -172,5 +172,36 @@ class TestGeotransformEdgeCases:
         assert northing == pytest.approx(4400000, abs=0.01)
 
 
+class TestPixelToLatLon:
+    """Test the pixel -> WGS84 lat/lon reprojection (issue #33)."""
+
+    def test_valte_origin_matches_known_gps(self):
+        """The Valte GeoTIFF origin reprojects to its documented GPS location.
+
+        The Valte camera's GeoTransform origin (EPSG:25830 UTM zone 30N) sits at
+        roughly 39.641 N, -0.231 E — the area the project targets.
+        """
+        geotiff = _make_geotiff([737575.05, 0.15, 0, 4391595.45, 0, -0.15], crs="EPSG:25830")
+
+        lat, lon = geotiff.pixel_to_latlon(0, 0)
+
+        assert lat == pytest.approx(39.6412, abs=1e-3)
+        assert lon == pytest.approx(-0.2314, abs=1e-3)
+
+    def test_roundtrip_consistency_with_pixel_to_geo(self):
+        """lat/lon is the WGS84 reprojection of the same easting/northing."""
+        from pyproj import Transformer
+
+        geotiff = _make_geotiff([737575.05, 0.15, 0, 4391595.45, 0, -0.15], crs="EPSG:25830")
+        easting, northing = geotiff.pixel_to_geo(120, 340)
+        lat, lon = geotiff.pixel_to_latlon(120, 340)
+
+        transformer = Transformer.from_crs("EPSG:25830", "EPSG:4326", always_xy=True)
+        exp_lon, exp_lat = transformer.transform(float(easting), float(northing))
+
+        assert lat == pytest.approx(exp_lat, abs=1e-9)
+        assert lon == pytest.approx(exp_lon, abs=1e-9)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -198,6 +198,7 @@ upload_command  # cli-command (poc_homography/cli/maps.py:15)
 
 # == domain-api ==
 # Domain public API (value-object / entity / algorithm methods exercised by tests or exported as public surface)
+_.pixel_to_latlon  # domain-api (poc_homography/domain/vo/geotiff.py:133 — consumed by api/routers/click_to_gps.py)
 _.remove_entry  # domain-api (poc_homography/calibration/lens_distortion/calibration_table.py:202)
 _.get_zoom_levels  # domain-api (poc_homography/calibration/lens_distortion/calibration_table.py:373)
 merge_distance_threshold  # domain-api (poc_homography/calibration/lens_distortion/line_detection.py:61)


### PR DESCRIPTION
Closes #33.

## What

Adds the project's primary user-facing feature — **click anywhere on a camera frame to get an estimated GPS coordinate** — to the live `api/` + `spa/` stack.

> **Translation note (cf#705):** The issue text described a desktop OpenCV `VideoAnnotator` clicking on an RTSP stream and a `project_point()` that returns a `WorldPoint` with lat/lon. Neither exists on this stack — `project_point()` returns map-pixel coordinates, and the desktop/Django tools (`tests/verify_homography.py`) are dev-only / slated for removal (#249). Per direction, the "click on live camera stream → GPS" intent was implemented on the live FastAPI + React app against a saved camera frame (camera access stays read-only/mocked in tests), not a new desktop command.

## How

Projection reuses the existing registration domain services and adds one new domain primitive (UTM→WGS84):

```
clicked camera pixel
  → MapPointHomography.camera_to_map()   # GCP homography → georeferenced map pixel
  → GeoTiff.pixel_to_geo()               # map pixel → UTM easting/northing
  → GeoTiff.pixel_to_latlon()            # UTM → WGS84 lat/lon (cached pyproj Transformer)  [NEW]
```

The homography **inlier ratio** is surfaced as the projection confidence, so the UI colour-codes each clicked point. The validated chain reproduces the issue's documented example (Valte origin → ~39.641, -0.231).

### Backend
- `poc_homography/domain/vo/geotiff.py`: `GeoTiff.pixel_to_latlon()` + `Latitude`/`Longitude` types.
- `api/routers/click_to_gps.py` + `api/schemas/click_to_gps.py`: `GET /api/frames/` (frames with ≥4 GCPs), `POST /api/project/` (pixel→GPS + confidence, horizon flagging), read-only `/image/`. Registered in `api/main.py`.

### Frontend
- `spa/src/pages/ClickToGpsPage.tsx` (+ css): crosshair markers, confidence colour bands (green >0.7 / yellow 0.5–0.7 / red <0.5), last-5 history, transient 3 s flash, `c` copy-to-clipboard, `x` clear. Routed in `App.tsx`, Dashboard card, regenerated typed `schema.d.ts`.

## DoD mapping

The issue's DoD targeted the (nonexistent) desktop tool; mapped onto the live stack:

- [x] Click triggers projection (`POST /api/project/` → `camera_to_map`)
- [x] GPS coordinates displayed at click location (marker label; newest flashed 3 s)
- [x] Confidence shown with colour (green >0.7, yellow 0.5–0.7, red <0.5)
- [x] Click point marked with crosshair
- [x] Last 5 clicked points remain visible with labels
- [x] Press `c` copies last GPS to clipboard
- [x] Press `x` clears all markers
- [x] Error handling for points on/above horizon (projection beyond map flagged)
- [x] Documentation in README for interactive mode
- [~] "Both intrinsic/extrinsic and GCP-based approaches": the live stack is GCP/registration-based; the intrinsic/extrinsic camera-pose path is a desktop concept not present in `api/`. GPS works regardless of how the GCP homography was obtained. Noted as an intentional scope translation.

## Test plan

- `uv run poe validate` (lint/format/typecheck/pylint/vulture) — pass.
- `uv run pytest tests/` — **1284 passed, 157 skipped** (skips are pre-existing DB/DVC/camera gates).
- New: `tests/test_api/test_click_to_gps.py` (success, on-horizon, insufficient annotations, no-map, frame listing) + `tests/test_geotiff_affine_transform.py::TestPixelToLatLon`.
- SPA `tsc -b` clean; `schema.d.ts` regenerated.

CI (`poe ci`) lints/typechecks `poc_homography/` and runs `pytest tests/` (which exercises the new api router); `api/`+`spa/` are not otherwise gated in CI.