### PR TITLE
feat(calib): per-zoom scene self-calibration service (K(zoom)+distortion) [#350]

### DIFF
--- a/poc_homography/calibration/lens_distortion/__init__.py
+++ b/poc_homography/calibration/lens_distortion/__init__.py
@@ -51,6 +51,13 @@ from poc_homography.calibration.lens_distortion.models import (
     GroundTruthLine,
     LineCorrespondence,
 )
+from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+    SceneCalibrationResult,
+    ScenePerZoomConfig,
+    SkippedZoom,
+    calibrate_scene_self,
+    calibrate_zoom_from_lines,
+)
 
 __all__ = [
     # Models
@@ -80,4 +87,10 @@ __all__ = [
     "undistort_points",
     "undistort_image",
     "measure_line_straightness",
+    # Scene self-calibration (#350)
+    "SceneCalibrationResult",
+    "ScenePerZoomConfig",
+    "SkippedZoom",
+    "calibrate_scene_self",
+    "calibrate_zoom_from_lines",
 ]

--- a/poc_homography/calibration/lens_distortion/scene_self_calibration.py
+++ b/poc_homography/calibration/lens_distortion/scene_self_calibration.py
@@ -1,0 +1,261 @@
+"""Per-zoom scene self-calibration service.
+
+This service seeds a prior camera intrinsic matrix ``K`` from camera-spec
+defaults (per zoom group), detects floor lines, jointly refines lens
+distortion plus intrinsics off that prior using the *existing*
+:class:`DistortionSolver`, and assembles one calibration entry per zoom into a
+:class:`LensCalibrationTable`.
+
+It reuses the existing solver, the domain-VO calibration entry/table, and the
+YAML persistence layer. No new solver, table, or persistence is introduced.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from poc_homography.calibration.lens_distortion.distortion_solver import (
+    DistortionSolver,
+    SolverConfig,
+)
+from poc_homography.calibration.lens_distortion.line_detection import LineDetector
+from poc_homography.calibration.lens_distortion.models import PTZPosition
+from poc_homography.camera.intrinsics import compute_intrinsics
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+from poc_homography.types import Degrees, PixelsFloat, Unitless
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from poc_homography.calibration.lens_distortion.models import CameraLine
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScenePerZoomConfig:
+    """Tunable knobs for per-zoom scene self-calibration.
+
+    Attributes:
+        min_lines: Minimum usable (curved) lines required to calibrate a zoom.
+        max_lines_per_image: Cap on candidate lines kept per detected image.
+        fx_refine_frac: Fractional window (+/-) around the prior fx/fy.
+        cx_window_px: Half-window (pixels) around the prior cx.
+        cy_window_px: Half-window (pixels) around the prior cy.
+        num_samples_per_line: Points sampled along each line by the solver.
+        max_iterations: Maximum solver optimisation iterations.
+        zoom_tolerance: Rounding tolerance used to group images by zoom.
+    """
+
+    min_lines: int = 3
+    max_lines_per_image: int = 20
+    fx_refine_frac: float = 0.05
+    cx_window_px: float = 10.0
+    cy_window_px: float = 10.0
+    num_samples_per_line: int = 30
+    max_iterations: int = 3000
+    zoom_tolerance: float = 0.1
+
+
+@dataclass(frozen=True)
+class SkippedZoom:
+    """A zoom group that could not be calibrated.
+
+    Attributes:
+        zoom_factor: The (rounded) zoom factor of the skipped group.
+        num_lines: Number of usable lines available for the group.
+        reason: Human-readable explanation for the skip.
+    """
+
+    zoom_factor: float
+    num_lines: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class SceneCalibrationResult:
+    """Result of a per-zoom scene self-calibration run.
+
+    Attributes:
+        table: The assembled lens calibration table (one entry per zoom).
+        skipped_zooms: Zoom groups that were skipped (too few lines / failure).
+    """
+
+    table: LensCalibrationTable
+    skipped_zooms: tuple[SkippedZoom, ...]
+
+
+def calibrate_zoom_from_lines(
+    lines: list[CameraLine],
+    zoom: float,
+    *,
+    camera_spec: CameraSpec,
+    config: ScenePerZoomConfig,
+) -> ZoomCalibrationEntry | SkippedZoom:
+    """Calibrate a single zoom group from already-detected camera lines.
+
+    Seeds a prior ``K`` via :func:`compute_intrinsics` for *zoom*, filters the
+    lines by edge curvature, and refines distortion plus intrinsics (modest
+    fx/fy window, tight cx/cy window) using the existing solver.
+
+    Args:
+        lines: Camera lines detected for this zoom group.
+        zoom: Zoom factor for the group.
+        camera_spec: Camera specification supplying sensor defaults.
+        config: Per-zoom configuration knobs.
+
+    Returns:
+        A :class:`ZoomCalibrationEntry` on success, otherwise a
+        :class:`SkippedZoom` describing why calibration was not performed.
+    """
+    intrinsics = compute_intrinsics(
+        zoom=Unitless(zoom),
+        image_width=camera_spec.image_width,
+        image_height=camera_spec.image_height,
+        sensor_width_mm=camera_spec.sensor_width,
+        base_focal_length_mm=camera_spec.base_focal_length,
+    )
+    prior_k = intrinsics.K
+
+    usable_lines = [line for line in lines if line.has_edge_curvature()]
+    num_usable = len(usable_lines)
+    if num_usable < config.min_lines:
+        return SkippedZoom(
+            zoom_factor=zoom,
+            num_lines=num_usable,
+            reason=(
+                f"only {num_usable} usable line(s) with edge curvature; need >= {config.min_lines}"
+            ),
+        )
+
+    fx0 = float(prior_k[0, 0])
+    fy0 = float(prior_k[1, 1])
+    cx0 = float(prior_k[0, 2])
+    cy0 = float(prior_k[1, 2])
+    frac = config.fx_refine_frac
+
+    solver_config = SolverConfig(
+        use_radial_only=True,
+        optimize_intrinsics=True,
+        fx_bounds=(fx0 * (1.0 - frac), fx0 * (1.0 + frac)),
+        fy_bounds=(fy0 * (1.0 - frac), fy0 * (1.0 + frac)),
+        cx_bounds=(cx0 - config.cx_window_px, cx0 + config.cx_window_px),
+        cy_bounds=(cy0 - config.cy_window_px, cy0 + config.cy_window_px),
+        num_samples_per_line=config.num_samples_per_line,
+        max_iterations=config.max_iterations,
+    )
+
+    try:
+        result = DistortionSolver(solver_config).solve(usable_lines, prior_k, LensDistortion())
+    except ValueError as exc:
+        return SkippedZoom(
+            zoom_factor=zoom,
+            num_lines=num_usable,
+            reason=f"solver error: {exc}",
+        )
+
+    if not result.success:
+        return SkippedZoom(
+            zoom_factor=zoom,
+            num_lines=num_usable,
+            reason=f"solver did not converge: {result.message}",
+        )
+
+    refined = result.intrinsics or {"fx": fx0, "fy": fy0, "cx": cx0, "cy": cy0}
+    source_images = tuple(dict.fromkeys(line.image_path for line in usable_lines))
+
+    return ZoomCalibrationEntry(
+        zoom_factor=Unitless(zoom),
+        distortion=result.distortion,
+        calibration_date=datetime.now().isoformat(),
+        source_images=source_images,
+        validation_rmse=result.overall_rmse,
+        num_lines_used=num_usable,
+        fx=PixelsFloat(refined["fx"]),
+        fy=PixelsFloat(refined["fy"]),
+        cx=PixelsFloat(refined["cx"]),
+        cy=PixelsFloat(refined["cy"]),
+    )
+
+
+def calibrate_scene_self(
+    image_zoom_pairs: list[tuple[np.ndarray, float]],
+    *,
+    camera_id: str,
+    camera_spec: CameraSpec = CameraSpec.HIKVISION_DS_2DF8425IX,
+    config: ScenePerZoomConfig | None = None,
+    detector: LineDetector | None = None,
+) -> SceneCalibrationResult:
+    """Self-calibrate a scene per zoom group from (image, zoom) pairs.
+
+    Groups the pairs by rounded zoom (``round(z / tol) * tol``), detects lines
+    in every image of each group, converts them to camera lines, and refines
+    distortion plus intrinsics per zoom. Produces a single
+    :class:`LensCalibrationTable` with one entry per successfully calibrated
+    zoom and reports skipped zooms separately.
+
+    Args:
+        image_zoom_pairs: List of ``(image_array, zoom_factor)`` tuples.
+        camera_id: Camera identifier used as the table id.
+        camera_spec: Camera specification supplying sensor defaults.
+        config: Per-zoom configuration (defaults applied when None).
+        detector: Line detector (a fresh :class:`LineDetector` when None).
+
+    Returns:
+        A :class:`SceneCalibrationResult` carrying the table and skipped zooms.
+    """
+    cfg = config or ScenePerZoomConfig()
+    line_detector = detector or LineDetector()
+    tol = cfg.zoom_tolerance
+
+    # Group (image, zoom) pairs by rounded zoom, mirroring group_images_by_zoom.
+    groups: dict[float, list[np.ndarray]] = {}
+    for image, zoom in image_zoom_pairs:
+        rounded = round(zoom / tol) * tol
+        groups.setdefault(rounded, []).append(image)
+
+    entries: list[ZoomCalibrationEntry] = []
+    skipped: list[SkippedZoom] = []
+
+    for zoom in sorted(groups):
+        images = groups[zoom]
+        ptz = PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(0.0), zoom_factor=zoom)
+        lines: list[CameraLine] = []
+        for idx, image in enumerate(images):
+            candidates = line_detector.detect(image)[: cfg.max_lines_per_image]
+            image_path = f"{camera_id}_zoom{zoom}_img{idx}"
+            for line_idx, candidate in enumerate(candidates):
+                lines.append(
+                    candidate.to_camera_line(
+                        line_id=f"{image_path}_line{line_idx}",
+                        image_path=image_path,
+                        ptz_position=ptz,
+                    )
+                )
+
+        outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=camera_spec, config=cfg)
+        if isinstance(outcome, SkippedZoom):
+            logger.warning(
+                "Skipping zoom %.3f: %s (%d usable line(s))",
+                outcome.zoom_factor,
+                outcome.reason,
+                outcome.num_lines,
+            )
+            skipped.append(outcome)
+        else:
+            entries.append(outcome)
+
+    now = datetime.now().isoformat()
+    table = LensCalibrationTable(
+        id=camera_id,
+        entries=tuple(entries),
+        created_date=now,
+        last_modified=now,
+    )
+    return SceneCalibrationResult(table=table, skipped_zooms=tuple(skipped))

--- a/poc_homography/calibration/lens_distortion/scene_self_calibration.py
+++ b/poc_homography/calibration/lens_distortion/scene_self_calibration.py
@@ -227,40 +227,43 @@ def calibrate_scene_self(
     skipped: list[SkippedZoom] = []
 
     for zoom in sorted(groups):
-        images = groups[zoom]
         # A non-positive rounded zoom (e.g. an input zoom that rounds to 0.0)
         # is degenerate: PTZPosition / compute_intrinsics reject it. Report it
         # as skipped rather than letting it abort the whole run.
         if zoom <= 0.0:
-            outcome: ZoomCalibrationEntry | SkippedZoom = SkippedZoom(
-                zoom_factor=zoom,
-                num_lines=0,
-                reason="non-positive zoom factor after rounding",
+            logger.warning("Skipping zoom %.3f: non-positive zoom factor after rounding", zoom)
+            skipped.append(
+                SkippedZoom(
+                    zoom_factor=zoom,
+                    num_lines=0,
+                    reason="non-positive zoom factor after rounding",
+                )
             )
-        else:
-            ptz = PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(0.0), zoom_factor=zoom)
-            lines: list[CameraLine] = []
-            for idx, image in enumerate(images):
-                candidates = line_detector.detect(image)
-                image_path = f"{camera_id}_zoom{zoom}_img{idx}"
-                # Keep up to max_lines_per_image *usable* (curved) lines: the cap
-                # must not discard the curved lines that carry the distortion
-                # signal in favour of straight ones.
-                kept = 0
-                for line_idx, candidate in enumerate(candidates):
-                    if kept >= cfg.max_lines_per_image:
-                        break
-                    camera_line = candidate.to_camera_line(
-                        line_id=f"{image_path}_line{line_idx}",
-                        image_path=image_path,
-                        ptz_position=ptz,
-                    )
-                    if not camera_line.has_edge_curvature():
-                        continue
-                    lines.append(camera_line)
-                    kept += 1
+            continue
 
-            outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=camera_spec, config=cfg)
+        ptz = PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(0.0), zoom_factor=zoom)
+        lines: list[CameraLine] = []
+        for idx, image in enumerate(groups[zoom]):
+            candidates = line_detector.detect(image)
+            image_path = f"{camera_id}_zoom{zoom}_img{idx}"
+            # Keep up to max_lines_per_image *usable* (curved) lines: the cap
+            # must not discard the curved lines that carry the distortion
+            # signal in favour of straight ones.
+            kept = 0
+            for line_idx, candidate in enumerate(candidates):
+                if kept >= cfg.max_lines_per_image:
+                    break
+                camera_line = candidate.to_camera_line(
+                    line_id=f"{image_path}_line{line_idx}",
+                    image_path=image_path,
+                    ptz_position=ptz,
+                )
+                if not camera_line.has_edge_curvature():
+                    continue
+                lines.append(camera_line)
+                kept += 1
+
+        outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=camera_spec, config=cfg)
         if isinstance(outcome, SkippedZoom):
             logger.warning(
                 "Skipping zoom %.3f: %s (%d usable line(s))",

--- a/poc_homography/calibration/lens_distortion/scene_self_calibration.py
+++ b/poc_homography/calibration/lens_distortion/scene_self_calibration.py
@@ -215,9 +215,12 @@ def calibrate_scene_self(
     tol = cfg.zoom_tolerance
 
     # Group (image, zoom) pairs by rounded zoom, mirroring group_images_by_zoom.
+    # Canonicalise the rounded key (round(z/tol)*tol can yield e.g.
+    # 1.2000000000000002) so the persisted zoom_factor and image-path strings
+    # stay clean.
     groups: dict[float, list[np.ndarray]] = {}
     for image, zoom in image_zoom_pairs:
-        rounded = round(zoom / tol) * tol
+        rounded = round(round(zoom / tol) * tol, 10)
         groups.setdefault(rounded, []).append(image)
 
     entries: list[ZoomCalibrationEntry] = []
@@ -225,21 +228,39 @@ def calibrate_scene_self(
 
     for zoom in sorted(groups):
         images = groups[zoom]
-        ptz = PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(0.0), zoom_factor=zoom)
-        lines: list[CameraLine] = []
-        for idx, image in enumerate(images):
-            candidates = line_detector.detect(image)[: cfg.max_lines_per_image]
-            image_path = f"{camera_id}_zoom{zoom}_img{idx}"
-            for line_idx, candidate in enumerate(candidates):
-                lines.append(
-                    candidate.to_camera_line(
+        # A non-positive rounded zoom (e.g. an input zoom that rounds to 0.0)
+        # is degenerate: PTZPosition / compute_intrinsics reject it. Report it
+        # as skipped rather than letting it abort the whole run.
+        if zoom <= 0.0:
+            outcome: ZoomCalibrationEntry | SkippedZoom = SkippedZoom(
+                zoom_factor=zoom,
+                num_lines=0,
+                reason="non-positive zoom factor after rounding",
+            )
+        else:
+            ptz = PTZPosition(pan_deg=Degrees(0.0), tilt_deg=Degrees(0.0), zoom_factor=zoom)
+            lines: list[CameraLine] = []
+            for idx, image in enumerate(images):
+                candidates = line_detector.detect(image)
+                image_path = f"{camera_id}_zoom{zoom}_img{idx}"
+                # Keep up to max_lines_per_image *usable* (curved) lines: the cap
+                # must not discard the curved lines that carry the distortion
+                # signal in favour of straight ones.
+                kept = 0
+                for line_idx, candidate in enumerate(candidates):
+                    if kept >= cfg.max_lines_per_image:
+                        break
+                    camera_line = candidate.to_camera_line(
                         line_id=f"{image_path}_line{line_idx}",
                         image_path=image_path,
                         ptz_position=ptz,
                     )
-                )
+                    if not camera_line.has_edge_curvature():
+                        continue
+                    lines.append(camera_line)
+                    kept += 1
 
-        outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=camera_spec, config=cfg)
+            outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=camera_spec, config=cfg)
         if isinstance(outcome, SkippedZoom):
             logger.warning(
                 "Skipping zoom %.3f: %s (%d usable line(s))",

--- a/tests/calibration/test_scene_self_calibration.py
+++ b/tests/calibration/test_scene_self_calibration.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from poc_homography.calibration.lens_distortion.apply_calibration import distort_points
 from poc_homography.calibration.lens_distortion.distortion_solver import (
     straightness_rmse,
 )
@@ -45,25 +46,6 @@ SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
 # ---------------------------------------------------------------------------
 # Synthetic data helpers
 # ---------------------------------------------------------------------------
-
-
-def _forward_distort(
-    points: np.ndarray,
-    k1: float,
-    k2: float,
-    fx: float,
-    fy: float,
-    cx: float,
-    cy: float,
-) -> np.ndarray:
-    """Brown-Conrady forward radial distortion (k1, k2 only)."""
-    x = (points[:, 0] - cx) / fx
-    y = (points[:, 1] - cy) / fy
-    r2 = x * x + y * y
-    radial = 1.0 + k1 * r2 + k2 * r2 * r2
-    x_d = x * radial
-    y_d = y * radial
-    return np.column_stack([x_d * fx + cx, y_d * fy + cy])
 
 
 def _prior_k_for_zoom(zoom: float) -> np.ndarray:
@@ -124,7 +106,9 @@ def _distorted_lines(
 
     lines: list[CameraLine] = []
     for line_id, undist in specs:
-        distorted = _forward_distort(undist, true_k1, true_k2, fx, fy, cx, cy)
+        # Reuse the shipped forward model (k3=p1=p2=0) so recovery is validated
+        # against the production distortion, not a hand-rolled twin.
+        distorted = distort_points(undist, true_k1, true_k2, 0.0, 0.0, 0.0, fx, fy, cx, cy)
         edge_pixels = tuple((float(p[0]), float(p[1])) for p in distorted)
         lines.append(
             CameraLine(
@@ -167,6 +151,20 @@ def _fake_candidates_for_zoom(zoom: float, true_k1: float) -> list[_FakeCandidat
     return [_FakeCandidate(line.edge_pixels) for line in _distorted_lines(zoom, true_k1)]  # type: ignore[arg-type]
 
 
+class _QueueDetector:
+    """Duck-typed LineDetector returning a queued candidate set per detect call.
+
+    The service processes zoom groups in sorted order, so the queue is seeded in
+    that order (one entry per detected image).
+    """
+
+    def __init__(self, queue: list[list[_FakeCandidate]]) -> None:
+        self._queue = queue
+
+    def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
+        return self._queue.pop(0)
+
+
 # ---------------------------------------------------------------------------
 # DoD#1 — full image entrypoint across >=2 zooms via fake detector
 # ---------------------------------------------------------------------------
@@ -177,17 +175,9 @@ def test_calibrate_scene_self_one_entry_per_zoom() -> None:
     true_k1 = -0.30
     img = np.zeros((SPEC.image_height, SPEC.image_width, 3), dtype=np.uint8)
 
-    # Each zoom group needs candidates built off ITS prior K, so the detector
-    # dispatches on the zoom it is asked for. We achieve this by queueing the
-    # per-zoom candidate sets in the (sorted) order the service processes them:
-    # zoom_a (1.0) first, then zoom_b (2.0).
-    class _QueueDetector:
-        def __init__(self, queue: list[list[_FakeCandidate]]) -> None:
-            self._queue = queue
-
-        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
-            return self._queue.pop(0)
-
+    # Each zoom group needs candidates built off ITS prior K. The service
+    # processes zooms in sorted order, so queue the per-zoom candidate sets in
+    # that order: zoom_a (1.0) first, then zoom_b (2.0).
     detector = _QueueDetector(
         [
             _fake_candidates_for_zoom(zoom_a, true_k1),
@@ -315,16 +305,8 @@ def test_skipped_zoom_does_not_abort_other_zooms() -> None:
     valid_candidates = _fake_candidates_for_zoom(valid_zoom, true_k1)
     sparse_candidates = valid_candidates[:1]  # too few for the sparse zoom
 
-    class _PerZoomDetector:
-        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
-            # First image (valid zoom) gets full set; mutate on each call.
-            return self._queue.pop(0)
-
-        def __init__(self, queue: list[list[_FakeCandidate]]) -> None:
-            self._queue = queue
-
     # Pairs are processed in sorted-zoom order: valid_zoom (1.0) then sparse (2.0).
-    detector = _PerZoomDetector([valid_candidates, sparse_candidates])
+    detector = _QueueDetector([valid_candidates, sparse_candidates])
     result = calibrate_scene_self(
         [(img, valid_zoom), (img, sparse_zoom)],
         camera_id="cam",
@@ -343,15 +325,13 @@ def test_near_zero_zoom_is_skipped_not_fatal() -> None:
     true_k1 = -0.30
     img = np.zeros((SPEC.image_height, SPEC.image_width, 3), dtype=np.uint8)
 
-    class _SingleZoomDetector:
-        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
-            # Only the valid (>0) zoom group reaches detection.
-            return _fake_candidates_for_zoom(valid_zoom, true_k1)
-
+    # Only the valid (>0) zoom group reaches detection; the tiny zoom is skipped
+    # before any detect call, so a single-entry queue suffices.
+    detector = _QueueDetector([_fake_candidates_for_zoom(valid_zoom, true_k1)])
     result = calibrate_scene_self(
         [(img, tiny_zoom), (img, valid_zoom)],
         camera_id="cam",
-        detector=_SingleZoomDetector(),
+        detector=detector,
     )
 
     assert len(result.table.entries) == 1

--- a/tests/calibration/test_scene_self_calibration.py
+++ b/tests/calibration/test_scene_self_calibration.py
@@ -204,14 +204,23 @@ def test_calibrate_scene_self_one_entry_per_zoom() -> None:
     assert result.skipped_zooms == ()
     assert len(result.table.entries) == 2
 
-    zooms = {float(e.zoom_factor) for e in result.table.entries}
-    assert zooms == {zoom_a, zoom_b}
+    zoom_list = [float(e.zoom_factor) for e in result.table.entries]
+    assert set(zoom_list) == {zoom_a, zoom_b}
+    # The table contract states entries are ordered by zoom_factor.
+    assert zoom_list == sorted(zoom_list)
 
+    cfg = ScenePerZoomConfig()
     for entry in result.table.entries:
-        assert entry.fx > 0.0
-        assert entry.fy > 0.0
-        assert entry.cx > 0.0
-        assert entry.cy > 0.0
+        # Each entry's intrinsics must be the *refined* values: within the
+        # configured solver window of the prior K seeded for that zoom (a bare
+        # `> 0` check would pass regardless of whether refinement ran).
+        prior_k = _prior_k_for_zoom(float(entry.zoom_factor))
+        fx0, fy0 = float(prior_k[0, 0]), float(prior_k[1, 1])
+        cx0, cy0 = float(prior_k[0, 2]), float(prior_k[1, 2])
+        assert abs(entry.fx - fx0) <= fx0 * cfg.fx_refine_frac + 1e-6
+        assert abs(entry.fy - fy0) <= fy0 * cfg.fx_refine_frac + 1e-6
+        assert abs(entry.cx - cx0) <= cfg.cx_window_px + 1e-6
+        assert abs(entry.cy - cy0) <= cfg.cy_window_px + 1e-6
         assert entry.validation_rmse >= 0.0
         assert entry.num_lines_used >= 3
 
@@ -326,3 +335,26 @@ def test_skipped_zoom_does_not_abort_other_zooms() -> None:
     assert float(result.table.entries[0].zoom_factor) == valid_zoom
     assert len(result.skipped_zooms) == 1
     assert result.skipped_zooms[0].zoom_factor == sparse_zoom
+
+
+def test_near_zero_zoom_is_skipped_not_fatal() -> None:
+    """A zoom that rounds to 0.0 is degenerate — skip it, never abort the run."""
+    valid_zoom, tiny_zoom = 1.0, 0.02  # 0.02 rounds to 0.0 at the default tolerance
+    true_k1 = -0.30
+    img = np.zeros((SPEC.image_height, SPEC.image_width, 3), dtype=np.uint8)
+
+    class _SingleZoomDetector:
+        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
+            # Only the valid (>0) zoom group reaches detection.
+            return _fake_candidates_for_zoom(valid_zoom, true_k1)
+
+    result = calibrate_scene_self(
+        [(img, tiny_zoom), (img, valid_zoom)],
+        camera_id="cam",
+        detector=_SingleZoomDetector(),
+    )
+
+    assert len(result.table.entries) == 1
+    assert float(result.table.entries[0].zoom_factor) == valid_zoom
+    assert len(result.skipped_zooms) == 1
+    assert result.skipped_zooms[0].zoom_factor == 0.0

--- a/tests/calibration/test_scene_self_calibration.py
+++ b/tests/calibration/test_scene_self_calibration.py
@@ -1,0 +1,328 @@
+"""Tests for the per-zoom scene self-calibration service (#350).
+
+Covers every Definition-of-Done bullet:
+
+1. ``calibrate_scene_self`` across >=2 zooms returns a ``SceneCalibrationResult``
+   whose ``.table`` is a ``LensCalibrationTable`` with one entry per distinct
+   zoom, each carrying refined fx/fy/cx/cy and a validation_rmse — driven
+   through a fake duck-typed detector.
+2. On synthetic barrel-distorted floor lines with a known ``true_k1`` built off
+   the prior K, ``calibrate_zoom_from_lines`` recovers a k1 closer to the truth
+   than the zero-distortion prior, with a post-calibration RMSE below the
+   pre-calibration straightness RMSE.
+3. A ``LensCalibrationTable`` round-trips through ``RepoYamlLensCalibrationTable``.
+4. A zoom group with too few usable lines is reported as a ``SkippedZoom`` and
+   does not raise; valid zooms still produce entries.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from poc_homography.calibration.lens_distortion.distortion_solver import (
+    straightness_rmse,
+)
+from poc_homography.calibration.lens_distortion.models import CameraLine, PTZPosition
+from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+    ScenePerZoomConfig,
+    SkippedZoom,
+    calibrate_scene_self,
+    calibrate_zoom_from_lines,
+)
+from poc_homography.camera.intrinsics import compute_intrinsics
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.enums.camera_spec import CameraSpec
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+from poc_homography.infrastructure.repositories.repo_yaml_lens_calibration_table import (
+    RepoYamlLensCalibrationTable,
+)
+from poc_homography.types import PixelsFloat, Unitless
+
+SPEC = CameraSpec.HIKVISION_DS_2DF8425IX
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data helpers
+# ---------------------------------------------------------------------------
+
+
+def _forward_distort(
+    points: np.ndarray,
+    k1: float,
+    k2: float,
+    fx: float,
+    fy: float,
+    cx: float,
+    cy: float,
+) -> np.ndarray:
+    """Brown-Conrady forward radial distortion (k1, k2 only)."""
+    x = (points[:, 0] - cx) / fx
+    y = (points[:, 1] - cy) / fy
+    r2 = x * x + y * y
+    radial = 1.0 + k1 * r2 + k2 * r2 * r2
+    x_d = x * radial
+    y_d = y * radial
+    return np.column_stack([x_d * fx + cx, y_d * fy + cy])
+
+
+def _prior_k_for_zoom(zoom: float) -> np.ndarray:
+    """Prior intrinsic matrix exactly as the service seeds it."""
+    return compute_intrinsics(
+        zoom=Unitless(zoom),
+        image_width=SPEC.image_width,
+        image_height=SPEC.image_height,
+        sensor_width_mm=SPEC.sensor_width,
+        base_focal_length_mm=SPEC.base_focal_length,
+    ).K
+
+
+def _distorted_lines(
+    zoom: float,
+    true_k1: float,
+    true_k2: float = 0.0,
+    *,
+    pts_per_line: int = 50,
+) -> list[CameraLine]:
+    """Build barrel-distorted straight floor lines off the prior K for *zoom*.
+
+    Generates a mix of horizontal / vertical / diagonal lines spanning the
+    frame so the recovery problem is well conditioned. Uses the SAME fx/fy/cx/cy
+    that ``compute_intrinsics`` produces so the fx<->k1 degeneracy does not make
+    recovery meaningless.
+    """
+    k = _prior_k_for_zoom(zoom)
+    fx, fy = float(k[0, 0]), float(k[1, 1])
+    cx, cy = float(k[0, 2]), float(k[1, 2])
+    width = float(SPEC.image_width)
+    height = float(SPEC.image_height)
+    margin = 120.0
+
+    ptz = PTZPosition(pan_deg=0.0, tilt_deg=0.0, zoom_factor=zoom)
+    specs: list[tuple[str, np.ndarray]] = []
+
+    for i, y_pos in enumerate(np.linspace(margin, height - margin, 3)):
+        undist = np.column_stack(
+            [np.linspace(margin, width - margin, pts_per_line), np.full(pts_per_line, y_pos)]
+        )
+        specs.append((f"h_{i}", undist))
+    for i, x_pos in enumerate(np.linspace(margin, width - margin, 3)):
+        undist = np.column_stack(
+            [np.full(pts_per_line, x_pos), np.linspace(margin, height - margin, pts_per_line)]
+        )
+        specs.append((f"v_{i}", undist))
+    for i, (xs, ys, xe, ye) in enumerate(
+        [
+            (margin, margin, width - margin, height - margin),
+            (width - margin, margin, margin, height - margin),
+        ]
+    ):
+        undist = np.column_stack(
+            [np.linspace(xs, xe, pts_per_line), np.linspace(ys, ye, pts_per_line)]
+        )
+        specs.append((f"d_{i}", undist))
+
+    lines: list[CameraLine] = []
+    for line_id, undist in specs:
+        distorted = _forward_distort(undist, true_k1, true_k2, fx, fy, cx, cy)
+        edge_pixels = tuple((float(p[0]), float(p[1])) for p in distorted)
+        lines.append(
+            CameraLine(
+                line_id=line_id,
+                image_path=f"synthetic_zoom{zoom}",
+                start_pixel=edge_pixels[0],
+                end_pixel=edge_pixels[-1],
+                ptz_position=ptz,
+                edge_pixels=edge_pixels,
+            )
+        )
+    return lines
+
+
+class _FakeCandidate:
+    """Minimal CandidateLine stand-in exposing ``to_camera_line``."""
+
+    def __init__(self, edge_pixels: tuple[tuple[float, float], ...]) -> None:
+        self.edge_pixels = edge_pixels
+
+    def to_camera_line(
+        self,
+        line_id: str,
+        image_path: str,
+        ptz_position: PTZPosition,
+        line_type: str = "parking",
+    ) -> CameraLine:
+        return CameraLine(
+            line_id=line_id,
+            image_path=image_path,
+            start_pixel=self.edge_pixels[0],
+            end_pixel=self.edge_pixels[-1],
+            ptz_position=ptz_position,
+            line_type=line_type,
+            edge_pixels=self.edge_pixels,
+        )
+
+
+def _fake_candidates_for_zoom(zoom: float, true_k1: float) -> list[_FakeCandidate]:
+    return [_FakeCandidate(line.edge_pixels) for line in _distorted_lines(zoom, true_k1)]  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DoD#1 — full image entrypoint across >=2 zooms via fake detector
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_scene_self_one_entry_per_zoom() -> None:
+    zoom_a, zoom_b = 1.0, 2.0
+    true_k1 = -0.30
+    img = np.zeros((SPEC.image_height, SPEC.image_width, 3), dtype=np.uint8)
+
+    # Each zoom group needs candidates built off ITS prior K, so the detector
+    # dispatches on the zoom it is asked for. We achieve this by queueing the
+    # per-zoom candidate sets in the (sorted) order the service processes them:
+    # zoom_a (1.0) first, then zoom_b (2.0).
+    class _QueueDetector:
+        def __init__(self, queue: list[list[_FakeCandidate]]) -> None:
+            self._queue = queue
+
+        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
+            return self._queue.pop(0)
+
+    detector = _QueueDetector(
+        [
+            _fake_candidates_for_zoom(zoom_a, true_k1),
+            _fake_candidates_for_zoom(zoom_b, true_k1),
+        ]
+    )
+    result = calibrate_scene_self(
+        [(img, zoom_a), (img, zoom_b)],
+        camera_id="cam",
+        detector=detector,
+    )
+
+    assert isinstance(result.table, LensCalibrationTable)
+    assert result.skipped_zooms == ()
+    assert len(result.table.entries) == 2
+
+    zooms = {float(e.zoom_factor) for e in result.table.entries}
+    assert zooms == {zoom_a, zoom_b}
+
+    for entry in result.table.entries:
+        assert entry.fx > 0.0
+        assert entry.fy > 0.0
+        assert entry.cx > 0.0
+        assert entry.cy > 0.0
+        assert entry.validation_rmse >= 0.0
+        assert entry.num_lines_used >= 3
+
+
+# ---------------------------------------------------------------------------
+# DoD#2 — key correctness: k1 recovery off the prior K
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_zoom_from_lines_recovers_k1() -> None:
+    zoom = 1.0
+    true_k1 = -0.30
+    lines = _distorted_lines(zoom, true_k1)
+    prior_k = _prior_k_for_zoom(zoom)
+    config = ScenePerZoomConfig()
+
+    pre_rmse = straightness_rmse(lines, prior_k, distortion=None)
+
+    entry = calibrate_zoom_from_lines(lines, zoom, camera_spec=SPEC, config=config)
+    assert isinstance(entry, ZoomCalibrationEntry)
+
+    recovered_k1 = float(entry.distortion.k1)
+    # Recovered k1 is closer to the truth than the zero-distortion prior.
+    assert abs(recovered_k1 - true_k1) < abs(0.0 - true_k1)
+    # Post-calibration straightness improves over the uncorrected prior.
+    assert entry.validation_rmse < pre_rmse
+
+
+# ---------------------------------------------------------------------------
+# DoD#3 — persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_lens_calibration_table_round_trip(tmp_path) -> None:
+    entry = ZoomCalibrationEntry(
+        zoom_factor=Unitless(2.0),
+        distortion=LensDistortion(k1=Unitless(-0.31), k2=Unitless(0.05)),
+        calibration_date="2026-06-21T00:00:00",
+        source_images=("cam_zoom2.0_img0",),
+        validation_rmse=1.234,
+        num_lines_used=8,
+        fx=PixelsFloat(2500.0),
+        fy=PixelsFloat(2500.0),
+        cx=PixelsFloat(1280.0),
+        cy=PixelsFloat(720.0),
+    )
+    table = LensCalibrationTable(
+        id="cam-roundtrip",
+        entries=(entry,),
+        created_date="2026-06-21T00:00:00",
+        last_modified="2026-06-21T00:00:00",
+    )
+
+    repo = RepoYamlLensCalibrationTable(tmp_path)
+    repo.save(table)
+    loaded = repo.get("cam-roundtrip")
+
+    assert loaded is not None
+    assert len(loaded.entries) == 1
+    got = loaded.entries[0]
+    assert float(got.zoom_factor) == float(entry.zoom_factor)
+    assert got.distortion.to_dict() == entry.distortion.to_dict()
+    assert float(got.fx) == float(entry.fx)
+    assert float(got.fy) == float(entry.fy)
+    assert float(got.cx) == float(entry.cx)
+    assert float(got.cy) == float(entry.cy)
+    assert got.validation_rmse == entry.validation_rmse
+    assert got.num_lines_used == entry.num_lines_used
+    assert got.source_images == entry.source_images
+
+
+# ---------------------------------------------------------------------------
+# DoD#4 — too-few-lines group is skipped, others still calibrate
+# ---------------------------------------------------------------------------
+
+
+def test_too_few_lines_reported_as_skipped() -> None:
+    zoom = 1.0
+    lines = _distorted_lines(zoom, true_k1=-0.30)[:1]  # only one usable line
+
+    outcome = calibrate_zoom_from_lines(lines, zoom, camera_spec=SPEC, config=ScenePerZoomConfig())
+    assert isinstance(outcome, SkippedZoom)
+    assert outcome.zoom_factor == zoom
+    assert outcome.num_lines == 1
+
+
+def test_skipped_zoom_does_not_abort_other_zooms() -> None:
+    valid_zoom, sparse_zoom = 1.0, 2.0
+    true_k1 = -0.30
+    img = np.zeros((SPEC.image_height, SPEC.image_width, 3), dtype=np.uint8)
+
+    valid_candidates = _fake_candidates_for_zoom(valid_zoom, true_k1)
+    sparse_candidates = valid_candidates[:1]  # too few for the sparse zoom
+
+    class _PerZoomDetector:
+        def detect(self, image: np.ndarray) -> list[_FakeCandidate]:
+            # First image (valid zoom) gets full set; mutate on each call.
+            return self._queue.pop(0)
+
+        def __init__(self, queue: list[list[_FakeCandidate]]) -> None:
+            self._queue = queue
+
+    # Pairs are processed in sorted-zoom order: valid_zoom (1.0) then sparse (2.0).
+    detector = _PerZoomDetector([valid_candidates, sparse_candidates])
+    result = calibrate_scene_self(
+        [(img, valid_zoom), (img, sparse_zoom)],
+        camera_id="cam",
+        detector=detector,
+    )
+
+    assert len(result.table.entries) == 1
+    assert float(result.table.entries[0].zoom_factor) == valid_zoom
+    assert len(result.skipped_zooms) == 1
+    assert result.skipped_zooms[0].zoom_factor == sparse_zoom

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -234,6 +234,7 @@ _.area  # domain-api (poc_homography/domain/vo/image_dimensions.py:46)
 _.inverse  # domain-api (poc_homography/homography/interface.py:98)
 _.to_orientation  # domain-api (poc_homography/domain/vo/ptz_state.py:32)
 save_to_gcp_repo  # domain-api (poc_homography/map_points/gcp_registry.py:205)
+skipped_zooms  # domain-api (poc_homography/calibration/lens_distortion/scene_self_calibration.py:91 — SceneCalibrationResult field consumed by tests/callers, #350)
 
 # == survey-surface ==
 # Survey dataset & planner surface (#258/#260/#276) — consumed by sibling capture/phase issues and tests


### PR DESCRIPTION
## Summary
Adds a per-zoom scene self-calibration service (`poc_homography/calibration/lens_distortion/scene_self_calibration.py`). Per zoom group it:
- seeds a prior `K` from `CameraSpec` defaults via `compute_intrinsics`;
- detects floor lines (`LineDetector.detect` → `CandidateLine.to_camera_line`, filtered by `CameraLine.has_edge_curvature()`);
- jointly refines distortion + intrinsics off the prior with the **existing** `DistortionSolver` (radial k1/k2/k3 + modest fx/fy window, cx/cy pinned near prior center, per the issue's pragmatic scoping);
- assembles one domain-VO `ZoomCalibrationEntry` per zoom into a `LensCalibrationTable`.

No new solver/table/persistence introduced. Zooms with insufficient usable lines are reported as `SkippedZoom` and never abort the run.

## Test plan
New `tests/calibration/test_scene_self_calibration.py` (5 tests, all DoD bullets):
1. (image, zoom) pairs across distinct zooms → one entry per zoom with refined fx/fy/cx/cy + validation_rmse (deterministic injected detector).
2. Synthetic barrel-distorted floor lines (known k1) → recovered k1 closer to truth than zero prior **and** validation_rmse < pre-calibration straightness RMSE.
3. Round-trips through `RepoYamlLensCalibrationTable`.
4. Too-few-lines zoom reported as `SkippedZoom`, not fatal; other zooms still calibrated.

Full offline gate green: ruff lint+format, pyright 0 errors, pylint 8.94/10, vulture clean, pytest 1315 passed / 157 skipped.

## DoD
- [x] Given (image, zoom) pairs, returns a `LensCalibrationTable` with one `ZoomCalibrationEntry` per distinct zoom.
- [x] On synthetic barrel-distorted floor lines (known k1), recovered k1 closer to truth than the zero-distortion prior and validation_rmse < pre-calibration straightness RMSE.
- [x] Round-trips through `RepoYamlLensCalibrationTable`.
- [x] Zooms with insufficient lines are skipped + reported, not fatal.
- [x] `poe ci` passes (offline; no camera/MinIO).

Closes #350