### PR TITLE
feat(minio): frame byte readback + offline survey-frame loader [#348]

### DIFF
--- a/poc_homography/calibration/lens_distortion/frame_source.py
+++ b/poc_homography/calibration/lens_distortion/frame_source.py
@@ -6,7 +6,7 @@ MinIO (bucket ``cleanplate-frames``) and the *metadata* rows land in Postgres
 consumes: given a ``run_id``/``camera_id``, it enumerates the frame rows via
 :class:`RepoPostgresCleanPlateFrame`, downloads each image via
 :meth:`MinioFrameStore.get_frame`, decodes it with OpenCV, and yields the
-decoded frame together with the pan/tilt/zoom the camera was commanded to.
+decoded frame together with the zoom and tilt the camera was commanded to.
 
 Both the store and the repo are injected, so the loader runs fully offline in
 tests against fakes (no live MinIO, no live Postgres).
@@ -22,7 +22,7 @@ import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-# query_frames caps each page at this many rows; the loader paginates to drain
+# Default rows requested per query_frames page; the loader paginates to drain
 # the full run rather than silently stopping at the first page.
 _DEFAULT_PAGE_SIZE = 100
 

--- a/poc_homography/calibration/lens_distortion/frame_source.py
+++ b/poc_homography/calibration/lens_distortion/frame_source.py
@@ -1,0 +1,119 @@
+"""Offline survey-frame loader for lens-distortion calibration.
+
+The clean-plate sweep (#338) captures survey frames: the *image* bytes land in
+MinIO (bucket ``cleanplate-frames``) and the *metadata* rows land in Postgres
+(``clean_plate_frames``). This module is the read side that lens calibration
+consumes: given a ``run_id``/``camera_id``, it enumerates the frame rows via
+:class:`RepoPostgresCleanPlateFrame`, downloads each image via
+:meth:`MinioFrameStore.get_frame`, decodes it with OpenCV, and yields the
+decoded frame together with the pan/tilt/zoom the camera was commanded to.
+
+Both the store and the repo are injected, so the loader runs fully offline in
+tests against fakes (no live MinIO, no live Postgres).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple, Protocol
+
+import cv2
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# query_frames caps each page at this many rows; the loader paginates to drain
+# the full run rather than silently stopping at the first page.
+_DEFAULT_PAGE_SIZE = 100
+
+
+class SurveyFrame(NamedTuple):
+    """One decoded survey frame plus the zoom/tilt the camera was commanded to.
+
+    A plain tuple ``(image, commanded_zoom, commanded_tilt)`` for unpacking,
+    with named fields for clarity at the call site.
+    """
+
+    image: np.ndarray
+    commanded_zoom: float
+    commanded_tilt: float
+
+
+class FrameRow(Protocol):
+    """The subset of a clean-plate frame row this loader reads."""
+
+    minio_bucket: str
+    minio_object_key: str
+    commanded_zoom: float
+    commanded_tilt: float
+
+
+class FrameStore(Protocol):
+    """The byte-readback surface this loader needs from the frame store."""
+
+    def get_frame(self, key: str, *, bucket: str | None = None) -> bytes: ...
+
+
+class FrameRepo(Protocol):
+    """The query surface this loader needs from the frame repository."""
+
+    def query_frames(
+        self,
+        *,
+        run_id: str | None = ...,
+        camera_id: str | None = ...,
+        limit: int = ...,
+        offset: int = ...,
+    ) -> tuple[list[FrameRow], int]: ...
+
+
+def iter_survey_frames(
+    *,
+    run_id: str,
+    camera_id: str,
+    repo: FrameRepo,
+    store: FrameStore,
+    page_size: int = _DEFAULT_PAGE_SIZE,
+) -> Iterator[SurveyFrame]:
+    """Yield decoded survey frames for ``run_id``/``camera_id``, newest first.
+
+    Paginates ``repo.query_frames`` to drain every matching row, downloads each
+    image from the bucket recorded on the row, and decodes it as a BGR image.
+
+    Args:
+        run_id: Survey run to load frames for.
+        camera_id: Camera within the run to load frames for.
+        repo: Frame metadata repository (injected; offline-testable).
+        store: Frame byte store (injected; offline-testable).
+        page_size: Rows fetched per ``query_frames`` call.
+
+    Yields:
+        ``SurveyFrame(image, commanded_zoom, commanded_tilt)`` per stored frame.
+
+    Raises:
+        ValueError: If a downloaded object cannot be decoded as an image.
+    """
+    offset = 0
+    while True:
+        rows, total = repo.query_frames(
+            run_id=run_id, camera_id=camera_id, limit=page_size, offset=offset
+        )
+        if not rows:
+            break
+        for row in rows:
+            data = store.get_frame(row.minio_object_key, bucket=row.minio_bucket)
+            image = cv2.imdecode(np.frombuffer(data, dtype=np.uint8), cv2.IMREAD_COLOR)
+            if image is None:
+                msg = f"Failed to decode frame image at {row.minio_bucket}/{row.minio_object_key}"
+                raise ValueError(msg)
+            yield SurveyFrame(
+                image=image,
+                commanded_zoom=row.commanded_zoom,
+                commanded_tilt=row.commanded_tilt,
+            )
+        offset += len(rows)
+        if offset >= total:
+            break
+
+
+__all__ = ["FrameRepo", "FrameRow", "FrameStore", "SurveyFrame", "iter_survey_frames"]

--- a/poc_homography/infrastructure/clients/minio_frame_store.py
+++ b/poc_homography/infrastructure/clients/minio_frame_store.py
@@ -126,6 +126,19 @@ class MinioFrameStore:
         )
         return PutResult(bucket=self.bucket, key=key, sha256=sha256)
 
+    def get_frame(self, key: str, *, bucket: str | None = None) -> bytes:
+        """Download and return the raw frame-image bytes stored under ``key``.
+
+        ``bucket`` overrides the store's configured bucket so callers can read
+        against the bucket recorded on a frame row (the authoritative location
+        of that image), rather than assuming the store's env-configured bucket.
+        Used by the offline survey-frame loader to materialise frames for lens
+        calibration. Propagates whatever the underlying S3 client raises when
+        the object is absent (boto3 ``ClientError`` with code ``NoSuchKey``).
+        """
+        resp = self._client.get_object(Bucket=bucket or self.bucket, Key=key)
+        return resp["Body"].read()
+
     def presign_get(self, key: str, expires_in: int = 3600, *, bucket: str | None = None) -> str:
         """Return a presigned GET URL for ``key`` (used by the gallery).
 

--- a/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_clean_plate_frame.py
@@ -115,7 +115,10 @@ class RepoPostgresCleanPlateFrame:
         stmt = (
             select(model)
             .where(*conditions)
-            .order_by(model.captured_at.desc())
+            # ``id`` is a stable secondary key so pagination is deterministic when
+            # rows share a ``captured_at`` (burst frames, multi-camera) — without
+            # it, offset paging can skip or duplicate tied rows across pages.
+            .order_by(model.captured_at.desc(), model.id)
             .limit(limit)
             .offset(offset)
         )

--- a/tests/calibration/lens_distortion/test_frame_source.py
+++ b/tests/calibration/lens_distortion/test_frame_source.py
@@ -22,10 +22,12 @@ class FakeRow:
     minio_object_key: str
     commanded_zoom: float
     commanded_tilt: float
+    run_id: str = "run1"
+    camera_id: str = "cam1"
 
 
 class FakeRepo:
-    """Returns canned rows for the matching run/camera, with pagination."""
+    """Filters canned rows by run/camera and paginates, mirroring the repo."""
 
     def __init__(self, rows: list[FakeRow]) -> None:
         self._rows = rows
@@ -42,7 +44,13 @@ class FakeRepo:
         self.calls.append(
             {"run_id": run_id, "camera_id": camera_id, "limit": limit, "offset": offset}
         )
-        return self._rows[offset : offset + limit], len(self._rows)
+        matched = [
+            r
+            for r in self._rows
+            if (run_id is None or r.run_id == run_id)
+            and (camera_id is None or r.camera_id == camera_id)
+        ]
+        return matched[offset : offset + limit], len(matched)
 
 
 class FakeStore:
@@ -106,12 +114,56 @@ def test_iter_survey_frames_paginates_until_drained() -> None:
     repo = FakeRepo(rows)
 
     frames = list(
-        iter_survey_frames(run_id="r", camera_id="c", repo=repo, store=store, page_size=2)
+        iter_survey_frames(run_id="run1", camera_id="cam1", repo=repo, store=store, page_size=2)
     )
 
     assert [f.commanded_zoom for f in frames] == [0.0, 1.0, 2.0, 3.0, 4.0]
     # 3 pages of size 2 (2 + 2 + 1) drains 5 rows.
     assert [c["offset"] for c in repo.calls] == [0, 2, 4]
+
+
+def test_iter_survey_frames_filters_by_run_and_camera() -> None:
+    rows = [
+        FakeRow(
+            "b", "match.jpg", commanded_zoom=1.0, commanded_tilt=0.0, run_id="r1", camera_id="c1"
+        ),
+        FakeRow(
+            "b",
+            "other-run.jpg",
+            commanded_zoom=2.0,
+            commanded_tilt=0.0,
+            run_id="r2",
+            camera_id="c1",
+        ),
+        FakeRow(
+            "b",
+            "other-cam.jpg",
+            commanded_zoom=3.0,
+            commanded_tilt=0.0,
+            run_id="r1",
+            camera_id="c2",
+        ),
+    ]
+    store = FakeStore({("b", "match.jpg"): _jpeg_bytes((1, 1, 1))})
+    repo = FakeRepo(rows)
+
+    frames = list(iter_survey_frames(run_id="r1", camera_id="c1", repo=repo, store=store))
+
+    # Only the row matching both run_id and camera_id is yielded (and downloaded).
+    assert [f.commanded_zoom for f in frames] == [1.0]
+    assert store.reads == [("match.jpg", "b")]
+
+
+def test_iter_survey_frames_empty_run_yields_nothing() -> None:
+    repo = FakeRepo([])
+    store = FakeStore({})
+
+    frames = list(iter_survey_frames(run_id="absent", camera_id="cam1", repo=repo, store=store))
+
+    assert frames == []
+    # A single query that returns no rows terminates the drain (no store reads).
+    assert len(repo.calls) == 1
+    assert store.reads == []
 
 
 def test_iter_survey_frames_raises_on_undecodable_bytes() -> None:
@@ -120,4 +172,4 @@ def test_iter_survey_frames_raises_on_undecodable_bytes() -> None:
     repo = FakeRepo(rows)
 
     with pytest.raises(ValueError, match="Failed to decode"):
-        list(iter_survey_frames(run_id="r", camera_id="c", repo=repo, store=store))
+        list(iter_survey_frames(run_id="run1", camera_id="cam1", repo=repo, store=store))

--- a/tests/calibration/lens_distortion/test_frame_source.py
+++ b/tests/calibration/lens_distortion/test_frame_source.py
@@ -1,0 +1,123 @@
+"""Offline tests for the survey-frame loader (fake repo + fake store)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+import pytest
+
+from poc_homography.calibration.lens_distortion.frame_source import (
+    SurveyFrame,
+    iter_survey_frames,
+)
+
+
+@dataclass
+class FakeRow:
+    """A minimal stand-in for a ``CleanPlateFrameModel`` row."""
+
+    minio_bucket: str
+    minio_object_key: str
+    commanded_zoom: float
+    commanded_tilt: float
+
+
+class FakeRepo:
+    """Returns canned rows for the matching run/camera, with pagination."""
+
+    def __init__(self, rows: list[FakeRow]) -> None:
+        self._rows = rows
+        self.calls: list[dict] = []
+
+    def query_frames(
+        self,
+        *,
+        run_id: str | None = None,
+        camera_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> tuple[list[FakeRow], int]:
+        self.calls.append(
+            {"run_id": run_id, "camera_id": camera_id, "limit": limit, "offset": offset}
+        )
+        return self._rows[offset : offset + limit], len(self._rows)
+
+
+class FakeStore:
+    """Serves bytes from an in-memory ``(bucket, key) -> bytes`` map."""
+
+    def __init__(self, objects: dict[tuple[str, str], bytes]) -> None:
+        self._objects = objects
+        self.reads: list[tuple[str, str | None]] = []
+
+    def get_frame(self, key: str, *, bucket: str | None = None) -> bytes:
+        self.reads.append((key, bucket))
+        return self._objects[(bucket, key)]
+
+
+def _jpeg_bytes(color: tuple[int, int, int]) -> bytes:
+    """Encode a tiny solid-color BGR image to JPEG bytes."""
+    image = np.full((4, 6, 3), color, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", image)
+    assert ok
+    return buf.tobytes()
+
+
+def test_iter_survey_frames_yields_decoded_frames_with_zoom_tilt() -> None:
+    rows = [
+        FakeRow("frames-a", "run1/cam1/0.jpg", commanded_zoom=1.5, commanded_tilt=-10.0),
+        FakeRow("frames-b", "run1/cam1/1.jpg", commanded_zoom=2.0, commanded_tilt=-20.0),
+    ]
+    store = FakeStore(
+        {
+            ("frames-a", "run1/cam1/0.jpg"): _jpeg_bytes((10, 20, 30)),
+            ("frames-b", "run1/cam1/1.jpg"): _jpeg_bytes((40, 50, 60)),
+        }
+    )
+    repo = FakeRepo(rows)
+
+    frames = list(iter_survey_frames(run_id="run1", camera_id="cam1", repo=repo, store=store))
+
+    assert len(frames) == 2
+    assert all(isinstance(f, SurveyFrame) for f in frames)
+    # Decoded numpy images of the expected shape.
+    assert frames[0].image.shape == (4, 6, 3)
+    assert frames[1].image.shape == (4, 6, 3)
+    # Zoom/tilt carried through from the rows.
+    assert (frames[0].commanded_zoom, frames[0].commanded_tilt) == (1.5, -10.0)
+    assert (frames[1].commanded_zoom, frames[1].commanded_tilt) == (2.0, -20.0)
+    # Each image was read from the bucket recorded on its own row.
+    assert store.reads == [
+        ("run1/cam1/0.jpg", "frames-a"),
+        ("run1/cam1/1.jpg", "frames-b"),
+    ]
+    # The repo was filtered by the requested run/camera.
+    assert repo.calls[0]["run_id"] == "run1"
+    assert repo.calls[0]["camera_id"] == "cam1"
+
+
+def test_iter_survey_frames_paginates_until_drained() -> None:
+    rows = [
+        FakeRow("b", f"k{i}.jpg", commanded_zoom=float(i), commanded_tilt=0.0) for i in range(5)
+    ]
+    store = FakeStore({("b", f"k{i}.jpg"): _jpeg_bytes((i, i, i)) for i in range(5)})
+    repo = FakeRepo(rows)
+
+    frames = list(
+        iter_survey_frames(run_id="r", camera_id="c", repo=repo, store=store, page_size=2)
+    )
+
+    assert [f.commanded_zoom for f in frames] == [0.0, 1.0, 2.0, 3.0, 4.0]
+    # 3 pages of size 2 (2 + 2 + 1) drains 5 rows.
+    assert [c["offset"] for c in repo.calls] == [0, 2, 4]
+
+
+def test_iter_survey_frames_raises_on_undecodable_bytes() -> None:
+    rows = [FakeRow("b", "bad.jpg", commanded_zoom=1.0, commanded_tilt=0.0)]
+    store = FakeStore({("b", "bad.jpg"): b"not an image"})
+    repo = FakeRepo(rows)
+
+    with pytest.raises(ValueError, match="Failed to decode"):
+        list(iter_survey_frames(run_id="r", camera_id="c", repo=repo, store=store))

--- a/tests/infrastructure/test_minio_frame_store.py
+++ b/tests/infrastructure/test_minio_frame_store.py
@@ -21,6 +21,7 @@ class FakeS3:
         self.puts: list[dict] = []
         self.created: list[str] = []
         self.heads: list[str] = []
+        self.objects: dict[tuple[str, str], bytes] = {}
 
     def head_bucket(self, Bucket: str) -> None:
         self.heads.append(Bucket)
@@ -32,9 +33,27 @@ class FakeS3:
 
     def put_object(self, **kwargs: object) -> None:
         self.puts.append(kwargs)
+        self.objects[(kwargs["Bucket"], kwargs["Key"])] = kwargs["Body"]
+
+    def get_object(self, Bucket: str, Key: str) -> dict:
+        try:
+            data = self.objects[(Bucket, Key)]
+        except KeyError as exc:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject") from exc
+        return {"Body": _Body(data)}
 
     def generate_presigned_url(self, op: str, Params: dict, ExpiresIn: int) -> str:
         return f"https://minio/{op}/{Params['Bucket']}/{Params['Key']}?e={ExpiresIn}"
+
+
+class _Body:
+    """Minimal stand-in for a boto3 streaming body (``.read()``)."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
 
 
 def _store(client: FakeS3, bucket: str = "cleanplate-frames") -> MinioFrameStore:
@@ -76,6 +95,31 @@ def test_ensure_bucket_noop_when_present() -> None:
     client = FakeS3(head_missing=False)
     _store(client).ensure_bucket()
     assert client.created == []
+
+
+def test_get_frame_round_trips_put_bytes() -> None:
+    client = FakeS3()
+    store = _store(client)
+    data = b"\xff\xd8\xff jpeg bytes"
+    store.put_frame(data, "run1/main/p1/cap1.jpg")
+
+    assert store.get_frame("run1/main/p1/cap1.jpg") == data
+
+
+def test_get_frame_bucket_override_reads_from_named_bucket() -> None:
+    client = FakeS3()
+    # Store configured for one bucket; the frame lives in another.
+    store = _store(client, bucket="store-default")
+    data = b"\x89PNG other-bucket bytes"
+    client.objects[("frame-bucket", "run9/cap9.jpg")] = data
+
+    assert store.get_frame("run9/cap9.jpg", bucket="frame-bucket") == data
+
+
+def test_get_frame_missing_raises_client_error() -> None:
+    store = _store(FakeS3())
+    with pytest.raises(ClientError):
+        store.get_frame("nope.jpg")
 
 
 def test_presign_get_delegates_to_client() -> None:


### PR DESCRIPTION
## Summary

Add the missing plumbing to consume #338 sweep frames offline. (1) MinioFrameStore.get_frame(key, *, bucket=None) -> bytes mirrors the minio_map_store.get_map pattern (with a bucket override so callers read the bucket recorded on a frame row). (2) A new offline survey-frame loader (calibration/lens_distortion/frame_source.py) enumerates rows via RepoPostgresCleanPlateFrame.query_frames, downloads each image via get_frame, decodes with cv2.imdecode, and yields SurveyFrame(image, commanded_zoom, commanded_tilt). Store and repo are injected (Protocols) so it runs fully offline. No new table — reuses clean_plate_frames.

## Test plan

poe ci passes locally (1342 passed, 157 skipped). New: round-trip test for get_frame (put_frame -> get_frame returns exact bytes, incl. bucket override and NoSuchKey propagation) with a fake S3 client; loader tests with fake repo + fake store covering decoded frames + zoom/tilt carry-through, pagination drain, and undecodable-bytes error — all offline, no live MinIO/Postgres.

## Closes DoD bullets

- MinioFrameStore.get_frame returns the exact bytes a prior put_frame stored (round-trip test with injected fake S3 — no live MinIO).
- Loader yields decoded numpy frames + zoom/tilt from injected fake repo + fake store — fully offline.
- poe ci passes.
