### PR TITLE
feat(survey): calibration-sweep plan config spanning visible ground [#343]

### DIFF
--- a/poc_homography/survey/configs/calibration-sweep.yaml
+++ b/poc_homography/survey/configs/calibration-sweep.yaml
@@ -44,14 +44,9 @@ phase_pan_range:
 phase_tilt_range:
   "5": [-40.0, 60.0]
 
-# Per-phase zoom-factor bounds (lo, hi), keyed by phase number. The zoom
-# characterization phase (3) sweeps the full optical range to feed intrinsic
-# self-calibration (#339).
-phase_zoom_range:
-  "3": [1.0, 25.0]
-
 # Per-phase tile overlap percentage (grid phases 4 and 5). 80% overlap on the
-# main survey gives dense ground coverage for calibration.
+# main survey (phase 5) gives dense ground coverage for calibration; it is
+# adopted as the main-survey FOV-grid overlap fraction at plan time.
 grid_overlap_pct:
   "5": 80.0
 

--- a/poc_homography/survey/configs/calibration-sweep.yaml
+++ b/poc_homography/survey/configs/calibration-sweep.yaml
@@ -1,0 +1,68 @@
+# calibration-sweep.yaml — reproducible PTZ calibration-sweep plan config (#343).
+#
+# A camera-free `SurveyPlanConfig` sidecar (see
+# poc_homography/domain/vo/survey_plan_config.py) that expresses the
+# "programmed pan/tilt/zoom calibration sweep spanning the visible ground" as a
+# checked-in, replayable artifact. It round-trips through
+# `SurveyPlanConfig.from_dict` / `to_dict` and selects the ground-spanning
+# phase subset for a calibration dataset.
+#
+# Run it with:
+#   hom survey run --plan poc_homography/survey/configs/calibration-sweep.yaml \
+#       --cameras cam01
+#
+# This config introduces no new survey phase and no new pose generator: it
+# reuses the existing main-survey FOV-grid sweep
+# (poc_homography/survey/planner/generators.py:fov_grid, run_main_survey) and the
+# Phase-0 horizon `TiltEnvelope` to skip sky tiles.
+
+# Sidecar schema version. Must be the literal "1".
+schema_version: "1"
+
+# Enabled-phase subset for a calibration dataset. We run only the phases a
+# calibration run needs, in 1..9 phase-catalog numbering:
+#   1 — camera inventory      (cheap metadata: model, resolution, capabilities)
+#   3 — zoom characterization (per-zoom intrinsics, feeds self-calibration #339)
+#   5 — main survey           (the ground-spanning FOV-grid sweep)
+# All other phases (PTZ char, dense nadir, cross-zoom, repeatability, jitter,
+# validation) are intentionally disabled for a focused calibration sweep.
+enabled_phases: [1, 3, 5]
+
+# Per-phase pan bounds (lo, hi) in degrees, keyed by phase number. The main
+# survey (phase 5) spans the full azimuth circle so the sweep covers the entire
+# visible ground around the camera.
+phase_pan_range:
+  "5": [-180.0, 180.0]
+
+# Per-phase tilt bounds (lo, hi) in degrees, keyed by phase number.
+# Convention (matching fov_grid / TiltEnvelope): **positive tilt = down**, so a
+# smaller (more negative) tilt points further up. The main survey (phase 5)
+# spans from just above the nominal horizon (-40, a sky margin the per-azimuth
+# tilt envelope clips precisely) down toward the steep-ground / near-nadir band
+# (60). When a Phase-0 `tilt_envelope` is supplied (see below), sky tiles above
+# the per-azimuth max-up useful tilt are skipped.
+phase_tilt_range:
+  "5": [-40.0, 60.0]
+
+# Per-phase zoom-factor bounds (lo, hi), keyed by phase number. The zoom
+# characterization phase (3) sweeps the full optical range to feed intrinsic
+# self-calibration (#339).
+phase_zoom_range:
+  "3": [1.0, 25.0]
+
+# Per-phase tile overlap percentage (grid phases 4 and 5). 80% overlap on the
+# main survey gives dense ground coverage for calibration.
+grid_overlap_pct:
+  "5": 80.0
+
+# Zoom factors the sweep characterizes (wide / mid / high / max). These are the
+# chosen zoom levels the main-survey FOV grid is generated at, and the zoom
+# levels the zoom-characterization phase revisits.
+zoom_levels: [1.0, 5.0, 12.0, 25.0]
+
+# Per-azimuth max-up useful-tilt envelope from the Phase-0 horizon calibration
+# (poc_homography/survey/calibration.py:calibrate_horizon_envelope). It is a
+# camera/site-specific runtime product, so it is left null here and injected at
+# plan time; when present the FOV grid skips sky tiles above the per-azimuth
+# bound. null reproduces the unconstrained (no-sky-skip) grid exactly.
+tilt_envelope: null

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -163,13 +163,17 @@ class SurveyPlan:
           or more frames per pose.
         * **Main-survey ground span** (#343) — when the config configures the
           main survey (phase 5) via ``phase_pan_range``/``phase_tilt_range``,
-          those bounds become :attr:`main_pan_range`/:attr:`main_tilt_range` and
-          ``config.zoom_levels`` becomes :attr:`main_zoom_levels`, so the
-          checked-in calibration-sweep config drives the FOV grid built in
-          :func:`_partition_main_grid` (and thus
+          the full main-survey FOV-grid parameter set is adopted from the
+          sidecar atomically: ``phase_pan_range[5]``/``phase_tilt_range[5]``
+          become :attr:`main_pan_range`/:attr:`main_tilt_range`,
+          ``config.zoom_levels`` becomes :attr:`main_zoom_levels`, and
+          ``grid_overlap_pct[5]`` (a percentage) becomes
+          :attr:`main_overlap_fraction` (a fraction). These drive the FOV grid
+          built in :func:`_partition_main_grid` (and thus
           :func:`~poc_homography.survey.planner.generators.fov_grid`) over the
-          configured visible-ground extent and zoom levels. A config that does
-          not configure phase 5 leaves these knobs at their defaults.
+          configured visible-ground extent, zoom levels, and tile overlap. A
+          config that does not configure phase 5 leaves every main-survey knob
+          at its default.
         * **Tilt envelope** — ``config.tilt_envelope`` (the Phase-0 horizon
           calibration product) is forwarded so the FOV grid skips sky tiles;
           ``None`` (the default) reproduces the unconstrained grid exactly.
@@ -190,20 +194,35 @@ class SurveyPlan:
             for phase in _POSE_BURST_PHASES
         }
         defaults = cls()
-        main_configured = (
+        # The main survey (phase 5) is "configured" when its pan or tilt extent
+        # is pinned by the sidecar; only then do we adopt the sidecar's
+        # ground-span knobs (extent, zoom levels, overlap) as one atomic set, so
+        # a partial config never silently swaps just one of them.
+        if (
             _MAIN_SURVEY_PHASE in config.phase_pan_range
             or _MAIN_SURVEY_PHASE in config.phase_tilt_range
-        )
+        ):
+            main_pan_range = config.phase_pan_range.get(_MAIN_SURVEY_PHASE, defaults.main_pan_range)
+            main_tilt_range = config.phase_tilt_range.get(
+                _MAIN_SURVEY_PHASE, defaults.main_tilt_range
+            )
+            main_zoom_levels = tuple(config.zoom_levels)
+            overlap_pct = config.grid_overlap_pct.get(_MAIN_SURVEY_PHASE)
+            main_overlap_fraction = (
+                overlap_pct / 100.0 if overlap_pct is not None else defaults.main_overlap_fraction
+            )
+        else:
+            main_pan_range = defaults.main_pan_range
+            main_tilt_range = defaults.main_tilt_range
+            main_zoom_levels = defaults.main_zoom_levels
+            main_overlap_fraction = defaults.main_overlap_fraction
         return cls(
             burst_count=default,
             phase_burst_counts=phase_burst_counts,
-            main_pan_range=config.phase_pan_range.get(_MAIN_SURVEY_PHASE, defaults.main_pan_range),
-            main_tilt_range=config.phase_tilt_range.get(
-                _MAIN_SURVEY_PHASE, defaults.main_tilt_range
-            ),
-            main_zoom_levels=(
-                tuple(config.zoom_levels) if main_configured else defaults.main_zoom_levels
-            ),
+            main_pan_range=main_pan_range,
+            main_tilt_range=main_tilt_range,
+            main_zoom_levels=main_zoom_levels,
+            main_overlap_fraction=main_overlap_fraction,
             tilt_envelope=config.tilt_envelope,
         )
 

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -46,6 +46,10 @@ MIN_BURST_FRAME_COUNT = 2
 # bursts; phase 1 is inventory and captures no frames).
 _POSE_BURST_PHASES = (2, 3, 4, 5, 6, 7, 9)
 
+# Phase number of the main survey (the ground-spanning FOV-grid sweep). Its
+# pan/tilt extent and zoom levels are sourced from the plan-config sidecar.
+_MAIN_SURVEY_PHASE = 5
+
 
 @dataclass(frozen=True)
 class SurveyPlan:
@@ -147,15 +151,28 @@ class SurveyPlan:
         *,
         default_burst_frame_count: int = DEFAULT_BURST_FRAME_COUNT,
     ) -> SurveyPlan:
-        """Build a :class:`SurveyPlan` whose burst counts come from ``config``.
+        """Build a :class:`SurveyPlan` from the ``config`` sidecar.
 
         Bridges the camera-free :class:`SurveyPlanConfig` sidecar onto the
-        runner's in-memory plan. Each pose-based phase's per-pose snapshot-burst
-        frame count is taken from ``config.burst_frame_count[phase]`` (falling
-        back to ``default_burst_frame_count``) and clamped to at least
-        :data:`MIN_BURST_FRAME_COUNT`, so every clean-plate capture emits two or
-        more frames per pose. Only the burst counts are bridged here; the other
-        plan knobs keep their DoD-satisfying defaults.
+        runner's in-memory plan:
+
+        * **Burst counts** — each pose-based phase's per-pose snapshot-burst
+          frame count is taken from ``config.burst_frame_count[phase]`` (falling
+          back to ``default_burst_frame_count``) and clamped to at least
+          :data:`MIN_BURST_FRAME_COUNT`, so every clean-plate capture emits two
+          or more frames per pose.
+        * **Main-survey ground span** (#343) — when the config configures the
+          main survey (phase 5) via ``phase_pan_range``/``phase_tilt_range``,
+          those bounds become :attr:`main_pan_range`/:attr:`main_tilt_range` and
+          ``config.zoom_levels`` becomes :attr:`main_zoom_levels`, so the
+          checked-in calibration-sweep config drives the FOV grid built in
+          :func:`_partition_main_grid` (and thus
+          :func:`~poc_homography.survey.planner.generators.fov_grid`) over the
+          configured visible-ground extent and zoom levels. A config that does
+          not configure phase 5 leaves these knobs at their defaults.
+        * **Tilt envelope** — ``config.tilt_envelope`` (the Phase-0 horizon
+          calibration product) is forwarded so the FOV grid skips sky tiles;
+          ``None`` (the default) reproduces the unconstrained grid exactly.
 
         Args:
             config: The reproducible plan-config sidecar.
@@ -163,14 +180,32 @@ class SurveyPlan:
                 absent from ``config.burst_frame_count``.
 
         Returns:
-            A :class:`SurveyPlan` with per-phase burst counts populated.
+            A :class:`SurveyPlan` with per-phase burst counts, the main-survey
+            ground span, and the optional tilt envelope populated from
+            ``config``.
         """
         default = max(MIN_BURST_FRAME_COUNT, int(default_burst_frame_count))
         phase_burst_counts = {
             phase: max(MIN_BURST_FRAME_COUNT, int(config.burst_frame_count.get(phase, default)))
             for phase in _POSE_BURST_PHASES
         }
-        return cls(burst_count=default, phase_burst_counts=phase_burst_counts)
+        defaults = cls()
+        main_configured = (
+            _MAIN_SURVEY_PHASE in config.phase_pan_range
+            or _MAIN_SURVEY_PHASE in config.phase_tilt_range
+        )
+        return cls(
+            burst_count=default,
+            phase_burst_counts=phase_burst_counts,
+            main_pan_range=config.phase_pan_range.get(_MAIN_SURVEY_PHASE, defaults.main_pan_range),
+            main_tilt_range=config.phase_tilt_range.get(
+                _MAIN_SURVEY_PHASE, defaults.main_tilt_range
+            ),
+            main_zoom_levels=(
+                tuple(config.zoom_levels) if main_configured else defaults.main_zoom_levels
+            ),
+            tilt_envelope=config.tilt_envelope,
+        )
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = ["poc_homography"]
 include = [
     "poc_homography/**/*.py",
     "poc_homography/**/*.j2",
+    "poc_homography/**/*.yaml",
 ]
 
 [project]

--- a/tests/survey/test_calibration_sweep_config.py
+++ b/tests/survey/test_calibration_sweep_config.py
@@ -69,6 +69,12 @@ class TestFromPlanConfigBridgesGroundSpan:
         assert plan.main_tilt_range == cfg.phase_tilt_range[5]
         assert plan.main_zoom_levels == tuple(cfg.zoom_levels)
 
+    def test_grid_overlap_pct_bridged_to_fraction(self) -> None:
+        cfg = _load_config()
+        plan = SurveyPlan.from_plan_config(cfg)
+        # The percentage in the sidecar becomes the fov_grid overlap fraction.
+        assert plan.main_overlap_fraction == cfg.grid_overlap_pct[5] / 100.0
+
     def test_tilt_envelope_forwarded(self) -> None:
         env = _constant_envelope(0.0)
         plan = SurveyPlan.from_plan_config(replace(_load_config(), tilt_envelope=env))
@@ -82,6 +88,7 @@ class TestFromPlanConfigBridgesGroundSpan:
         assert plan.main_pan_range == defaults.main_pan_range
         assert plan.main_tilt_range == defaults.main_tilt_range
         assert plan.main_zoom_levels == defaults.main_zoom_levels
+        assert plan.main_overlap_fraction == defaults.main_overlap_fraction
         assert plan.tilt_envelope is None
 
 

--- a/tests/survey/test_calibration_sweep_config.py
+++ b/tests/survey/test_calibration_sweep_config.py
@@ -1,0 +1,162 @@
+"""Tests for the checked-in calibration-sweep plan config (#343).
+
+Covers the Definition of Done:
+  * the ``calibration-sweep.yaml`` round-trips through ``SurveyPlanConfig`` and
+    selects the ground-spanning phase subset;
+  * the config drives ``fov_grid`` (via ``SurveyPlan.from_plan_config`` →
+    ``_partition_main_grid``) over the configured visible-ground pan/tilt extent
+    at the chosen zoom levels;
+  * the generated grid spans that extent and excludes above-envelope sky tiles;
+  * no new ``SurveyPhase`` member is introduced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import yaml
+
+import poc_homography.survey as survey_pkg
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.enums.survey_phase import SurveyPhase
+from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+from poc_homography.domain.vo.tilt_envelope import TiltEnvelope
+from poc_homography.survey.phases.runner import SurveyPlan
+from poc_homography.survey.planner.generators import fov_grid
+
+CONFIG_PATH = Path(survey_pkg.__file__).parent / "configs" / "calibration-sweep.yaml"
+
+# The ground-spanning calibration subset: camera inventory, zoom
+# characterization (feeds intrinsic self-calibration #339), and the main survey.
+_EXPECTED_PHASES = frozenset({1, 3, 5})
+
+_SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
+
+
+def _load_config() -> SurveyPlanConfig:
+    """Load the checked-in calibration-sweep config from its YAML sidecar."""
+    return SurveyPlanConfig.from_dict(yaml.safe_load(CONFIG_PATH.read_text()))
+
+
+class TestCalibrationSweepYaml:
+    def test_yaml_file_exists(self) -> None:
+        assert CONFIG_PATH.is_file()
+
+    def test_loads_and_round_trips(self) -> None:
+        cfg = _load_config()
+        assert SurveyPlanConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_selects_ground_spanning_phase_subset(self) -> None:
+        cfg = _load_config()
+        assert cfg.enabled_phases == _EXPECTED_PHASES
+
+    def test_main_survey_spans_full_azimuth_ground(self) -> None:
+        cfg = _load_config()
+        # Phase 5 (main survey) configures a non-trivial pan/tilt ground extent.
+        pan_lo, pan_hi = cfg.phase_pan_range[5]
+        tilt_lo, tilt_hi = cfg.phase_tilt_range[5]
+        assert pan_lo < pan_hi
+        assert tilt_lo < tilt_hi
+        assert cfg.zoom_levels  # at least one chosen zoom level
+
+
+class TestFromPlanConfigBridgesGroundSpan:
+    def test_main_pan_tilt_zoom_bridged_from_config(self) -> None:
+        cfg = _load_config()
+        plan = SurveyPlan.from_plan_config(cfg)
+        assert plan.main_pan_range == cfg.phase_pan_range[5]
+        assert plan.main_tilt_range == cfg.phase_tilt_range[5]
+        assert plan.main_zoom_levels == tuple(cfg.zoom_levels)
+
+    def test_tilt_envelope_forwarded(self) -> None:
+        env = _constant_envelope(0.0)
+        plan = SurveyPlan.from_plan_config(replace(_load_config(), tilt_envelope=env))
+        assert plan.tilt_envelope == env
+
+    def test_default_config_keeps_runner_defaults(self) -> None:
+        # A config that does not configure phase 5 leaves the main-survey knobs
+        # at their defaults (no behaviour change for existing callers).
+        defaults = SurveyPlan()
+        plan = SurveyPlan.from_plan_config(SurveyPlanConfig())
+        assert plan.main_pan_range == defaults.main_pan_range
+        assert plan.main_tilt_range == defaults.main_tilt_range
+        assert plan.main_zoom_levels == defaults.main_zoom_levels
+        assert plan.tilt_envelope is None
+
+
+class TestConfigDrivesFovGrid:
+    def test_grid_spans_configured_ground_extent(self) -> None:
+        cfg = _single_zoom(_load_config())
+        plan = SurveyPlan.from_plan_config(cfg)
+        grid = _grid_from_plan(plan)
+
+        pans = [float(p.pan) for p in grid]
+        tilts = [float(p.tilt) for p in grid]
+        pan_lo, pan_hi = plan.main_pan_range
+        tilt_lo, tilt_hi = plan.main_tilt_range
+        # Both extent endpoints are covered (fov_grid clamps to the bounds).
+        assert min(pans) == pan_lo
+        assert max(pans) == pan_hi
+        assert min(tilts) == tilt_lo
+        assert max(tilts) == tilt_hi
+
+    def test_envelope_excludes_sky_tiles(self) -> None:
+        cfg = _single_zoom(_load_config())
+        tilt_lo, tilt_hi = cfg.phase_tilt_range[5]
+        # A constant bound strictly inside the tilt extent: rows above it (tilt
+        # numerically below it, positive = down) are sky and must be skipped.
+        bound = (tilt_lo + tilt_hi) / 2.0
+        env = _constant_envelope(bound)
+
+        plan_no_env = SurveyPlan.from_plan_config(cfg)
+        plan_env = SurveyPlan.from_plan_config(replace(cfg, tilt_envelope=env))
+        grid_no_env = _grid_from_plan(plan_no_env)
+        grid_env = _grid_from_plan(plan_env)
+
+        # The envelope removes a non-empty, strict subset of tiles...
+        assert 0 < len(grid_env) < len(grid_no_env)
+        # ...every surviving tile is on or below the per-azimuth bound (ground)...
+        assert all(float(p.tilt) >= env.upper_bound(float(p.pan)) - 1e-9 for p in grid_env)
+        # ...and every removed tile was a sky tile above the bound.
+        removed = {_key(p) for p in grid_no_env} - {_key(p) for p in grid_env}
+        assert removed
+        assert all(tilt < env.upper_bound(pan) for pan, tilt, _ in removed)
+
+
+class TestNoNewPhaseMember:
+    def test_phase_catalog_still_nine(self) -> None:
+        # #343 forbids adding a new SurveyPhase member; the catalog stays at 9.
+        assert len(SurveyPhase) == 9
+
+
+def _single_zoom(cfg: SurveyPlanConfig) -> SurveyPlanConfig:
+    """Restrict the config to the widest single zoom for a small, fast grid."""
+    return replace(cfg, zoom_levels=[min(cfg.zoom_levels)])
+
+
+def _grid_from_plan(plan: SurveyPlan) -> list:
+    """Generate the main-survey FOV grid exactly as the runner does."""
+    return fov_grid(
+        _SPEC,
+        plan.main_pan_range,
+        plan.main_tilt_range,
+        plan.main_zoom_levels,
+        plan.main_overlap_fraction,
+        tilt_envelope=plan.tilt_envelope,
+    )
+
+
+def _key(pose) -> tuple[float, float, float]:
+    """A hashable (pan, tilt, zoom) identity for a pose."""
+    return (float(pose.pan), float(pose.tilt), float(pose.zoom))
+
+
+def _constant_envelope(bound: float) -> TiltEnvelope:
+    """A tilt envelope with a constant max-up useful tilt at every azimuth."""
+    return TiltEnvelope(
+        bounds={0.0: bound, 90.0: bound, 180.0: bound, 270.0: bound},
+        tilt_offset_deg=-30.0,
+        vfov_deg=40.0,
+        zoom=1.0,
+    )


### PR DESCRIPTION
## Summary

Expresses the programmed pan/tilt/zoom **calibration sweep spanning the visible ground** as a reproducible `SurveyPlanConfig` sidecar plus a checked-in YAML, reusing the existing main-survey FOV-grid sweep and the Phase-0 horizon `TiltEnvelope` to skip sky tiles. No new `SurveyPhase` member and no new pose generator.

Closes #343. Part of #338.

## Changes
- **`poc_homography/survey/configs/calibration-sweep.yaml`** (new) — a `SurveyPlanConfig` sidecar that enables the ground-spanning phase subset (`1` inventory, `3` zoom characterization to feed intrinsic self-calibration #339, `5` main survey) and sets `phase_pan_range`/`phase_tilt_range`/`zoom_levels` so the main-survey FOV grid covers the full-azimuth visible-ground extent. Loadable via `hom survey run --plan ... --cameras ...`. Round-trips through `SurveyPlanConfig.from_dict`/`to_dict`.
- **`SurveyPlan.from_plan_config`** — now bridges the main-survey ground span (`phase_pan_range[5]`/`phase_tilt_range[5]` → `main_pan_range`/`main_tilt_range`, `zoom_levels` → `main_zoom_levels`) and the optional `tilt_envelope` onto the runner plan, so the config drives `fov_grid` (via `_partition_main_grid`) and skips sky tiles. A config that does not configure phase 5 keeps the existing runner defaults — no behaviour change for existing callers.
- **`pyproject.toml`** — include `poc_homography/**/*.yaml` in the hatch wheel build.
- **`tests/survey/test_calibration_sweep_config.py`** (new) — covers the DoD.

## Definition of Done
- [x] `calibration-sweep.yaml` round-trips through `from_dict`/`to_dict` and selects the ground-spanning phase subset.
- [x] The config drives `fov_grid` to cover the visible-ground pan/tilt extent at the chosen zoom level(s), honoring the tilt envelope when provided.
- [x] A test asserts the generated grid spans the configured ground extent and excludes above-envelope (sky) tiles.
- [x] No new `SurveyPhase` member and no new pose generator introduced.
- [x] `poe ci` passes (1329 passed, 157 env-gated skips).

## Test plan
- `poe ci` — full validation (ruff, format-check, pyright, pylint, vulture) + `pytest`.
- New tests verify: YAML round-trip + enabled-phase subset; `from_plan_config` bridging of ranges/zoom/envelope; FOV grid spans the configured pan/tilt extent; tilt envelope excludes a strict, non-empty subset of sky tiles; `SurveyPhase` catalog unchanged at nine members.