### PR TITLE
feat(sites): Map Points Capture Tool — site selector + drop camera geotiff_params [#170]

### DIFF
--- a/api/routers/point_picker.py
+++ b/api/routers/point_picker.py
@@ -28,6 +28,8 @@ from poc_homography.infrastructure.models.user import (  # noqa: TC001 - resolve
 from poc_homography.infrastructure.repositories import RepoPostgresMap
 
 if TYPE_CHECKING:
+    from webapp.point_picker.state import PointPickerState
+
     from poc_homography.domain.entities.map import Map
 from webapp.point_picker.state import (
     delete_gcp_from_repo_pg,
@@ -45,6 +47,22 @@ from webapp.point_picker.validation import (
 # ---------------------------------------------------------------------------
 
 router = APIRouter(prefix="/point-picker", tags=["point-picker"])
+
+
+def _resolve_state(tenant_id: str, session: Session, map_id: str | None) -> PointPickerState:
+    """Resolve point-picker state, mapping resolution failures to clean 404s.
+
+    ``get_state`` raises ``LookupError`` for an unknown ``map_id`` and
+    ``RuntimeError`` when the selected map has no resolvable image asset (e.g.
+    an ``asset_key`` whose object is missing from storage — a case the cheap
+    ``map_has_image`` selector check cannot detect). Surface both as 404 rather
+    than letting them propagate as HTTP 500.
+    """
+    try:
+        return get_state(tenant_id, session, map_id=map_id)
+    except (LookupError, RuntimeError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
 
 # ---------------------------------------------------------------------------
 # Map selector
@@ -84,7 +102,7 @@ def image_info(
     session: Session = Depends(get_db_session),
 ) -> ImageInfoResponse:
     """Return image metadata (dimensions, geotransform, CRS, filename)."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     return ImageInfoResponse(
         width=state.width,
         height=state.height,
@@ -109,7 +127,7 @@ def image_tile(
 
     At level *z* the image appears at resolution ``original / 2^(max_level - z)``.
     """
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     png_bytes = render_tile(
         image_path=state.geotiff_path,
         width=state.width,
@@ -131,7 +149,7 @@ def image_full(
     session: Session = Depends(get_db_session),
 ) -> Response:
     """Return the full image scaled to *max_size* as a PNG."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     png_bytes = render_full_image(image_path=state.geotiff_path, max_size=max_size)
     return Response(content=png_bytes, media_type="image/png")
 
@@ -149,7 +167,7 @@ def list_points(
     session: Session = Depends(get_db_session),
 ) -> PointListResponse:
     """List all GCPs for the tenant's map."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     return PointListResponse(
         map_id=state.registry.map_id,
         points=[
@@ -182,7 +200,7 @@ def add_point(
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
 
     tag = data.get("tag", "extra")
     pixel_x = float(data["pixel_x"])
@@ -217,7 +235,7 @@ def update_point(
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
 
     px = float(data["pixel_x"])
     py = float(data["pixel_y"])
@@ -245,7 +263,7 @@ def delete_point(
     session: Session = Depends(get_db_session),
 ) -> DeletePointResponse:
     """Delete a GCP."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
 
     if point_id not in state.registry.points:
         raise HTTPException(status_code=404, detail=f"Point not found: {point_id}")
@@ -269,7 +287,7 @@ def next_id(
     session: Session = Depends(get_db_session),
 ) -> NextIdResponse:
     """Return the next auto-incremented ID for a tag category."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     try:
         nid = state.get_next_id(tag)
         return NextIdResponse(tag=tag, next_id=nid)
@@ -287,7 +305,7 @@ def geo_coords(
     session: Session = Depends(get_db_session),
 ) -> GeoCoordsResponse:
     """Convert pixel coordinates to geographic coordinates."""
-    state = get_state(tenant_id, session, map_id=map_id)
+    state = _resolve_state(tenant_id, session, map_id)
     coords = state.get_geo_coords(pixel_x, pixel_y)
     if coords:
         return GeoCoordsResponse(

--- a/api/routers/point_picker.py
+++ b/api/routers/point_picker.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session  # noqa: TC002 - resolved at runtime by FastAPI
 
 from api.deps import get_current_user, get_db_session
 from api.schemas.point_picker import (
@@ -11,13 +13,22 @@ from api.schemas.point_picker import (
     DeletePointResponse,
     GeoCoordsResponse,
     ImageInfoResponse,
+    MapsListResponse,
+    MapSummaryOut,
     NextIdResponse,
     PointListResponse,
     PointOut,
     UpdatePointRequest,
 )
+from api.utils.frame_helpers import map_has_image
 from api.utils.tiles import render_full_image, render_tile
-from poc_homography.infrastructure.models.user import UserModel
+from poc_homography.infrastructure.models.user import (  # noqa: TC001 - resolved at runtime by FastAPI
+    UserModel,
+)
+from poc_homography.infrastructure.repositories import RepoPostgresMap
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.map import Map
 from webapp.point_picker.state import (
     delete_gcp_from_repo_pg,
     get_state,
@@ -36,6 +47,31 @@ from webapp.point_picker.validation import (
 router = APIRouter(prefix="/point-picker", tags=["point-picker"])
 
 # ---------------------------------------------------------------------------
+# Map selector
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/maps/", response_model=MapsListResponse)
+def list_maps(
+    tenant_id: str = Query(...),
+    user: UserModel = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> MapsListResponse:
+    """List the maps available for *tenant_id* with image-configured flags."""
+    maps = cast("dict[str, Map]", RepoPostgresMap(session).get_by_tenant(tenant_id))
+    summaries = [
+        MapSummaryOut(
+            id=m.id,
+            label=m.id,
+            image_configured=map_has_image(m),
+        )
+        for m in maps.values()
+    ]
+    summaries.sort(key=lambda s: s.id)
+    return MapsListResponse(maps=summaries)
+
+
+# ---------------------------------------------------------------------------
 # Image endpoints
 # ---------------------------------------------------------------------------
 
@@ -43,11 +79,12 @@ router = APIRouter(prefix="/point-picker", tags=["point-picker"])
 @router.get("/api/image/info/", response_model=ImageInfoResponse)
 def image_info(
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> ImageInfoResponse:
     """Return image metadata (dimensions, geotransform, CRS, filename)."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     return ImageInfoResponse(
         width=state.width,
         height=state.height,
@@ -60,6 +97,7 @@ def image_info(
 @router.get("/api/image/tile/")
 def image_tile(
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     x: int = Query(0),
     y: int = Query(0),
     z: int = Query(0),
@@ -71,12 +109,15 @@ def image_tile(
 
     At level *z* the image appears at resolution ``original / 2^(max_level - z)``.
     """
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     png_bytes = render_tile(
         image_path=state.geotiff_path,
         width=state.width,
         height=state.height,
-        x=x, y=y, z=z, size=size,
+        x=x,
+        y=y,
+        z=z,
+        size=size,
     )
     return Response(content=png_bytes, media_type="image/png")
 
@@ -84,12 +125,13 @@ def image_tile(
 @router.get("/api/image/full/")
 def image_full(
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     max_size: int = Query(2048, ge=1, le=8192),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> Response:
     """Return the full image scaled to *max_size* as a PNG."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     png_bytes = render_full_image(image_path=state.geotiff_path, max_size=max_size)
     return Response(content=png_bytes, media_type="image/png")
 
@@ -102,11 +144,12 @@ def image_full(
 @router.get("/api/points/", response_model=PointListResponse)
 def list_points(
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> PointListResponse:
     """List all GCPs for the tenant's map."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     return PointListResponse(
         map_id=state.registry.map_id,
         points=[
@@ -125,6 +168,7 @@ def list_points(
 def add_point(
     body: AddPointRequest,
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> PointOut:
@@ -138,7 +182,7 @@ def add_point(
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
 
     tag = data.get("tag", "extra")
     pixel_x = float(data["pixel_x"])
@@ -163,6 +207,7 @@ def update_point(
     point_id: str,
     body: UpdatePointRequest,
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> PointOut:
@@ -172,7 +217,7 @@ def update_point(
     if error:
         raise HTTPException(status_code=422, detail=error)
 
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
 
     px = float(data["pixel_x"])
     py = float(data["pixel_y"])
@@ -195,11 +240,12 @@ def update_point(
 def delete_point(
     point_id: str,
     tenant_id: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> DeletePointResponse:
     """Delete a GCP."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
 
     if point_id not in state.registry.points:
         raise HTTPException(status_code=404, detail=f"Point not found: {point_id}")
@@ -218,11 +264,12 @@ def delete_point(
 def next_id(
     tenant_id: str = Query(...),
     tag: str = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> NextIdResponse:
     """Return the next auto-incremented ID for a tag category."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     try:
         nid = state.get_next_id(tag)
         return NextIdResponse(tag=tag, next_id=nid)
@@ -235,11 +282,12 @@ def geo_coords(
     tenant_id: str = Query(...),
     pixel_x: float = Query(...),
     pixel_y: float = Query(...),
+    map_id: str | None = Query(None),
     user: UserModel = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> GeoCoordsResponse:
     """Convert pixel coordinates to geographic coordinates."""
-    state = get_state(tenant_id, session)
+    state = get_state(tenant_id, session, map_id=map_id)
     coords = state.get_geo_coords(pixel_x, pixel_y)
     if coords:
         return GeoCoordsResponse(

--- a/api/schemas/point_picker.py
+++ b/api/schemas/point_picker.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-
 # ---------------------------------------------------------------------------
 # Image info
 # ---------------------------------------------------------------------------
@@ -20,6 +19,25 @@ class ImageInfoResponse(BaseModel):
     geotransform: list[float] | None = None
     crs: str | None = None
     filename: str
+
+
+# ---------------------------------------------------------------------------
+# Maps
+# ---------------------------------------------------------------------------
+
+
+class MapSummaryOut(BaseModel):
+    """Summary of a single map for the map selector."""
+
+    id: str
+    label: str
+    image_configured: bool
+
+
+class MapsListResponse(BaseModel):
+    """Response for ``GET /api/maps/``."""
+
+    maps: list[MapSummaryOut]
 
 
 # ---------------------------------------------------------------------------

--- a/api/utils/frame_helpers.py
+++ b/api/utils/frame_helpers.py
@@ -47,7 +47,9 @@ __all__ = [
     "list_image_filenames",
     "load_annotations_for_frame",
     "load_line_annotations_for_frame",
+    "map_has_image",
     "normalize_array",
+    "resolve_map",
     "resolve_map_for_tenant",
     "save_annotations_for_frame",
     "validate_image_filename",
@@ -78,6 +80,45 @@ def resolve_map_for_tenant(tenant_id: str, session: Session) -> tuple[Map, Path]
         raise RuntimeError(f"Map asset not found for tenant: {tenant_id}")
 
     return map_entity, map_file
+
+
+def resolve_map(map_id: str, session: Session) -> tuple[Map, Path]:
+    """Resolve a specific ``Map`` and its image file by *map_id*.
+
+    The image is resolved via :func:`resolve_map_geotiff`, so object-storage
+    assets (``Map.asset_key``, see #292) are materialised the same way the
+    tile/info endpoints do; local-only maps fall back to ``data/maps``.
+
+    Raises:
+        LookupError: If no map with *map_id* exists.
+        RuntimeError: If the map's image asset is missing.
+    """
+    map_entity = RepoPostgresMap(session).get(map_id)
+    if map_entity is None:
+        raise LookupError(f"Map not found: {map_id}")
+
+    map_file = resolve_map_geotiff(map_entity)
+    if map_file is None:
+        raise RuntimeError(f"Map asset not found: {map_id}")
+
+    return map_entity, map_file
+
+
+def map_has_image(map_entity: Map) -> bool:
+    """Return ``True`` iff *map_entity* has a usable reference image.
+
+    A map is "configured" when it carries an object-storage asset key (#292)
+    or a local file under ``data/maps``. The asset-key branch is intentionally
+    cheap — it does not download the GeoTIFF — so listing many maps for the
+    selector never triggers per-map object-storage fetches.
+    """
+    if map_entity.asset_key:
+        return True
+    path = map_entity.photo.path
+    # An empty path normalises to ``Path(".")``; treat that as unconfigured.
+    if not str(path) or str(path) == ".":
+        return False
+    return (DATA_MAPS_DIR / path).is_file()
 
 
 def _frame_repo(session: Session) -> RepoPostgresCapturedFrame:

--- a/poc_homography/camera_config.py
+++ b/poc_homography/camera_config.py
@@ -156,14 +156,6 @@ CAMERAS = [
         # If None, uses linear focal length approximation
         # See CALIBRATION TABLE FORMAT documentation above for details
         "calibration_table": None,
-        # GeoTIFF reference parameters for georeferencing
-        # Updated to use GDAL 6-parameter GeoTransform format (Issue #133)
-        # GeoTransform: [origin_easting, pixel_width, row_rotation, origin_northing, col_rotation, pixel_height]
-        # For north-up rasters, row_rotation=0 and col_rotation=0
-        "geotiff_params": {
-            "geotransform": [737575.05, 0.15, 0, 4391595.45, 0, -0.15],
-            "utm_crs": "EPSG:25830",
-        },
         "description": "Valte Cam01 - primary camera",
     },
     {

--- a/poc_homography/camera_registry.py
+++ b/poc_homography/camera_registry.py
@@ -11,7 +11,7 @@ Design notes
   stores only *registration* data: ``id``, ``tenant_id``, ``map_id``, ``name``,
   ``spec``, ``credential`` (``{username, password}``) and ``ip_address``.  It does
   **not** store the rich calibration parameters (``k1``, ``k2``,
-  ``pan_offset_deg``, ``geotiff_params``, ``sensor_width_mm`` …) that homography
+  ``pan_offset_deg``, ``sensor_width_mm`` …) that homography
   and calibration consumers rely on.  Those still live in the hardcoded
   ``CAMERAS`` list.
 

--- a/spa/src/api/schema.d.ts
+++ b/spa/src/api/schema.d.ts
@@ -2046,6 +2046,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/point-picker/api/maps/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Maps
+         * @description List the maps available for *tenant_id* with image-configured flags.
+         */
+        get: operations["list_maps_point_picker_api_maps__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/point-picker/api/image/info/": {
         parameters: {
             query?: never;
@@ -2268,7 +2288,7 @@ export interface components {
         CalibrateAnnotatedLinesRequest: {
             /** Camera Line Annotations */
             camera_line_annotations: components["schemas"]["CameraLineAnnotationIn"][];
-            intrinsics: components["schemas"]["IntrinsicsIn"];
+            intrinsics: components["schemas"]["api__schemas__lens_calibration__IntrinsicsIn"];
             /**
              * Auto Intrinsics
              * @default false
@@ -2774,6 +2794,10 @@ export interface components {
          * @description Response for ``GET /api/geo-coords/``.
          */
         GeoCoordsResponse: {
+            /** Pixel X */
+            pixel_x: number;
+            /** Pixel Y */
+            pixel_y: number;
             /** Easting */
             easting?: number | null;
             /** Northing */
@@ -2880,32 +2904,10 @@ export interface components {
              * @default 1000
              */
             fy: number;
-            /**
-             * Cx
-             * @default 960
-             */
-            cx: number;
-            /**
-             * Cy
-             * @default 540
-             */
-            cy: number;
-            /**
-             * Image Width
-             * @default 1920
-             */
-            image_width: number;
-            /**
-             * Image Height
-             * @default 1080
-             */
-            image_height: number;
-            /** Sensor Width Mm */
-            sensor_width_mm?: number | null;
-            /** Base Focal Length Mm */
-            base_focal_length_mm?: number | null;
-            /** Zoom */
-            zoom?: number | null;
+            /** Cx */
+            cx?: number | null;
+            /** Cy */
+            cy?: number | null;
         };
         /**
          * IntrinsicsOut
@@ -2987,11 +2989,11 @@ export interface components {
             /** Map Id */
             map_id: string;
             /** Lines */
-            lines: components["schemas"]["api__schemas__line_picker__LineOut"][];
+            lines: components["schemas"]["LineOut"][];
         };
         /**
          * LineOut
-         * @description Single line in the registry.
+         * @description Single line serialisation.
          */
         LineOut: {
             /** Line Id */
@@ -3013,7 +3015,7 @@ export interface components {
             /** Map Id */
             map_id: string | null;
             /** Lines */
-            lines: components["schemas"]["LineOut"][];
+            lines: components["schemas"]["api__schemas__homography_precision__LineOut"][];
         };
         /**
          * LineTestCaseDetailResponse
@@ -3136,6 +3138,26 @@ export interface components {
             geotiff: components["schemas"]["GeoTiffOut"];
         };
         /**
+         * MapSummaryOut
+         * @description Summary of a single map for the map selector.
+         */
+        MapSummaryOut: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Image Configured */
+            image_configured: boolean;
+        };
+        /**
+         * MapsListResponse
+         * @description Response for ``GET /api/maps/``.
+         */
+        MapsListResponse: {
+            /** Maps */
+            maps: components["schemas"]["MapSummaryOut"][];
+        };
+        /**
          * MeasureStraightnessRequest
          * @description Body for ``POST /api/measure-straightness/``.
          */
@@ -3148,7 +3170,7 @@ export interface components {
              */
             undistort: boolean;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
+            intrinsics?: components["schemas"]["IntrinsicsIn"];
         };
         /**
          * NextIdResponse
@@ -3603,7 +3625,7 @@ export interface components {
              */
             direction: string;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
+            intrinsics?: components["schemas"]["IntrinsicsIn"];
         };
         /**
          * TransformPointsResponse
@@ -3623,7 +3645,7 @@ export interface components {
             /** Image Path */
             image_path: string;
             coefficients?: components["schemas"]["DistortionCoefficientsIn"];
-            intrinsics?: components["schemas"]["api__schemas__distortion_validator__IntrinsicsIn"];
+            intrinsics?: components["schemas"]["IntrinsicsIn"];
             /**
              * Use Opencv
              * @default false
@@ -3709,7 +3731,7 @@ export interface components {
          * @description Body for ``POST /api/validate/``.
          */
         ValidateRequest: {
-            intrinsics: components["schemas"]["IntrinsicsIn"];
+            intrinsics: components["schemas"]["api__schemas__lens_calibration__IntrinsicsIn"];
             coefficients?: components["schemas"]["DistortionCoefficients"];
             /** Lines */
             lines?: components["schemas"]["ValidationLineIn"][];
@@ -3809,26 +3831,6 @@ export interface components {
             camera_status: components["schemas"]["CameraStatusOut"];
         };
         /**
-         * IntrinsicsIn
-         * @description Camera intrinsic parameters.
-         */
-        api__schemas__distortion_validator__IntrinsicsIn: {
-            /**
-             * Fx
-             * @default 1000
-             */
-            fx: number;
-            /**
-             * Fy
-             * @default 1000
-             */
-            fy: number;
-            /** Cx */
-            cx?: number | null;
-            /** Cy */
-            cy?: number | null;
-        };
-        /**
          * LoadCalibrationRequest
          * @description Body for ``POST /api/load-calibration/``.
          */
@@ -3850,9 +3852,9 @@ export interface components {
         };
         /**
          * LineOut
-         * @description Single line serialisation.
+         * @description Single line in the registry.
          */
-        api__schemas__line_picker__LineOut: {
+        api__schemas__homography_precision__LineOut: {
             /** Line Id */
             line_id: string;
             /** Start X */
@@ -3865,14 +3867,52 @@ export interface components {
             end_y: number;
         };
         /**
+         * IntrinsicsIn
+         * @description Camera intrinsic parameters.
+         */
+        api__schemas__lens_calibration__IntrinsicsIn: {
+            /**
+             * Fx
+             * @default 1000
+             */
+            fx: number;
+            /**
+             * Fy
+             * @default 1000
+             */
+            fy: number;
+            /**
+             * Cx
+             * @default 960
+             */
+            cx: number;
+            /**
+             * Cy
+             * @default 540
+             */
+            cy: number;
+            /**
+             * Image Width
+             * @default 1920
+             */
+            image_width: number;
+            /**
+             * Image Height
+             * @default 1080
+             */
+            image_height: number;
+            /** Sensor Width Mm */
+            sensor_width_mm?: number | null;
+            /** Base Focal Length Mm */
+            base_focal_length_mm?: number | null;
+            /** Zoom */
+            zoom?: number | null;
+        };
+        /**
          * GeoCoordsResponse
          * @description Response for ``GET /api/geo-coords/``.
          */
-        api__schemas__point_picker__GeoCoordsResponse: {
-            /** Pixel X */
-            pixel_x: number;
-            /** Pixel Y */
-            pixel_y: number;
+        api__schemas__line_picker__GeoCoordsResponse: {
             /** Easting */
             easting?: number | null;
             /** Northing */
@@ -6944,7 +6984,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__schemas__line_picker__LineOut"];
+                    "application/json": components["schemas"]["LineOut"];
                 };
             };
             /** @description Validation Error */
@@ -6981,7 +7021,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__schemas__line_picker__LineOut"];
+                    "application/json": components["schemas"]["LineOut"];
                 };
             };
             /** @description Validation Error */
@@ -7078,7 +7118,38 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GeoCoordsResponse"];
+                    "application/json": components["schemas"]["api__schemas__line_picker__GeoCoordsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_maps_point_picker_api_maps__get: {
+        parameters: {
+            query: {
+                tenant_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MapsListResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7096,6 +7167,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -7127,6 +7199,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
                 x?: number;
                 y?: number;
                 z?: number;
@@ -7162,6 +7235,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
                 max_size?: number;
             };
             header?: never;
@@ -7194,6 +7268,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -7225,6 +7300,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -7260,6 +7336,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
             };
             header?: never;
             path: {
@@ -7297,6 +7374,7 @@ export interface operations {
         parameters: {
             query: {
                 tenant_id: string;
+                map_id?: string | null;
             };
             header?: never;
             path: {
@@ -7331,6 +7409,7 @@ export interface operations {
             query: {
                 tenant_id: string;
                 tag: string;
+                map_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -7364,6 +7443,7 @@ export interface operations {
                 tenant_id: string;
                 pixel_x: number;
                 pixel_y: number;
+                map_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -7377,7 +7457,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["api__schemas__point_picker__GeoCoordsResponse"];
+                    "application/json": components["schemas"]["GeoCoordsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/spa/src/pages/DashboardPage.tsx
+++ b/spa/src/pages/DashboardPage.tsx
@@ -22,10 +22,10 @@ const TOOL_CARDS: ToolCardDef[] = [
   },
   {
     to: '/point-picker',
-    title: 'Point Picker',
+    title: 'Map Points Capture Tool',
     badge: 'Primary',
     description:
-      'Pick and annotate points on high-resolution images. Supports tiled image viewing and coordinate export.',
+      'Capture and annotate map points on high-resolution site reference images. Supports per-site selection, tiled image viewing, and coordinate export.',
   },
   {
     to: '/homography-precision',

--- a/spa/src/pages/PointPickerPage.module.css
+++ b/spa/src/pages/PointPickerPage.module.css
@@ -173,10 +173,55 @@
   background: #cc0000;
 }
 
+/* --------------------------------------------------------- Site select */
+
+.mapSelect {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  background: white;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+/* Disabled tag buttons (unconfigured map) */
+.tagBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* -------------------------------------------------------------- Viewer */
 
 .viewer {
   flex: 1;
   background: #222;
   min-width: 0;
+}
+
+/* --------------------------------------------------- Not-configured panel */
+
+.notConfigured {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+  color: #fff;
+}
+
+.notConfiguredTitle {
+  font-size: 22px;
+  font-weight: 700;
+  color: #ffcc66;
+}
+
+.notConfiguredBody {
+  max-width: 480px;
+  margin-top: 12px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #ccc;
 }

--- a/spa/src/pages/PointPickerPage.tsx
+++ b/spa/src/pages/PointPickerPage.tsx
@@ -204,9 +204,13 @@ export default function PointPickerPage() {
 
   // -------------------------------------------------------- load points
   const loadPoints = useCallback(async () => {
+    const requestedMapId = selectedMapId;
     const { data } = await client.GET('/point-picker/api/points/', {
-      params: { query: { tenant_id: '', map_id: selectedMapId } },
+      params: { query: { tenant_id: '', map_id: requestedMapId } },
     });
+    // Drop a stale response if the selected map changed mid-flight, so a slow
+    // load for map A cannot overwrite the points already shown for map B.
+    if (requestedMapId !== selectedMapIdRef.current) return;
     if (data) {
       setPoints(data.points as PointData[]);
     }

--- a/spa/src/pages/PointPickerPage.tsx
+++ b/spa/src/pages/PointPickerPage.tsx
@@ -19,10 +19,13 @@ import {
 } from '../hooks/useOpenSeadragonDrag';
 import { useTenant } from '../contexts/TenantContext';
 import client from '../api/client';
+import type { components } from '../api/schema';
 
 import styles from './PointPickerPage.module.css';
 
 // ------------------------------------------------------------------ types
+
+type MapSummary = components['schemas']['MapSummaryOut'];
 
 interface PointData {
   id: string;
@@ -66,6 +69,8 @@ const TAG_ACTIVE_STYLE: Record<MarkerTag, string> = {
 export default function PointPickerPage() {
   const { selectedTenantId } = useTenant();
 
+  const [maps, setMaps] = useState<MapSummary[]>([]);
+  const [selectedMapId, setSelectedMapId] = useState<string | null>(null);
   const [imageInfo, setImageInfo] = useState<ImageInfo | null>(null);
   const [currentTag, setCurrentTag] = useState<MarkerTag>('parking_spot');
   const [nextId, setNextId] = useState<string>('');
@@ -84,6 +89,50 @@ export default function PointPickerPage() {
     selectedPointIdRef.current = selectedPointId;
   }, [selectedPointId]);
 
+  // Keep selectedMapId in a ref so overlay drag callbacks (memoised without
+  // selectedMapId in their deps) always persist against the current map.
+  const selectedMapIdRef = useRef(selectedMapId);
+  useEffect(() => {
+    selectedMapIdRef.current = selectedMapId;
+  }, [selectedMapId]);
+
+  // --------------------------------------------------- selected map state
+  const selectedMap = useMemo(
+    () => maps.find((m) => m.id === selectedMapId) ?? null,
+    [maps, selectedMapId],
+  );
+  const imageConfigured = selectedMap?.image_configured ?? false;
+
+  // ----------------------------------------------------------- load maps
+  // Fetch the maps available for the current tenant and pick a sensible
+  // default (the first image-configured map, else the first map).
+  useEffect(() => {
+    const controller = new AbortController();
+
+    (async () => {
+      if (!selectedTenantId) {
+        setMaps([]);
+        setSelectedMapId(null);
+        return;
+      }
+      const { data } = await client.GET('/point-picker/api/maps/', {
+        params: { query: { tenant_id: '' } },
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted || !data) return;
+      const list = data.maps;
+      setMaps(list);
+      const preferred = list.find((m) => m.image_configured) ?? list[0] ?? null;
+      setSelectedMapId(preferred ? preferred.id : null);
+    })().catch((err: unknown) => {
+      if (!controller.signal.aborted) {
+        console.error('Failed to load maps:', err);
+      }
+    });
+
+    return () => { controller.abort(); };
+  }, [selectedTenantId]);
+
   // ------------------------------------------------- fetch helpers (raw)
   // The openapi-fetch client auto-injects tenant_id and auth. We use it
   // for typed JSON endpoints. Tile URLs are bare strings for OSD.
@@ -91,21 +140,24 @@ export default function PointPickerPage() {
   const fetchNextId = useCallback(
     async (tag: MarkerTag) => {
       const { data } = await client.GET('/point-picker/api/points/next-id/', {
-        params: { query: { tag, tenant_id: '' } },
+        params: { query: { tag, tenant_id: '', map_id: selectedMapId } },
       });
       if (data) setNextId(data.next_id);
     },
-    [],
+    [selectedMapId],
   );
 
   // ----------------------------------------------------- load image info
   useEffect(() => {
-    if (!selectedTenantId) return;
     let cancelled = false;
 
     (async () => {
+      if (!selectedTenantId || !selectedMapId || !imageConfigured) {
+        setImageInfo(null);
+        return;
+      }
       const { data } = await client.GET('/point-picker/api/image/info/', {
-        params: { query: { tenant_id: '' } },
+        params: { query: { tenant_id: '', map_id: selectedMapId } },
       });
       if (cancelled || !data) return;
       setImageInfo({
@@ -117,14 +169,16 @@ export default function PointPickerPage() {
     })();
 
     return () => { cancelled = true; };
-  }, [selectedTenantId]);
+  }, [selectedTenantId, selectedMapId, imageConfigured]);
 
   // --------------------------------------------------------- tile source
   // Memoise so we only hand OSD a new object when tenant or image actually
   // change. The tile URL must embed tenant_id directly because OSD fetches
   // tiles via <img src>, not through the openapi-fetch client.
   const tileSource: TileSourceConfig | null = useMemo(() => {
-    if (!imageInfo || !selectedTenantId) return null;
+    if (!imageInfo || !selectedTenantId || !selectedMapId || !imageConfigured) {
+      return null;
+    }
     return {
       width: imageInfo.width,
       height: imageInfo.height,
@@ -135,11 +189,12 @@ export default function PointPickerPage() {
           y: String(y),
           z: String(level),
           tenant_id: selectedTenantId,
+          map_id: selectedMapId,
         });
         return `/point-picker/api/image/tile/?${params}`;
       },
     };
-  }, [imageInfo, selectedTenantId]);
+  }, [imageInfo, selectedTenantId, selectedMapId, imageConfigured]);
 
   // ------------------------------------------------- image dimensions ref
   const imageDims: ImageDimensions | null = useMemo(() => {
@@ -150,12 +205,12 @@ export default function PointPickerPage() {
   // -------------------------------------------------------- load points
   const loadPoints = useCallback(async () => {
     const { data } = await client.GET('/point-picker/api/points/', {
-      params: { query: { tenant_id: '' } },
+      params: { query: { tenant_id: '', map_id: selectedMapId } },
     });
     if (data) {
       setPoints(data.points as PointData[]);
     }
-  }, []);
+  }, [selectedMapId]);
 
   // -------------------------------------------------------- tag selection
   const handleSelectTag = useCallback(
@@ -168,9 +223,10 @@ export default function PointPickerPage() {
 
   // Initial tag fetch
   useEffect(() => {
-    if (selectedTenantId) fetchNextId(currentTag);
+    if (!selectedTenantId || !selectedMapId || !imageConfigured) return;
+    void (async () => { await fetchNextId(currentTag); })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTenantId]);
+  }, [selectedTenantId, selectedMapId, imageConfigured]);
 
   // ------------------------------------------------ marker management
 
@@ -257,7 +313,7 @@ export default function PointPickerPage() {
           // Persist move to server
           await client.PUT('/point-picker/api/points/{point_id}/', {
             params: {
-              query: { tenant_id: '' },
+              query: { tenant_id: '', map_id: selectedMapIdRef.current },
               path: { point_id: point.id },
             },
             body: { pixel_x: x, pixel_y: y },
@@ -343,22 +399,28 @@ export default function PointPickerPage() {
     }
   }, [points, imageDims, addOverlayMarker, removeOverlayMarker]);
 
-  // ----------------------------------------- load points when tenant ready
+  // ------------------------------------ load points when tenant/map ready
   useEffect(() => {
-    if (selectedTenantId) loadPoints();
-  }, [selectedTenantId, loadPoints]);
+    void (async () => {
+      if (selectedTenantId && selectedMapId && imageConfigured) {
+        await loadPoints();
+      } else {
+        setPoints([]);
+      }
+    })();
+  }, [selectedTenantId, selectedMapId, imageConfigured, loadPoints]);
 
   // --------------------------------------------------- add point on click
   const handleCanvasClick = useCallback(
     async (imageX: number, imageY: number) => {
       if (isDraggingRef.current) return;
-      if (!imageInfo) return;
+      if (!imageInfo || !imageConfigured) return;
       if (imageX < 0 || imageX >= imageInfo.width || imageY < 0 || imageY >= imageInfo.height) {
         return;
       }
 
       const { data } = await client.POST('/point-picker/api/points/', {
-        params: { query: { tenant_id: '' } },
+        params: { query: { tenant_id: '', map_id: selectedMapId } },
         body: { tag: currentTag, pixel_x: imageX, pixel_y: imageY },
       });
       if (data) {
@@ -367,7 +429,7 @@ export default function PointPickerPage() {
         fetchNextId(currentTag);
       }
     },
-    [imageInfo, currentTag, fetchNextId],
+    [imageInfo, imageConfigured, currentTag, fetchNextId, selectedMapId],
   );
 
   // -------------------------------------------- coordinate display on move
@@ -394,7 +456,12 @@ export default function PointPickerPage() {
         coordsTimerRef.current = setTimeout(async () => {
           const { data } = await client.GET('/point-picker/api/geo-coords/', {
             params: {
-              query: { tenant_id: '', pixel_x: imageX, pixel_y: imageY },
+              query: {
+                tenant_id: '',
+                map_id: selectedMapIdRef.current,
+                pixel_x: imageX,
+                pixel_y: imageY,
+              },
             },
           });
           if (data && data.easting != null && data.northing != null) {
@@ -422,7 +489,7 @@ export default function PointPickerPage() {
         '/point-picker/api/points/{point_id}/',
         {
           params: {
-            query: { tenant_id: '' },
+            query: { tenant_id: '', map_id: selectedMapId },
             path: { point_id: pointId },
           },
         },
@@ -433,7 +500,7 @@ export default function PointPickerPage() {
         fetchNextId(currentTag);
       }
     },
-    [selectedPointId, fetchNextId, currentTag],
+    [selectedPointId, fetchNextId, currentTag, selectedMapId],
   );
 
   // ---------------------------------------------------- click point in list
@@ -488,9 +555,28 @@ export default function PointPickerPage() {
         <Link to="/" className={styles.backLink}>
           &larr; Back to Tools
         </Link>
-        <h1 className={styles.title}>Point Picker</h1>
+        <h1 className={styles.title}>Map Points Capture Tool</h1>
 
-        {imageInfo && (
+        {/* Site / map selector */}
+        {maps.length > 0 && (
+          <div className={styles.section}>
+            <div className={styles.sectionTitle}>Site</div>
+            <select
+              className={styles.mapSelect}
+              value={selectedMapId ?? ''}
+              onChange={(e) => setSelectedMapId(e.target.value)}
+            >
+              {maps.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                  {m.image_configured ? '' : ' (no image)'}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {imageConfigured && imageInfo && (
           <div className={styles.filename}>{imageInfo.filename}</div>
         )}
 
@@ -511,6 +597,7 @@ export default function PointPickerPage() {
                   key={tag}
                   type="button"
                   className={cls}
+                  disabled={!imageConfigured}
                   onClick={() => handleSelectTag(tag)}
                 >
                   {TAG_LABELS[tag]}
@@ -528,55 +615,72 @@ export default function PointPickerPage() {
         </div>
 
         {/* Point list */}
-        <div className={styles.section}>
-          <div className={styles.sectionTitle}>Points</div>
-          <div className={styles.pointList}>
-            {points.map((pt) => {
-              const isSelected = pt.id === selectedPointId;
-              const cls = [
-                styles.pointItem,
-                isSelected ? styles.pointItemSelected : '',
-              ]
-                .filter(Boolean)
-                .join(' ');
-              return (
-                <div
-                  key={pt.id}
-                  className={cls}
-                  onClick={() => handlePointListClick(pt)}
-                >
-                  <span>
-                    {pt.id}: ({pt.pixel_x.toFixed(1)}, {pt.pixel_y.toFixed(1)})
-                  </span>
-                  <button
-                    type="button"
-                    className={styles.deleteBtn}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDeletePoint(pt.id);
-                    }}
+        {imageConfigured && (
+          <div className={styles.section}>
+            <div className={styles.sectionTitle}>Points</div>
+            <div className={styles.pointList}>
+              {points.map((pt) => {
+                const isSelected = pt.id === selectedPointId;
+                const cls = [
+                  styles.pointItem,
+                  isSelected ? styles.pointItemSelected : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+                return (
+                  <div
+                    key={pt.id}
+                    className={cls}
+                    onClick={() => handlePointListClick(pt)}
                   >
-                    X
-                  </button>
-                </div>
-              );
-            })}
+                    <span>
+                      {pt.id}: ({pt.pixel_x.toFixed(1)}, {pt.pixel_y.toFixed(1)})
+                    </span>
+                    <button
+                      type="button"
+                      className={styles.deleteBtn}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDeletePoint(pt.id);
+                      }}
+                    >
+                      X
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
-      {/* ----- Viewer ----- */}
-      {tileSource && (
-        <OpenSeadragonViewer
-          tileSource={tileSource}
-          onViewerReady={handleViewerReady}
-          onCanvasClick={handleCanvasClick}
-          onMouseMove={handleMouseMove}
-          className={styles.viewer}
-          showNavigator
-          minZoomLevel={0.5}
-          maxZoomLevel={20}
-        />
+      {/* ----- Viewer / unconfigured panel ----- */}
+      {imageConfigured ? (
+        tileSource && (
+          <OpenSeadragonViewer
+            tileSource={tileSource}
+            onViewerReady={handleViewerReady}
+            onCanvasClick={handleCanvasClick}
+            onMouseMove={handleMouseMove}
+            className={styles.viewer}
+            showNavigator
+            minZoomLevel={0.5}
+            maxZoomLevel={20}
+          />
+        )
+      ) : (
+        <div className={styles.viewer}>
+          <div className={styles.notConfigured}>
+            <div className={styles.notConfiguredTitle}>
+              &#9888; Image not configured for this site
+            </div>
+            <p className={styles.notConfiguredBody}>
+              The site &ldquo;{selectedMap?.label ?? ''}&rdquo; does not have a
+              reference image configured. Map point capture is disabled until an
+              image is added.
+            </p>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/spa/src/pages/PointPickerPage.tsx
+++ b/spa/src/pages/PointPickerPage.tsx
@@ -228,7 +228,11 @@ export default function PointPickerPage() {
   // Initial tag fetch
   useEffect(() => {
     if (!selectedTenantId || !selectedMapId || !imageConfigured) return;
-    void (async () => { await fetchNextId(currentTag); })();
+    // Wrapped in an async IIFE so the setState inside fetchNextId runs in a
+    // microtask, not synchronously in the effect body (react-hooks lint).
+    void (async () => {
+      await fetchNextId(currentTag);
+    })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTenantId, selectedMapId, imageConfigured]);
 
@@ -405,6 +409,8 @@ export default function PointPickerPage() {
 
   // ------------------------------------ load points when tenant/map ready
   useEffect(() => {
+    // Async IIFE keeps setState out of the synchronous effect body
+    // (react-hooks set-state-in-effect lint).
     void (async () => {
       if (selectedTenantId && selectedMapId && imageConfigured) {
         await loadPoints();

--- a/tests/homography/test_homography_precision.py
+++ b/tests/homography/test_homography_precision.py
@@ -22,16 +22,19 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pytest
 import yaml
 
-from poc_homography.camera_config import get_camera_by_name
-from poc_homography.homography.map_points import MapPointHomography
-from poc_homography.map_points import GCPRegistry
 from poc_homography.domain.vo import PixelPoint
+from poc_homography.homography.map_points import MapPointHomography
+from poc_homography.infrastructure.repositories import RepoYamlMap
+from poc_homography.map_points import GCPRegistry
+
+if TYPE_CHECKING:
+    from poc_homography.domain.entities.map import Map
 
 # =============================================================================
 # Test Data Paths - Update these to point to your test data
@@ -45,12 +48,25 @@ pytestmark = pytest.mark.skipif(
     reason="DVC test data not available (run 'poe dvc-pull')",
 )
 
-# Valte camera geotransform: 0.15 m/pixel in map space
-# GeoTransform: [origin_easting, pixel_width, row_rotation, origin_northing, col_rotation, pixel_height]
-VALTE_CONFIG = get_camera_by_name("Valte")
-MAP_METERS_PER_PIXEL = (
-    abs(VALTE_CONFIG["geotiff_params"]["geotransform"][1]) if VALTE_CONFIG else 0.15
-)
+# Valte map ground resolution: 0.15 m/pixel in map space.
+# The geotransform now lives on the Map entity (data/maps/*.yaml), not the
+# camera config. Read it from the Valte tenant's Map via RepoYamlMap.
+_DATA_MAPS_DIR = Path(__file__).parents[2] / "data" / "maps"
+
+
+def _valte_meters_per_pixel() -> float:
+    """Return abs(pixel_width) from the Valte Map, falling back to 0.15."""
+    try:
+        maps = RepoYamlMap(_DATA_MAPS_DIR).get_by_tenant("valte")
+    except (OSError, KeyError, ValueError):
+        return 0.15
+    if not maps:
+        return 0.15
+    valte_map = cast("Map", next(iter(maps.values())))
+    return abs(float(valte_map.geotiff.geotransform.pixel_width))
+
+
+MAP_METERS_PER_PIXEL = _valte_meters_per_pixel()
 
 
 # =============================================================================

--- a/tests/test_api/test_point_picker.py
+++ b/tests/test_api/test_point_picker.py
@@ -1,0 +1,143 @@
+"""Integration tests for the point-picker router (map selector + map_id forwarding)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from poc_homography.domain.entities.map import Map
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.domain.vo.photo import Photo
+from poc_homography.types import Easting, Meters, Northing, Pixels, Unitless
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Test data factories
+# ---------------------------------------------------------------------------
+
+
+def _make_map(mid: str = "acme-map", tenant_id: str = "acme") -> Map:
+    photo = Photo(path=Path("acme.tif"), width=Pixels(1024), height=Pixels(768))
+    geotransform = GeoTransform(
+        origin_easting=Easting(500_000.0),
+        pixel_width=Meters(0.1),
+        row_rotation=Unitless(0.0),
+        origin_northing=Northing(4_500_000.0),
+        col_rotation=Unitless(0.0),
+        pixel_height=Meters(-0.1),
+    )
+    geotiff = GeoTiff(geotransform=geotransform, crs="EPSG:25830")
+    return Map(id=mid, tenant_id=tenant_id, photo=photo, geotiff=geotiff)
+
+
+def _fake_state(width: int = 1000, height: int = 800) -> MagicMock:
+    """Return a minimal stand-in for ``PointPickerState``."""
+    state = MagicMock()
+    state.width = width
+    state.height = height
+    state.geotiff = None
+    state.geotiff_path = Path("acme.tif")
+    state.registry.map_id = "acme-map"
+    state.registry.points = {}
+    return state
+
+
+# ---------------------------------------------------------------------------
+# GET /point-picker/api/maps/
+# ---------------------------------------------------------------------------
+
+
+class TestListMaps:
+    """Tests for ``GET /point-picker/api/maps/``."""
+
+    @patch("api.routers.point_picker.map_has_image")
+    @patch("api.routers.point_picker.RepoPostgresMap")
+    def test_returns_maps_with_image_configured_flags(
+        self,
+        mock_repo_cls: object,
+        mock_has_image: object,
+        client: TestClient,
+    ) -> None:
+        configured = _make_map("map-configured", "acme")
+        unconfigured = _make_map("map-unconfigured", "acme")
+        mock_repo_cls.return_value.get_by_tenant.return_value = {  # type: ignore[union-attr]
+            "map-unconfigured": unconfigured,
+            "map-configured": configured,
+        }
+        # Configured map -> True, unconfigured -> False.
+        mock_has_image.side_effect = lambda m: m.id == "map-configured"  # type: ignore[union-attr]
+
+        resp = client.get("/point-picker/api/maps/", params={"tenant_id": "acme"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # Sorted by id for determinism.
+        assert [m["id"] for m in data["maps"]] == ["map-configured", "map-unconfigured"]
+        assert data["maps"][0] == {
+            "id": "map-configured",
+            "label": "map-configured",
+            "image_configured": True,
+        }
+        assert data["maps"][1]["image_configured"] is False
+
+    @patch("api.routers.point_picker.RepoPostgresMap")
+    def test_returns_empty_when_no_maps(self, mock_repo_cls: object, client: TestClient) -> None:
+        mock_repo_cls.return_value.get_by_tenant.return_value = {}  # type: ignore[union-attr]
+
+        resp = client.get("/point-picker/api/maps/", params={"tenant_id": "acme"})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"maps": []}
+
+    def test_requires_tenant_id(self, client: TestClient) -> None:
+        resp = client.get("/point-picker/api/maps/")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# map_id forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestMapIdForwarding:
+    """The image/points endpoints forward ``map_id`` to ``get_state``."""
+
+    @patch("api.routers.point_picker.get_state")
+    def test_image_info_forwards_map_id(self, mock_get_state: object, client: TestClient) -> None:
+        mock_get_state.return_value = _fake_state()  # type: ignore[union-attr]
+
+        resp = client.get(
+            "/point-picker/api/image/info/",
+            params={"tenant_id": "acme", "map_id": "map-7"},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_get_state.call_args  # type: ignore[union-attr]
+        assert kwargs["map_id"] == "map-7"
+
+    @patch("api.routers.point_picker.get_state")
+    def test_list_points_forwards_map_id(self, mock_get_state: object, client: TestClient) -> None:
+        mock_get_state.return_value = _fake_state()  # type: ignore[union-attr]
+
+        resp = client.get(
+            "/point-picker/api/points/",
+            params={"tenant_id": "acme", "map_id": "map-9"},
+        )
+
+        assert resp.status_code == 200
+        _, kwargs = mock_get_state.call_args  # type: ignore[union-attr]
+        assert kwargs["map_id"] == "map-9"
+
+    @patch("api.routers.point_picker.get_state")
+    def test_map_id_defaults_to_none(self, mock_get_state: object, client: TestClient) -> None:
+        mock_get_state.return_value = _fake_state()  # type: ignore[union-attr]
+
+        resp = client.get("/point-picker/api/points/", params={"tenant_id": "acme"})
+
+        assert resp.status_code == 200
+        _, kwargs = mock_get_state.call_args  # type: ignore[union-attr]
+        assert kwargs["map_id"] is None

--- a/tests/test_point_picker.py
+++ b/tests/test_point_picker.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -265,6 +265,123 @@ class TestPointPickerState:
         assert len(yaml_files) == 0
 
 
+class TestMapHasImage:
+    """Tests for ``api.utils.frame_helpers.map_has_image``."""
+
+    def _map_with_path(self, rel: str):
+        from poc_homography.domain.entities.map import Map
+        from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+        from poc_homography.domain.vo.photo import Photo
+        from poc_homography.types import Easting, Meters, Northing, Pixels, Unitless
+
+        photo = Photo(path=Path(rel), width=Pixels(10), height=Pixels(10))
+        geotiff = GeoTiff(
+            geotransform=GeoTransform(
+                origin_easting=Easting(0.0),
+                pixel_width=Meters(1.0),
+                row_rotation=Unitless(0.0),
+                origin_northing=Northing(0.0),
+                col_rotation=Unitless(0.0),
+                pixel_height=Meters(-1.0),
+            ),
+            crs="EPSG:25830",
+        )
+        return Map(id="m", tenant_id="t", photo=photo, geotiff=geotiff)
+
+    def test_true_when_file_exists(self, tmp_path: Path) -> None:
+        from api.utils import frame_helpers
+
+        img = tmp_path / "configured.tif"
+        img.touch()
+        m = self._map_with_path("configured.tif")
+        with patch.object(frame_helpers, "DATA_MAPS_DIR", tmp_path):
+            assert frame_helpers.map_has_image(m) is True
+
+    def test_false_when_file_missing(self, tmp_path: Path) -> None:
+        from api.utils import frame_helpers
+
+        m = self._map_with_path("absent.tif")
+        with patch.object(frame_helpers, "DATA_MAPS_DIR", tmp_path):
+            assert frame_helpers.map_has_image(m) is False
+
+    def test_false_when_path_empty(self, tmp_path: Path) -> None:
+        from api.utils import frame_helpers
+
+        m = self._map_with_path("")
+        with patch.object(frame_helpers, "DATA_MAPS_DIR", tmp_path):
+            assert frame_helpers.map_has_image(m) is False
+
+
+class TestGetStateMapId:
+    """Tests for the ``map_id`` selection path in ``get_state``."""
+
+    def test_distinct_map_ids_get_distinct_states(self, tmp_path: Path) -> None:
+        import point_picker.state as pp_state
+
+        from poc_homography.domain.entities.map import Map
+        from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+        from poc_homography.domain.vo.photo import Photo
+        from poc_homography.types import Easting, Meters, Northing, Pixels, Unitless
+
+        def _make(mid: str, rel: str) -> Map:
+            img = tmp_path / rel
+            img.touch()
+            photo = Photo(path=Path(rel), width=Pixels(20), height=Pixels(30))
+            geotiff = GeoTiff(
+                geotransform=GeoTransform(
+                    origin_easting=Easting(0.0),
+                    pixel_width=Meters(1.0),
+                    row_rotation=Unitless(0.0),
+                    origin_northing=Northing(0.0),
+                    col_rotation=Unitless(0.0),
+                    pixel_height=Meters(-1.0),
+                ),
+                crs="EPSG:25830",
+            )
+            return Map(id=mid, tenant_id="t", photo=photo, geotiff=geotiff)
+
+        maps = {"map-a": _make("map-a", "a.tif"), "map-b": _make("map-b", "b.tif")}
+        pp_state._states.clear()
+        pp_state._default_map_for_tenant.clear()
+
+        fake_repo = MagicMock()
+        fake_repo.get.side_effect = lambda mid: maps.get(mid)
+
+        with (
+            patch("homography_web.frame_utils.get_map_repo", return_value=fake_repo),
+            patch("homography_web.frame_utils.DATA_MAPS_DIR", tmp_path),
+            patch("point_picker.state.tifffile.TiffFile") as mock_tif,
+        ):
+            mock_tif.return_value = MockTiffFile()
+            state_a = pp_state.get_state("t", map_id="map-a")
+            state_b = pp_state.get_state("t", map_id="map-b")
+
+        assert state_a is not state_b
+        assert ("t", "map-a") in pp_state._states
+        assert ("t", "map-b") in pp_state._states
+        # Cached fast-path returns the same instance.
+        with patch("point_picker.state.tifffile.TiffFile") as mock_tif:
+            mock_tif.return_value = MockTiffFile()
+            assert pp_state.get_state("t", map_id="map-a") is state_a
+
+        pp_state._states.clear()
+        pp_state._default_map_for_tenant.clear()
+
+    def test_unknown_map_id_raises(self, tmp_path: Path) -> None:
+        import point_picker.state as pp_state
+
+        fake_repo = MagicMock()
+        fake_repo.get.return_value = None
+        pp_state._states.clear()
+        with (
+            patch("homography_web.frame_utils.get_map_repo", return_value=fake_repo),
+            patch("homography_web.frame_utils.DATA_MAPS_DIR", tmp_path),
+            pytest.raises(LookupError),
+        ):
+            pp_state.get_state("t", map_id="missing")
+        pp_state._states.clear()
+
+
 class TestPointPickerStateGeoCoords:
     """Tests for geographic coordinate conversion."""
 
@@ -357,8 +474,12 @@ class TestPointPickerAPI:
             mock_tif.return_value = MockTiffFile(width=1000, height=800)
             state = pp_state.PointPickerState(geotiff_path)
 
-        # Inject state for the test tenant, clean up after test
-        pp_state._states[self.TENANT_ID] = state
+        # Inject state for the test tenant, clean up after test.
+        # The cache is keyed by (tenant_id, map_id); register the default-map
+        # alias so get_state(tenant_id) with no explicit map_id hits this
+        # injected state instead of resolving a (nonexistent) map repo.
+        pp_state._states[(self.TENANT_ID, state.map_id)] = state
+        pp_state._default_map_for_tenant[self.TENANT_ID] = state.map_id
         # Bypass tenant repo validation and YAML persistence (test tenant has no repo dir)
         with (
             patch("point_picker.views.get_tenant_id", return_value=self.TENANT_ID),
@@ -366,7 +487,8 @@ class TestPointPickerAPI:
             patch("point_picker.views.delete_gcp_from_repo"),
         ):
             yield Client()
-        pp_state._states.pop(self.TENANT_ID, None)
+        pp_state._states.pop((self.TENANT_ID, state.map_id), None)
+        pp_state._default_map_for_tenant.pop(self.TENANT_ID, None)
 
     def _url(self, path: str, extra_qs: str = "") -> str:
         """Build URL with tenant_id query parameter."""

--- a/tests/test_point_picker.py
+++ b/tests/test_point_picker.py
@@ -342,7 +342,6 @@ class TestGetStateMapId:
 
         maps = {"map-a": _make("map-a", "a.tif"), "map-b": _make("map-b", "b.tif")}
         pp_state._states.clear()
-        pp_state._default_map_for_tenant.clear()
 
         fake_repo = MagicMock()
         fake_repo.get.side_effect = lambda mid: maps.get(mid)
@@ -365,7 +364,6 @@ class TestGetStateMapId:
             assert pp_state.get_state("t", map_id="map-a") is state_a
 
         pp_state._states.clear()
-        pp_state._default_map_for_tenant.clear()
 
     def test_unknown_map_id_raises(self, tmp_path: Path) -> None:
         import point_picker.state as pp_state
@@ -474,21 +472,26 @@ class TestPointPickerAPI:
             mock_tif.return_value = MockTiffFile(width=1000, height=800)
             state = pp_state.PointPickerState(geotiff_path)
 
-        # Inject state for the test tenant, clean up after test.
-        # The cache is keyed by (tenant_id, map_id); register the default-map
-        # alias so get_state(tenant_id) with no explicit map_id hits this
-        # injected state instead of resolving a (nonexistent) map repo.
+        # Inject state for the test tenant, clean up after test. The cache is
+        # keyed by (tenant_id, map_id); ``get_state(tenant_id)`` (no explicit
+        # map_id) resolves the tenant's default map then hits the cache, so we
+        # stub ``resolve_map_for_tenant`` to return a map whose id matches the
+        # injected key instead of touching a (nonexistent) map repo.
         pp_state._states[(self.TENANT_ID, state.map_id)] = state
-        pp_state._default_map_for_tenant[self.TENANT_ID] = state.map_id
+        default_map = MagicMock()
+        default_map.id = state.map_id
         # Bypass tenant repo validation and YAML persistence (test tenant has no repo dir)
         with (
+            patch(
+                "point_picker.state.resolve_map_for_tenant",
+                return_value=(default_map, geotiff_path),
+            ),
             patch("point_picker.views.get_tenant_id", return_value=self.TENANT_ID),
             patch("point_picker.views.save_gcp_to_repo"),
             patch("point_picker.views.delete_gcp_from_repo"),
         ):
             yield Client()
         pp_state._states.pop((self.TENANT_ID, state.map_id), None)
-        pp_state._default_map_for_tenant.pop(self.TENANT_ID, None)
 
     def _url(self, path: str, extra_qs: str = "") -> str:
         """Build URL with tenant_id query parameter."""

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -187,10 +187,6 @@ class PointPickerState:
 # Per-(tenant, map) state (lazily initialized)
 _states: dict[tuple[str, str], PointPickerState] = {}
 
-# Records, per tenant, which map id a ``map_id=None`` call resolved to, so the
-# default (no explicit map) path can reuse the cached state without re-resolving.
-_default_map_for_tenant: dict[str, str] = {}
-
 
 def get_state(
     tenant_id: str,
@@ -216,13 +212,14 @@ def get_state(
     # Fast path: an explicit, previously resolved (tenant, map) entry.
     if map_id is not None and (tenant_id, map_id) in _states:
         return _states[(tenant_id, map_id)]
-    # Fast path: the tenant's default map was resolved on a prior call.
-    if map_id is None:
-        cached_id = _default_map_for_tenant.get(tenant_id)
-        if cached_id is not None and (tenant_id, cached_id) in _states:
-            return _states[(tenant_id, cached_id)]
 
+    # Resolve the concrete map (a ``map_id=None`` call picks the tenant's
+    # default map), then key the cache by its real id — so the default path
+    # reuses the same cached state as an explicit call for that map.
     map_entity, map_file = _resolve_map(tenant_id, session, map_id)
+    key = (tenant_id, map_entity.id)
+    if key in _states:
+        return _states[key]
 
     state = PointPickerState(
         map_file,
@@ -237,16 +234,12 @@ def get_state(
         from poc_homography.map_points.gcp_registry import from_gcp_repo_pg
 
         state.registry = from_gcp_repo_pg(session, map_entity.id)
-        state.map_id = state.registry.map_id
     elif GCPS_DIR.exists():
         from poc_homography.map_points.gcp_registry import from_gcp_repo
 
         state.registry = from_gcp_repo(GCPS_DIR, map_entity.id)
-        state.map_id = state.registry.map_id
 
-    _states[(tenant_id, map_entity.id)] = state
-    if map_id is None:
-        _default_map_for_tenant[tenant_id] = map_entity.id
+    _states[key] = state
     return state
 
 
@@ -399,5 +392,4 @@ def delete_gcp_from_repo_pg(point_id: str, map_id: str, session: Session) -> Non
 
 
 register_invalidation_callback(_states.clear)
-register_invalidation_callback(_default_map_for_tenant.clear)
 register_invalidation_callback(_gcp_repo_cache.clear)

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -14,13 +14,15 @@ from homography_web.frame_utils import (
 )
 from PIL import Image
 
-from poc_homography.domain.vo.geotiff import GeoTiff
+from poc_homography.domain.vo.geotiff import GeoTiff  # noqa: TC001 - used at runtime
 from poc_homography.infrastructure.repositories import RepoYamlGroundControlPoint
 from poc_homography.map_points.gcp_registry import GCPRegistry
 from poc_homography.map_points.map_point import MapPoint
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+    from poc_homography.domain.entities.map import Map
 
 # Tag abbreviation mapping
 TAG_ABBREVIATIONS = {
@@ -182,33 +184,45 @@ class PointPickerState:
         return None
 
 
-# Per-tenant state (lazily initialized)
-_states: dict[str, PointPickerState] = {}
+# Per-(tenant, map) state (lazily initialized)
+_states: dict[tuple[str, str], PointPickerState] = {}
+
+# Records, per tenant, which map id a ``map_id=None`` call resolved to, so the
+# default (no explicit map) path can reuse the cached state without re-resolving.
+_default_map_for_tenant: dict[str, str] = {}
 
 
-def get_state(tenant_id: str, session: Session | None = None) -> PointPickerState:
-    """Get or lazily initialize state for a tenant.
+def get_state(
+    tenant_id: str,
+    session: Session | None = None,
+    map_id: str | None = None,
+) -> PointPickerState:
+    """Get or lazily initialize state for a tenant's map.
 
     Args:
         tenant_id: Tenant identifier.
         session: Optional SQLAlchemy session. When provided, GCPs are loaded
             from PostgreSQL instead of YAML files.
+        map_id: Optional specific map identifier. When ``None`` the tenant's
+            first configured map is resolved (backward-compatible behavior).
 
     Returns:
-        PointPickerState for the given tenant.
+        PointPickerState for the given (tenant, map).
 
     Raises:
         RuntimeError: If no map is configured for the tenant or map file not found.
+        LookupError: If *map_id* is provided but no such map exists.
     """
-    if tenant_id in _states:
-        return _states[tenant_id]
+    # Fast path: an explicit, previously resolved (tenant, map) entry.
+    if map_id is not None and (tenant_id, map_id) in _states:
+        return _states[(tenant_id, map_id)]
+    # Fast path: the tenant's default map was resolved on a prior call.
+    if map_id is None:
+        cached_id = _default_map_for_tenant.get(tenant_id)
+        if cached_id is not None and (tenant_id, cached_id) in _states:
+            return _states[(tenant_id, cached_id)]
 
-    if session is not None:
-        from api.utils.frame_helpers import resolve_map_for_tenant as resolve_pg
-
-        map_entity, map_file = resolve_pg(tenant_id, session)
-    else:
-        map_entity, map_file = resolve_map_for_tenant(tenant_id)
+    map_entity, map_file = _resolve_map(tenant_id, session, map_id)
 
     state = PointPickerState(
         map_file,
@@ -227,8 +241,34 @@ def get_state(tenant_id: str, session: Session | None = None) -> PointPickerStat
         state.registry = from_gcp_repo(GCPS_DIR, map_entity.id)
         state.map_id = state.registry.map_id
 
-    _states[tenant_id] = state
+    _states[(tenant_id, map_entity.id)] = state
+    if map_id is None:
+        _default_map_for_tenant[tenant_id] = map_entity.id
     return state
+
+
+def _resolve_map(
+    tenant_id: str,
+    session: Session | None,
+    map_id: str | None,
+) -> tuple[Map, Path]:
+    """Resolve the (Map, image-file) pair for *tenant_id*/*map_id*."""
+    if map_id is not None and session is not None:
+        from api.utils.frame_helpers import resolve_map as resolve_pg_by_id
+
+        return resolve_pg_by_id(map_id, session)
+    if map_id is not None:
+        from homography_web.frame_utils import DATA_MAPS_DIR, get_map_repo
+
+        map_entity = get_map_repo().get(map_id)
+        if map_entity is None:
+            raise LookupError(f"Map not found: {map_id}")
+        return map_entity, DATA_MAPS_DIR / map_entity.photo.path
+    if session is not None:
+        from api.utils.frame_helpers import resolve_map_for_tenant as resolve_pg
+
+        return resolve_pg(tenant_id, session)
+    return resolve_map_for_tenant(tenant_id)
 
 
 def get_tag_from_id(point_id: str) -> str:
@@ -356,4 +396,5 @@ def delete_gcp_from_repo_pg(point_id: str, map_id: str, session: Session) -> Non
 
 
 register_invalidation_callback(_states.clear)
+register_invalidation_callback(_default_map_for_tenant.clear)
 register_invalidation_callback(_gcp_repo_cache.clear)

--- a/webapp/point_picker/state.py
+++ b/webapp/point_picker/state.py
@@ -229,6 +229,9 @@ def get_state(
         width=int(map_entity.photo.width),
         height=int(map_entity.photo.height),
     )
+    # Anchor the state to the resolved map id rather than the image filename
+    # stem, so persistence (add/update/delete) always targets the right map.
+    state.map_id = map_entity.id
 
     if session is not None:
         from poc_homography.map_points.gcp_registry import from_gcp_repo_pg


### PR DESCRIPTION
Closes #170

Delivers issue #170 translated onto the current live stack (FastAPI `api/` + React `spa/` + DDD `poc_homography/`).

## Translation note (cf#705)
Issue #170 was authored against the old Django `webapp/gcp` "GCP Capture Tool" (Leaflet + per-site YAML + a new `Site` dataclass). That tool was since **deleted** (PR #184, unified dashboard) and **PR #171** — the original #170 implementation — was **closed as stale**. On the current stack the issue intent already maps onto existing concepts, so per maintainer direction this PR **translates** #170 rather than re-adding dead code:

- The **Site** concept = the existing **`Map`** entity (`poc_homography/domain/entities/map.py`: `id`, `tenant_id`, `photo`, `geotiff` geotransform+CRS). No new `Site` model.
- The **GCP Capture Tool** = the existing **`/point-picker`** tool, which already displays a map image and captures **pixel coordinates** (no `lat/lng*1e6` hack) persisted as MapPoints/GCPs. We **extend** it instead of building a parallel page.
- **Leaflet `imageOverlay`** → the codebase standard **OpenSeadragon** viewer (no new mapping dependency).
- **Per-site `data/map_points/{site}.yaml`** → existing per-GCP YAML / Postgres GCP storage (unchanged).

## What changed
**Backend**
- Removed `geotiff_params` from `valte_cam01` in `camera_config.py`; geotransform now lives on the `Map` entity. Updated `camera_registry.py` docstring and rewrote `test_homography_precision.py` to read pixel width from the Valte `Map` via `RepoYamlMap`.
- `api/utils/frame_helpers.py`: `resolve_map(map_id, session)` + `map_has_image(map)`.
- `webapp/point_picker/state.py`: `get_state(tenant_id, session, map_id=None)`, cache keyed by `(tenant_id, effective_map_id)`.
- `api/routers/point_picker.py`: new `GET /point-picker/api/maps/` (per-tenant maps + `image_configured` flag) and optional `map_id` threaded through every image/points endpoint. New schemas `MapSummaryOut`/`MapsListResponse`.

**Frontend**
- `PointPickerPage`: site/map selector, `map_id` on all calls, "Image not configured for this site" panel that disables capture for image-less maps, renamed to **"Map Points Capture Tool"**.
- `DashboardPage`: tool card renamed. Regenerated `schema.d.ts`.

> Note: the SPA is not built/linted by CI (`ci.yml` runs only `poe ci`); SPA changes were validated locally (tsc build + eslint clean on changed files).

## Test plan
- `uv run poe ci`: **1288 passed, 157 skipped** (skips are DVC/DB-gated).
- Hooks: ruff, ruff-format, pyright (0 errors), pylint (**8.93** ≥ 8.0), vulture — all pass.
- New `tests/test_api/test_point_picker.py` covers `/api/maps/` (configured/unconfigured/empty/missing-tenant) and `map_id` forwarding; state tests cover per-map cache + `map_has_image`.
- SPA: `npm run build` (tsc -b && vite build) succeeds; `npm run lint` clean on changed files.
- No remaining `geotiff_params` references in `poc_homography`/`api`/`webapp`/`tests`.

## DoD (translated)
- [x] Site model = existing `Map` entity (no fork)
- [x] No camera carries `geotiff_params`; geotransform routed via `Map`
- [x] Site/map selector dropdown on the capture tool
- [x] Selected map image shown via the OSD viewer (translation of `imageOverlay`)
- [x] Unconfigured map → "Image not configured for this site" + capture disabled
- [x] MapPoints loaded/saved per selected map (existing GCP storage)
- [x] All UI text says "Map Points Capture Tool"
