### PR TITLE
feat(capture): PTZ save/restore bracketing for capture sweeps

### DIFF
--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -22,6 +22,7 @@ from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
 from poc_homography.infrastructure.survey.capture_engine import SurveyCaptureEngine
 from poc_homography.survey.phases import executors
 from poc_homography.survey.planner.generators import fov_grid, partition_holdout
+from poc_homography.survey.ptz_bracketing import preserve_ptz_position
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -225,121 +226,124 @@ def execute_survey(
     results: list[PhaseResult] = []
     captured_4_to_7: list[CommandedState] = []
 
-    inventory = executors.run_inventory(camera, run_id=run_id, camera_id=camera_id, clock=now)
-    results.append(inventory)
+    # Bracket the whole camera-driving sweep: snapshot the pre-sweep PTZ
+    # position and restore it on normal completion, exception, or abort (#342).
+    with preserve_ptz_position(camera):
+        inventory = executors.run_inventory(camera, run_id=run_id, camera_id=camera_id, clock=now)
+        results.append(inventory)
 
-    results.append(
-        executors.run_ptz_characterization(
+        results.append(
+            executors.run_ptz_characterization(
+                engine,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.PTZ_CHARACTERIZATION),
+                pan_range=plan.ptz_pan_range,
+                tilt_range=plan.ptz_tilt_range,
+                small_step=plan.ptz_small_step,
+                large_step=plan.ptz_large_step,
+                fixed_tilt=plan.ptz_fixed_tilt,
+                fixed_pan=plan.ptz_fixed_pan,
+                fixed_zoom=plan.ptz_fixed_zoom,
+                repeat_count=plan.ptz_repeat_count,
+                burst_count=plan.burst_for(2),
+            )
+        )
+
+        results.append(
+            executors.run_zoom_characterization(
+                engine,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.ZOOM_CHARACTERIZATION),
+                zoom_min=plan.zoom_min,
+                zoom_max=plan.zoom_max,
+                zoom_step=plan.zoom_step,
+                fixed_pan=plan.zoom_fixed_pan,
+                fixed_tilt=plan.zoom_fixed_tilt,
+                burst_count=plan.burst_for(3),
+            )
+        )
+
+        nadir = executors.run_dense_nadir(
+            engine,
+            spec,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.DENSE_NADIR),
+            nadir_pan=plan.nadir_pan,
+            nadir_tilt=plan.nadir_tilt,
+            radius_deg=plan.nadir_radius_deg,
+            zoom=plan.nadir_zoom,
+            overlap_fraction=plan.nadir_overlap_fraction,
+            region_id=plan.nadir_region_id,
+            burst_count=plan.burst_for(4),
+        )
+        results.append(nadir)
+        captured_4_to_7.extend(nadir.commanded_states)
+
+        main = executors.run_main_survey(
+            engine,
+            training,
+            run_id=run_id,
+            camera_id=camera_id,
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
+            burst_count=plan.burst_for(5),
+        )
+        results.append(main)
+        captured_4_to_7.extend(main.commanded_states)
+
+        cross = executors.run_cross_zoom(
             engine,
             run_id=run_id,
             camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.PTZ_CHARACTERIZATION),
-            pan_range=plan.ptz_pan_range,
-            tilt_range=plan.ptz_tilt_range,
-            small_step=plan.ptz_small_step,
-            large_step=plan.ptz_large_step,
-            fixed_tilt=plan.ptz_fixed_tilt,
-            fixed_pan=plan.ptz_fixed_pan,
-            fixed_zoom=plan.ptz_fixed_zoom,
-            repeat_count=plan.ptz_repeat_count,
-            burst_count=plan.burst_for(2),
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
+            anchors=plan.cross_zoom_anchors,
+            zoom_levels=plan.cross_zoom_levels,
+            burst_count=plan.burst_for(6),
         )
-    )
+        results.append(cross)
+        captured_4_to_7.extend(cross.commanded_states)
 
-    results.append(
-        executors.run_zoom_characterization(
+        repeat = executors.run_repeatability(
             engine,
             run_id=run_id,
             camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.ZOOM_CHARACTERIZATION),
-            zoom_min=plan.zoom_min,
-            zoom_max=plan.zoom_max,
-            zoom_step=plan.zoom_step,
-            fixed_pan=plan.zoom_fixed_pan,
-            fixed_tilt=plan.zoom_fixed_tilt,
-            burst_count=plan.burst_for(3),
+            output_dir=_phase_dir(base_output_dir, SurveyPhase.REPEATABILITY),
+            target_pan=plan.repeat_target_pan,
+            target_tilt=plan.repeat_target_tilt,
+            target_zoom=plan.repeat_target_zoom,
+            approach_deltas=plan.repeat_approach_deltas,
+            burst_count=plan.burst_for(7),
         )
-    )
+        results.append(repeat)
+        captured_4_to_7.extend(repeat.commanded_states)
 
-    nadir = executors.run_dense_nadir(
-        engine,
-        spec,
-        run_id=run_id,
-        camera_id=camera_id,
-        output_dir=_phase_dir(base_output_dir, SurveyPhase.DENSE_NADIR),
-        nadir_pan=plan.nadir_pan,
-        nadir_tilt=plan.nadir_tilt,
-        radius_deg=plan.nadir_radius_deg,
-        zoom=plan.nadir_zoom,
-        overlap_fraction=plan.nadir_overlap_fraction,
-        region_id=plan.nadir_region_id,
-        burst_count=plan.burst_for(4),
-    )
-    results.append(nadir)
-    captured_4_to_7.extend(nadir.commanded_states)
-
-    main = executors.run_main_survey(
-        engine,
-        training,
-        run_id=run_id,
-        camera_id=camera_id,
-        output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
-        burst_count=plan.burst_for(5),
-    )
-    results.append(main)
-    captured_4_to_7.extend(main.commanded_states)
-
-    cross = executors.run_cross_zoom(
-        engine,
-        run_id=run_id,
-        camera_id=camera_id,
-        output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
-        anchors=plan.cross_zoom_anchors,
-        zoom_levels=plan.cross_zoom_levels,
-        burst_count=plan.burst_for(6),
-    )
-    results.append(cross)
-    captured_4_to_7.extend(cross.commanded_states)
-
-    repeat = executors.run_repeatability(
-        engine,
-        run_id=run_id,
-        camera_id=camera_id,
-        output_dir=_phase_dir(base_output_dir, SurveyPhase.REPEATABILITY),
-        target_pan=plan.repeat_target_pan,
-        target_tilt=plan.repeat_target_tilt,
-        target_zoom=plan.repeat_target_zoom,
-        approach_deltas=plan.repeat_approach_deltas,
-        burst_count=plan.burst_for(7),
-    )
-    results.append(repeat)
-    captured_4_to_7.extend(repeat.commanded_states)
-
-    results.append(
-        executors.run_jitter(
-            engine,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.STATIC_JITTER),
-            rtsp_url=plan.jitter_rtsp_url,
-            poses=plan.jitter_poses,
-            zoom_levels=plan.jitter_zoom_levels,
-            burst_duration_s=plan.jitter_burst_duration_s,
-            target_fps=plan.jitter_target_fps,
+        results.append(
+            executors.run_jitter(
+                engine,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.STATIC_JITTER),
+                rtsp_url=plan.jitter_rtsp_url,
+                poses=plan.jitter_poses,
+                zoom_levels=plan.jitter_zoom_levels,
+                burst_duration_s=plan.jitter_burst_duration_s,
+                target_fps=plan.jitter_target_fps,
+            )
         )
-    )
 
-    results.append(
-        executors.run_validation(
-            engine,
-            holdout,
-            captured_4_to_7,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
-            burst_count=plan.burst_for(9),
+        results.append(
+            executors.run_validation(
+                engine,
+                holdout,
+                captured_4_to_7,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
+                burst_count=plan.burst_for(9),
+            )
         )
-    )
 
     _emit(results, sink)
     _assert_no_cross_tagging(results)

--- a/poc_homography/survey/ptz_bracketing.py
+++ b/poc_homography/survey/ptz_bracketing.py
@@ -2,18 +2,21 @@
 
 A survey sweep repositions a PTZ camera across many poses but leaves it parked
 at the last commanded pose when it finishes. :func:`preserve_ptz_position`
-brackets a sweep so the camera is returned to exactly where it started — on
+brackets a sweep so the camera's original ``(pan, tilt, zoom)`` is restored — on
 normal completion *and* on exception or operator abort.
 
 This is a thin orchestration concern: it composes the existing
 :class:`~poc_homography.domain.protocols.camera_device.CameraDevice` surface
 (``get_ptz_status`` to snapshot, ``move_absolute`` to restore) and deliberately
 adds **no** new method to the Hikvision ISAPI adapter — the try/finally lives
-here, not in the client.
+here, not in the client. Restore is scoped to the three ``move_absolute`` axes
+``(pan, tilt, zoom)``; ``focus`` (which a sweep may also change) is intentionally
+out of scope, as ``move_absolute`` has no focus parameter.
 """
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -23,6 +26,8 @@ if TYPE_CHECKING:
     from poc_homography.domain.protocols.camera_device import CameraDevice
     from poc_homography.domain.vo.ptz_state import PTZState
 
+_logger = logging.getLogger(__name__)
+
 
 @contextmanager
 def preserve_ptz_position(camera: CameraDevice) -> Iterator[PTZState]:
@@ -31,7 +36,13 @@ def preserve_ptz_position(camera: CameraDevice) -> Iterator[PTZState]:
     On entry the current ``(pan, tilt, zoom)`` is read via
     :meth:`CameraDevice.get_ptz_status`. The position is restored via a single
     :meth:`CameraDevice.move_absolute` call in a ``finally`` block, so it runs
-    whether the wrapped sweep completes normally, raises, or is aborted.
+    whether the wrapped sweep completes normally, raises, or is aborted. Only
+    ``(pan, tilt, zoom)`` is restored; ``focus`` is out of scope.
+
+    If the wrapped block raises and the restore *also* fails, the original
+    sweep error is preserved (the restore failure is logged, not re-raised) so
+    the operator sees the root cause rather than a masking restore error. When
+    the block completes normally, a restore failure propagates.
 
     Args:
         camera: The PTZ device to bracket. Must satisfy :class:`CameraDevice`.
@@ -46,11 +57,22 @@ def preserve_ptz_position(camera: CameraDevice) -> Iterator[PTZState]:
             after the restore is attempted.
     """
     original = camera.get_ptz_status()
+    block_failed = False
     try:
         yield original
+    except BaseException:
+        block_failed = True
+        raise
     finally:
-        camera.move_absolute(
-            pan=original.pan_raw,
-            tilt=original.tilt_deg,
-            zoom=original.zoom,
-        )
+        try:
+            camera.move_absolute(
+                pan=original.pan_raw,
+                tilt=original.tilt_deg,
+                zoom=original.zoom,
+            )
+        except Exception:
+            if not block_failed:
+                raise
+            # A sweep error is already propagating; don't let the restore
+            # failure mask the root cause — record it and re-raise the original.
+            _logger.exception("PTZ restore failed during error/abort unwind")

--- a/poc_homography/survey/ptz_bracketing.py
+++ b/poc_homography/survey/ptz_bracketing.py
@@ -1,0 +1,56 @@
+"""PTZ save/restore bracketing for capture sweeps (#342).
+
+A survey sweep repositions a PTZ camera across many poses but leaves it parked
+at the last commanded pose when it finishes. :func:`preserve_ptz_position`
+brackets a sweep so the camera is returned to exactly where it started — on
+normal completion *and* on exception or operator abort.
+
+This is a thin orchestration concern: it composes the existing
+:class:`~poc_homography.domain.protocols.camera_device.CameraDevice` surface
+(``get_ptz_status`` to snapshot, ``move_absolute`` to restore) and deliberately
+adds **no** new method to the Hikvision ISAPI adapter — the try/finally lives
+here, not in the client.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from poc_homography.domain.protocols.camera_device import CameraDevice
+    from poc_homography.domain.vo.ptz_state import PTZState
+
+
+@contextmanager
+def preserve_ptz_position(camera: CameraDevice) -> Iterator[PTZState]:
+    """Snapshot the camera's PTZ position and restore it when the block exits.
+
+    On entry the current ``(pan, tilt, zoom)`` is read via
+    :meth:`CameraDevice.get_ptz_status`. The position is restored via a single
+    :meth:`CameraDevice.move_absolute` call in a ``finally`` block, so it runs
+    whether the wrapped sweep completes normally, raises, or is aborted.
+
+    Args:
+        camera: The PTZ device to bracket. Must satisfy :class:`CameraDevice`.
+
+    Yields:
+        The original :class:`PTZState` captured before the sweep, for callers
+        that want to inspect or log the parked position.
+
+    Raises:
+        CameraControllerError: If reading the original position fails (the
+            sweep never starts). Errors raised by the wrapped block propagate
+            after the restore is attempted.
+    """
+    original = camera.get_ptz_status()
+    try:
+        yield original
+    finally:
+        camera.move_absolute(
+            pan=original.pan_raw,
+            tilt=original.tilt_deg,
+            zoom=original.zoom,
+        )

--- a/tests/survey/conftest.py
+++ b/tests/survey/conftest.py
@@ -170,10 +170,14 @@ class FakeCamera:
             pan_raw=Degrees(1.0), tilt_deg=Degrees(-1.0), zoom=Unitless(2.0), focus=510
         )
 
+    def get_ptz_status(self) -> PTZState:
+        self.calls.append("get_ptz_status")
+        return self._reported
+
     def move_absolute(
         self, pan: float | None = None, tilt: float | None = None, zoom: float | None = None
     ) -> PTZState:
-        self.calls.append("move_absolute")
+        self.calls.append(f"move_absolute({pan},{tilt},{zoom})")
         return self._reported
 
     def set_focus(self, focus: int) -> None:

--- a/tests/survey/test_ptz_bracketing.py
+++ b/tests/survey/test_ptz_bracketing.py
@@ -78,3 +78,44 @@ def test_restores_original_position_on_exception() -> None:
 
     # Restore still ran exactly once despite the propagating exception.
     assert camera.absolute_moves == [(_ORIGINAL.pan_raw, _ORIGINAL.tilt_deg, _ORIGINAL.zoom)]
+
+
+def test_restore_failure_does_not_mask_sweep_error() -> None:
+    class _SweepAborted(RuntimeError):
+        """Stand-in for a mid-sweep failure or operator abort."""
+
+    class _RestoreFailingCamera(_RecordingCamera):
+        """A camera whose restore move also fails (e.g. lost connection)."""
+
+        def move_absolute(
+            self,
+            pan: float | None = None,
+            tilt: float | None = None,
+            zoom: float | None = None,
+        ) -> PTZState:
+            raise ConnectionError("camera unreachable during restore")
+
+    camera = _RestoreFailingCamera(_ORIGINAL)
+
+    # The original sweep error wins; the restore failure is logged, not raised.
+    with pytest.raises(_SweepAborted):
+        with preserve_ptz_position(camera):  # type: ignore[arg-type]
+            raise _SweepAborted("aborted mid-sweep")
+
+
+def test_restore_failure_propagates_on_normal_completion() -> None:
+    class _RestoreFailingCamera(_RecordingCamera):
+        def move_absolute(
+            self,
+            pan: float | None = None,
+            tilt: float | None = None,
+            zoom: float | None = None,
+        ) -> PTZState:
+            raise ConnectionError("camera unreachable during restore")
+
+    camera = _RestoreFailingCamera(_ORIGINAL)
+
+    # No sweep error to preserve, so a restore failure surfaces to the caller.
+    with pytest.raises(ConnectionError):
+        with preserve_ptz_position(camera):  # type: ignore[arg-type]
+            pass

--- a/tests/survey/test_ptz_bracketing.py
+++ b/tests/survey/test_ptz_bracketing.py
@@ -1,0 +1,80 @@
+"""Unit tests for the PTZ save/restore sweep bracketing (#342).
+
+A minimal recording :class:`CameraDevice` double asserts the exact pre-sweep
+``(pan, tilt, zoom)`` is re-issued via ``move_absolute`` exactly once, on both
+the normal-completion and the exception/abort paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from poc_homography.domain.vo.ptz_state import PTZState
+from poc_homography.survey.ptz_bracketing import preserve_ptz_position
+from poc_homography.types import Degrees, FocusSteps, Unitless
+
+_ORIGINAL = PTZState(
+    pan_raw=Degrees(42.5),
+    tilt_deg=Degrees(-17.0),
+    zoom=Unitless(8.0),
+    focus=FocusSteps(300),
+)
+
+
+class _RecordingCamera:
+    """A :class:`CameraDevice` double recording PTZ reads and absolute moves.
+
+    ``get_ptz_status`` answers a fixed original position; ``move_absolute``
+    records every ``(pan, tilt, zoom)`` it is asked to issue so the test can
+    assert the restore happened exactly once with the snapshotted values.
+    """
+
+    def __init__(self, original: PTZState) -> None:
+        self._original = original
+        self.status_reads = 0
+        self.absolute_moves: list[tuple[float | None, float | None, float | None]] = []
+
+    def get_ptz_status(self) -> PTZState:
+        self.status_reads += 1
+        return self._original
+
+    def move_absolute(
+        self,
+        pan: float | None = None,
+        tilt: float | None = None,
+        zoom: float | None = None,
+    ) -> PTZState:
+        self.absolute_moves.append((pan, tilt, zoom))
+        return self._original
+
+
+def test_restores_original_position_on_normal_completion() -> None:
+    camera = _RecordingCamera(_ORIGINAL)
+
+    with preserve_ptz_position(camera) as original:  # type: ignore[arg-type]
+        assert original == _ORIGINAL
+        # Simulate a sweep moving the camera elsewhere.
+        camera.move_absolute(pan=180.0, tilt=-80.0, zoom=1.0)
+
+    # Last move is the restore; the original (pan, tilt, zoom) is re-issued once.
+    assert camera.status_reads == 1
+    assert camera.absolute_moves[-1] == (
+        _ORIGINAL.pan_raw,
+        _ORIGINAL.tilt_deg,
+        _ORIGINAL.zoom,
+    )
+    assert camera.absolute_moves.count((_ORIGINAL.pan_raw, _ORIGINAL.tilt_deg, _ORIGINAL.zoom)) == 1
+
+
+def test_restores_original_position_on_exception() -> None:
+    camera = _RecordingCamera(_ORIGINAL)
+
+    class _SweepAborted(RuntimeError):
+        """Stand-in for a mid-sweep failure or operator abort."""
+
+    with pytest.raises(_SweepAborted):
+        with preserve_ptz_position(camera):  # type: ignore[arg-type]
+            raise _SweepAborted("aborted mid-sweep")
+
+    # Restore still ran exactly once despite the propagating exception.
+    assert camera.absolute_moves == [(_ORIGINAL.pan_raw, _ORIGINAL.tilt_deg, _ORIGINAL.zoom)]

--- a/tests/survey/test_runner.py
+++ b/tests/survey/test_runner.py
@@ -80,6 +80,21 @@ class TestExecuteSurvey:
         assert execution.run.phases == frozenset(_ALL_NINE)
         assert execution.run.status is SurveyRunStatus.COMPLETED
 
+    def test_sweep_restores_original_ptz_position(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        patch_rtsp,
+    ) -> None:
+        patch_rtsp(20)
+        _run(camera, clock, uuid_factory, _RecordingSink(), tmp_path)
+        # The sweep snapshots the pre-sweep PTZ once and the final move restores
+        # exactly that (pan, tilt, zoom) — the FakeCamera reports (1.0, -1.0, 2.0).
+        assert camera.calls.count("get_ptz_status") == 1
+        assert camera.calls[-1] == "move_absolute(1.0,-1.0,2.0)"
+
     def test_one_inventory_record(
         self,
         camera: FakeCamera,


### PR DESCRIPTION
Closes #342

## Summary

Adds preserve_ptz_position, a survey-layer context manager that snapshots a CameraDevice's PTZ position via get_ptz_status() before a sweep and restores it via a single move_absolute(pan,tilt,zoom) in a finally block — so the camera returns to its pre-sweep pose on normal completion, exception, or operator abort. Wired into execute_survey so the whole nine-phase sweep is bracketed. No new public method is added to HikvisionISAPIClient; restore stays a thin orchestration concern.

## Test plan

$- New unit tests (tests/survey/test_ptz_bracketing.py) assert the original (pan,tilt,zoom) is re-issued via move_absolute exactly once on both the success and the exception/abort paths.\n- New runner test (test_runner.py::test_sweep_restores_original_ptz_position) asserts execute_survey snapshots PTZ once and the final move restores the pre-sweep position.\n- uv run poe ci passes (lint, format-check, typecheck, pylint, vulture, 1322 passed / 157 skipped).

## Closes DoD bullets

- A reusable helper restores the exact pre-sweep (pan,tilt,zoom) after normal completion.
- Restore also runs on exception and on user abort (guaranteed via try/finally or context manager).
- Unit test with a fake CameraDevice asserts the original state is re-issued via move_absolute exactly once on both success and failure paths.
- No new public method added to HikvisionISAPIClient.
- poe ci passes.
