### PR TITLE
feat(cli): hom calibrate self-calibrate command (survey run → LensCalibrationTable) [#351]

### DIFF
--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -39,6 +39,7 @@ def _register_commands() -> None:
         line_picker,
         maps,
         point_picker,
+        self_calibrate,
         survey,
         test_cmds,
     )
@@ -56,6 +57,7 @@ def _register_commands() -> None:
     _ = line_picker
     _ = maps
     _ = point_picker
+    _ = self_calibrate
     _ = survey
     _ = test_cmds
 

--- a/poc_homography/cli/self_calibrate.py
+++ b/poc_homography/cli/self_calibrate.py
@@ -21,6 +21,7 @@ import typer
 
 from poc_homography.calibration.lens_distortion.frame_source import iter_survey_frames
 from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+    ScenePerZoomConfig,
     calibrate_scene_self,
 )
 from poc_homography.cli.main import calibrate_app
@@ -48,12 +49,14 @@ if TYPE_CHECKING:
         SceneCalibrationResult,
     )
 
-# Grouping window (in zoom units) the calibrator buckets frames into; mirrors
-# ``ScenePerZoomConfig.zoom_tolerance``. A ``--zoom`` filter value matches a
-# frame iff both round to the *same* group key, so the filter admits exactly the
-# frames the calibrator would route to the requested zoom group -- not the wider
-# neighbouring groups a symmetric +/- tolerance window would also capture.
-_ZOOM_GROUP_TOLERANCE = 0.1
+# Grouping window (in zoom units) the calibrator buckets frames into. Sourced
+# from ``ScenePerZoomConfig`` -- the default config this command hands to
+# :func:`calibrate_scene_self` -- so the filter's group keys can never drift from
+# the calibrator's own grouping. A ``--zoom`` filter value matches a frame iff
+# both round to the *same* group key, so the filter admits exactly the frames the
+# calibrator routes to the requested zoom group, not the wider neighbouring
+# groups a symmetric +/- tolerance window would also capture.
+_ZOOM_GROUP_TOLERANCE = ScenePerZoomConfig().zoom_tolerance
 
 
 @calibrate_app.command("self-calibrate")
@@ -137,19 +140,22 @@ def _run_self_calibration(
         # protocol (extra optional filters, a richer row type); cast at the
         # boundary since it structurally satisfies the reads the loader makes.
         frame_repo = cast("FrameRepo", RepoPostgresCleanPlateFrame(session))
+        # Pre-compute the requested zoom groups once (they are static for the
+        # run) so the per-frame check is a set membership test, not a re-derived
+        # group key per filter value per frame.
+        filter_keys = {_zoom_group_key(z) for z in zoom_filter} if zoom_filter else None
         image_zoom_pairs: list[tuple[np.ndarray, float]] = []
         for frame in iter_survey_frames(
             run_id=run_id, camera_id=camera_id, repo=frame_repo, store=frame_store
         ):
-            if zoom_filter is not None and not _zoom_matches(frame.commanded_zoom, zoom_filter):
+            if filter_keys is not None and _zoom_group_key(frame.commanded_zoom) not in filter_keys:
                 continue
             image_zoom_pairs.append((frame.image, frame.commanded_zoom))
 
         if not image_zoom_pairs:
+            zoom_clause = f" matching zoom(s) {zoom_filter}" if zoom_filter else ""
             typer.echo(
-                f"Error: No frames found for run_id={run_id} camera_id={camera_id}"
-                + (f" matching zoom(s) {zoom_filter}" if zoom_filter else "")
-                + ".",
+                f"Error: No frames found for run_id={run_id} camera_id={camera_id}{zoom_clause}.",
                 err=True,
             )
             raise typer.Exit(1)
@@ -170,17 +176,6 @@ def _run_self_calibration(
 def _zoom_group_key(zoom: float) -> float:
     """Round ``zoom`` to its calibrator group key (mirrors group_images_by_zoom)."""
     return round(round(zoom / _ZOOM_GROUP_TOLERANCE) * _ZOOM_GROUP_TOLERANCE, 10)
-
-
-def _zoom_matches(commanded_zoom: float, zoom_filter: list[float]) -> bool:
-    """Return True if ``commanded_zoom`` shares a zoom group with any filter value.
-
-    Compares rounded group keys (not a symmetric tolerance window) so a
-    ``--zoom`` value admits exactly the frames the calibrator routes to that
-    zoom group, never the adjacent groups a wider window would also capture.
-    """
-    key = _zoom_group_key(commanded_zoom)
-    return any(_zoom_group_key(z) == key for z in zoom_filter)
 
 
 def _print_report(*, camera_id: str, result: SceneCalibrationResult) -> None:

--- a/poc_homography/cli/self_calibrate.py
+++ b/poc_homography/cli/self_calibrate.py
@@ -48,18 +48,21 @@ if TYPE_CHECKING:
         SceneCalibrationResult,
     )
 
-# Half-window (in zoom units) used to match a frame's commanded zoom against a
-# requested ``--zoom`` filter value. Survey frames record the *commanded* zoom,
-# which may drift slightly from the requested value; this tolerance mirrors the
-# calibrator's own ``ScenePerZoomConfig.zoom_tolerance`` grouping window.
-_ZOOM_MATCH_TOLERANCE = 0.1
+# Grouping window (in zoom units) the calibrator buckets frames into; mirrors
+# ``ScenePerZoomConfig.zoom_tolerance``. A ``--zoom`` filter value matches a
+# frame iff both round to the *same* group key, so the filter admits exactly the
+# frames the calibrator would route to the requested zoom group -- not the wider
+# neighbouring groups a symmetric +/- tolerance window would also capture.
+_ZOOM_GROUP_TOLERANCE = 0.1
 
 
 @calibrate_app.command("self-calibrate")
 def self_calibrate_command(
     run_id: str = typer.Option(..., "--run-id", help="Survey run id to calibrate from"),
     camera: str = typer.Option(..., "--camera", help="Camera id (table id)"),
-    zoom: list[float] = typer.Option(None, "--zoom", help="Optional zoom factor(s) to restrict to"),
+    zoom: list[float] | None = typer.Option(
+        None, "--zoom", help="Optional zoom factor(s) to restrict to"
+    ),
     yaml_dir: Path | None = typer.Option(
         None, "--yaml-dir", help="Optional dir to also write a YAML table for inspection"
     ),
@@ -111,9 +114,9 @@ def _run_self_calibration(
     Extracted from the command body so tests can inject a fake frame store, a
     fake session factory, and monkeypatch the loader/calibrator/repos -- with no
     live MinIO, Neon, or solver access. Opens a session, drains the run's frames
-    via :func:`iter_survey_frames`, optionally filters them by commanded zoom
-    (within :data:`_ZOOM_MATCH_TOLERANCE`), self-calibrates per zoom, and saves
-    the table to Postgres (and YAML when ``yaml_dir`` is given).
+    via :func:`iter_survey_frames`, optionally filters them to the requested
+    zoom group(s), self-calibrates per zoom, and saves the table to Postgres
+    (then, after the DB commit, a YAML copy when ``yaml_dir`` is given).
 
     Args:
         run_id: Survey run to calibrate from.
@@ -154,15 +157,30 @@ def _run_self_calibration(
         result = calibrate_scene_self(image_zoom_pairs, camera_id=camera_id)
 
         RepoPostgresLensCalibrationTable(session).save(result.table)
-        if yaml_dir is not None:
-            RepoYamlLensCalibrationTable(yaml_dir).save(result.table)
+
+    # The YAML copy is an optional diagnostic artifact written only after the DB
+    # session has committed, so a YAML write failure (bad path, permissions,
+    # disk full) cannot roll back the persisted lens table.
+    if yaml_dir is not None:
+        RepoYamlLensCalibrationTable(yaml_dir).save(result.table)
 
     return result
 
 
+def _zoom_group_key(zoom: float) -> float:
+    """Round ``zoom`` to its calibrator group key (mirrors group_images_by_zoom)."""
+    return round(round(zoom / _ZOOM_GROUP_TOLERANCE) * _ZOOM_GROUP_TOLERANCE, 10)
+
+
 def _zoom_matches(commanded_zoom: float, zoom_filter: list[float]) -> bool:
-    """Return True if ``commanded_zoom`` is within tolerance of any filter value."""
-    return any(abs(commanded_zoom - z) <= _ZOOM_MATCH_TOLERANCE for z in zoom_filter)
+    """Return True if ``commanded_zoom`` shares a zoom group with any filter value.
+
+    Compares rounded group keys (not a symmetric tolerance window) so a
+    ``--zoom`` value admits exactly the frames the calibrator routes to that
+    zoom group, never the adjacent groups a wider window would also capture.
+    """
+    key = _zoom_group_key(commanded_zoom)
+    return any(_zoom_group_key(z) == key for z in zoom_filter)
 
 
 def _print_report(*, camera_id: str, result: SceneCalibrationResult) -> None:

--- a/poc_homography/cli/self_calibrate.py
+++ b/poc_homography/cli/self_calibrate.py
@@ -1,0 +1,188 @@
+"""Unattended per-zoom scene self-calibration CLI command (#351).
+
+Pure composition of existing read-side pieces: enumerate a survey run's stored
+frames offline via :func:`iter_survey_frames` (frame metadata from Neon's
+``clean_plate_frames`` via :class:`RepoPostgresCleanPlateFrame`, image bytes from
+MinIO via :class:`MinioFrameStore`), feed the decoded ``(image, zoom)`` pairs to
+:func:`calibrate_scene_self`, and persist the resulting per-zoom
+:class:`LensCalibrationTable` (``K(zoom)`` + distortion) to Neon -- closing the
+#338 (capture) -> #339 (calibrate) loop. The helper is fully offline-testable:
+the loader, the calibrator, and both repositories are referenced as module-level
+names so tests can swap them for doubles.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path  # noqa: TC003  # runtime import: Typer resolves the --yaml-dir annotation
+from typing import TYPE_CHECKING, cast
+
+import typer
+
+from poc_homography.calibration.lens_distortion.frame_source import iter_survey_frames
+from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+    calibrate_scene_self,
+)
+from poc_homography.cli.main import calibrate_app
+from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
+from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_clean_plate_frame import (
+    RepoPostgresCleanPlateFrame,
+)
+from poc_homography.infrastructure.repositories.repo_postgres_lens_calibration_table import (
+    RepoPostgresLensCalibrationTable,
+)
+from poc_homography.infrastructure.repositories.repo_yaml_lens_calibration_table import (
+    RepoYamlLensCalibrationTable,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from contextlib import AbstractContextManager
+
+    import numpy as np
+    from sqlalchemy.orm import Session
+
+    from poc_homography.calibration.lens_distortion.frame_source import FrameRepo, FrameStore
+    from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+        SceneCalibrationResult,
+    )
+
+# Half-window (in zoom units) used to match a frame's commanded zoom against a
+# requested ``--zoom`` filter value. Survey frames record the *commanded* zoom,
+# which may drift slightly from the requested value; this tolerance mirrors the
+# calibrator's own ``ScenePerZoomConfig.zoom_tolerance`` grouping window.
+_ZOOM_MATCH_TOLERANCE = 0.1
+
+
+@calibrate_app.command("self-calibrate")
+def self_calibrate_command(
+    run_id: str = typer.Option(..., "--run-id", help="Survey run id to calibrate from"),
+    camera: str = typer.Option(..., "--camera", help="Camera id (table id)"),
+    zoom: list[float] = typer.Option(None, "--zoom", help="Optional zoom factor(s) to restrict to"),
+    yaml_dir: Path | None = typer.Option(
+        None, "--yaml-dir", help="Optional dir to also write a YAML table for inspection"
+    ),
+) -> None:
+    """
+    Calibrate a survey run's stored frames into a persisted per-zoom lens table.
+
+    Enumerates the run's frames offline (Neon metadata + MinIO bytes), self-
+    calibrates ``K(zoom)`` plus distortion per zoom group via
+    :func:`calibrate_scene_self`, persists the resulting
+    :class:`LensCalibrationTable` to Neon (and optionally a YAML copy for
+    inspection), then prints a per-zoom residual report. Both the MinIO and the
+    database env contracts are pre-flighted up front so a misconfiguration fails
+    fast.
+    """
+    # Pre-flight the env contracts before any work so misconfig fails fast.
+    try:
+        frame_store = MinioFrameStore.from_env()
+    except RuntimeError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+    if not os.environ.get("DATABASE_URL"):
+        typer.echo("Error: DATABASE_URL environment variable is not set.", err=True)
+        raise typer.Exit(1)
+
+    result = _run_self_calibration(
+        run_id=run_id,
+        camera_id=camera,
+        frame_store=frame_store,
+        session_factory=get_session,
+        zoom_filter=zoom or None,
+        yaml_dir=yaml_dir,
+    )
+
+    _print_report(camera_id=camera, result=result)
+
+
+def _run_self_calibration(
+    *,
+    run_id: str,
+    camera_id: str,
+    frame_store: FrameStore,
+    session_factory: Callable[[], AbstractContextManager[Session]],
+    zoom_filter: list[float] | None = None,
+    yaml_dir: Path | None = None,
+) -> SceneCalibrationResult:
+    """Calibrate a run's stored frames into a persisted lens table.
+
+    Extracted from the command body so tests can inject a fake frame store, a
+    fake session factory, and monkeypatch the loader/calibrator/repos -- with no
+    live MinIO, Neon, or solver access. Opens a session, drains the run's frames
+    via :func:`iter_survey_frames`, optionally filters them by commanded zoom
+    (within :data:`_ZOOM_MATCH_TOLERANCE`), self-calibrates per zoom, and saves
+    the table to Postgres (and YAML when ``yaml_dir`` is given).
+
+    Args:
+        run_id: Survey run to calibrate from.
+        camera_id: Camera id; also the persisted table id.
+        frame_store: Frame byte store (injected; offline-testable).
+        session_factory: Database session context-manager factory.
+        zoom_filter: Optional zoom factor(s) to restrict the frames to.
+        yaml_dir: Optional directory to also write a YAML table copy.
+
+    Returns:
+        The :class:`SceneCalibrationResult` carrying the table and skipped zooms.
+
+    Raises:
+        typer.Exit: If no frames are found for ``run_id``/``camera_id``.
+    """
+    with session_factory() as session:
+        # The concrete repo's query surface is wider than the loader's FrameRepo
+        # protocol (extra optional filters, a richer row type); cast at the
+        # boundary since it structurally satisfies the reads the loader makes.
+        frame_repo = cast("FrameRepo", RepoPostgresCleanPlateFrame(session))
+        image_zoom_pairs: list[tuple[np.ndarray, float]] = []
+        for frame in iter_survey_frames(
+            run_id=run_id, camera_id=camera_id, repo=frame_repo, store=frame_store
+        ):
+            if zoom_filter is not None and not _zoom_matches(frame.commanded_zoom, zoom_filter):
+                continue
+            image_zoom_pairs.append((frame.image, frame.commanded_zoom))
+
+        if not image_zoom_pairs:
+            typer.echo(
+                f"Error: No frames found for run_id={run_id} camera_id={camera_id}"
+                + (f" matching zoom(s) {zoom_filter}" if zoom_filter else "")
+                + ".",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+        result = calibrate_scene_self(image_zoom_pairs, camera_id=camera_id)
+
+        RepoPostgresLensCalibrationTable(session).save(result.table)
+        if yaml_dir is not None:
+            RepoYamlLensCalibrationTable(yaml_dir).save(result.table)
+
+    return result
+
+
+def _zoom_matches(commanded_zoom: float, zoom_filter: list[float]) -> bool:
+    """Return True if ``commanded_zoom`` is within tolerance of any filter value."""
+    return any(abs(commanded_zoom - z) <= _ZOOM_MATCH_TOLERANCE for z in zoom_filter)
+
+
+def _print_report(*, camera_id: str, result: SceneCalibrationResult) -> None:
+    """Print a per-zoom residual report plus a final summary line."""
+    for entry in result.table.entries:
+        typer.echo(
+            f"zoom={float(entry.zoom_factor):<6} "
+            f"lines={entry.num_lines_used:<3} "
+            f"rmse={entry.validation_rmse:<8} "
+            f"fx={float(entry.fx):<10} "
+            f"fy={float(entry.fy):<10} "
+            f"reproj_px={entry.reprojection_error_px}"
+        )
+    for skipped in result.skipped_zooms:
+        typer.echo(
+            f"skipped zoom={skipped.zoom_factor:<6} "
+            f"lines={skipped.num_lines:<3} reason={skipped.reason}"
+        )
+    typer.echo(
+        f"Done: camera_id={camera_id} "
+        f"zooms_calibrated={len(result.table.entries)} "
+        f"skipped={len(result.skipped_zooms)}"
+    )

--- a/tests/survey/test_self_calibrate_cmd.py
+++ b/tests/survey/test_self_calibrate_cmd.py
@@ -1,0 +1,301 @@
+"""Tests for the ``hom calibrate self-calibrate`` command (#351).
+
+Exercise the extracted ``_run_self_calibration`` helper offline: the survey-frame
+loader and the scene self-calibrator are monkeypatched to canned doubles, the
+Postgres lens-table repo is replaced with an in-memory capture, and the session
+factory is a no-op context manager -- so nothing touches MinIO, Neon, or the
+scene-calibration solver. A DB round-trip integration test (gated on
+``DATABASE_URL``) uses the real Postgres repo to prove the table persists.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from poc_homography.calibration.lens_distortion.frame_source import SurveyFrame
+from poc_homography.calibration.lens_distortion.scene_self_calibration import (
+    SceneCalibrationResult,
+    SkippedZoom,
+)
+from poc_homography.cli import self_calibrate as cmd
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+from poc_homography.types import PixelsFloat, Unitless
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+def _canned_frames() -> list[SurveyFrame]:
+    """Three canned survey frames spanning two distinct zooms."""
+    return [
+        SurveyFrame(
+            image=np.zeros((4, 6, 3), dtype=np.uint8), commanded_zoom=1.0, commanded_tilt=-10.0
+        ),
+        SurveyFrame(
+            image=np.ones((4, 6, 3), dtype=np.uint8), commanded_zoom=1.0, commanded_tilt=-12.0
+        ),
+        SurveyFrame(
+            image=np.full((4, 6, 3), 2, dtype=np.uint8), commanded_zoom=5.0, commanded_tilt=-20.0
+        ),
+    ]
+
+
+def _canned_result(camera_id: str) -> SceneCalibrationResult:
+    """A canned result: two calibrated zooms + one skipped zoom."""
+    table = LensCalibrationTable(
+        id=camera_id,
+        entries=(
+            ZoomCalibrationEntry(
+                zoom_factor=Unitless(1.0),
+                distortion=LensDistortion(k1=Unitless(-0.1), k2=Unitless(0.01)),
+                calibration_date="2026-06-21T10:00:00",
+                source_images=("img_a.jpg",),
+                validation_rmse=0.42,
+                num_lines_used=7,
+                fx=PixelsFloat(1000.0),
+                fy=PixelsFloat(1001.0),
+                cx=PixelsFloat(640.0),
+                cy=PixelsFloat(360.0),
+                reprojection_error_px=0.31,
+            ),
+            ZoomCalibrationEntry(
+                zoom_factor=Unitless(5.0),
+                distortion=LensDistortion(k1=Unitless(-0.2), k2=Unitless(0.02)),
+                calibration_date="2026-06-21T10:01:00",
+                source_images=("img_b.jpg",),
+                validation_rmse=0.55,
+                num_lines_used=9,
+                fx=PixelsFloat(5000.0),
+                fy=PixelsFloat(5002.0),
+                cx=PixelsFloat(641.0),
+                cy=PixelsFloat(361.0),
+                reprojection_error_px=0.48,
+            ),
+        ),
+        created_date="2026-06-21T10:00:00",
+        last_modified="2026-06-21T10:01:00",
+    )
+    skipped = (SkippedZoom(zoom_factor=10.0, num_lines=2, reason="only 2 usable line(s)"),)
+    return SceneCalibrationResult(table=table, skipped_zooms=skipped)
+
+
+class _CapturingLensRepo:
+    """In-memory ``RepoPostgresLensCalibrationTable`` double capturing saves."""
+
+    saved: list[LensCalibrationTable] = []
+
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+    def save(self, table: LensCalibrationTable) -> bool:
+        type(self).saved.append(table)
+        return True
+
+
+@contextmanager
+def _fake_session_factory() -> Generator[object, None, None]:
+    """A no-op session context manager (nothing touches Neon)."""
+    yield object()
+
+
+def _install_doubles(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    frames: list[SurveyFrame],
+    result: SceneCalibrationResult,
+) -> list[list[tuple[np.ndarray, float]]]:
+    """Patch the loader, calibrator, and repo; return a calibrator-arg sink."""
+    monkeypatch.setattr(cmd, "iter_survey_frames", lambda **_kwargs: iter(frames))
+
+    captured_pairs: list[list[tuple[np.ndarray, float]]] = []
+
+    def fake_calibrate(
+        image_zoom_pairs: list[tuple[np.ndarray, float]], *, camera_id: str
+    ) -> SceneCalibrationResult:
+        captured_pairs.append(image_zoom_pairs)
+        return result
+
+    monkeypatch.setattr(cmd, "calibrate_scene_self", fake_calibrate)
+
+    _CapturingLensRepo.saved = []
+    monkeypatch.setattr(cmd, "RepoPostgresLensCalibrationTable", _CapturingLensRepo)
+
+    return captured_pairs
+
+
+def test_run_self_calibration_saves_table_and_reports(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    frames = _canned_frames()
+    result = _canned_result("cam01")
+    captured_pairs = _install_doubles(monkeypatch, frames=frames, result=result)
+
+    returned = cmd._run_self_calibration(
+        run_id="run-1",
+        camera_id="cam01",
+        frame_store=object(),
+        session_factory=_fake_session_factory,
+    )
+
+    # The canned result is returned and the table was persisted verbatim.
+    assert returned is result
+    assert _CapturingLensRepo.saved == [result.table]
+
+    # The calibrator received one (image, zoom) pair per canned frame.
+    assert len(captured_pairs) == 1
+    pairs = captured_pairs[0]
+    assert [z for _img, z in pairs] == [1.0, 1.0, 5.0]
+
+    # The per-zoom report carries each entry's diagnostics and the skip reason.
+    cmd._print_report(camera_id="cam01", result=returned)
+    out = capsys.readouterr().out
+    assert "7" in out  # num_lines_used (zoom 1.0)
+    assert "9" in out  # num_lines_used (zoom 5.0)
+    assert "0.42" in out  # validation_rmse (zoom 1.0)
+    assert "1000.0" in out  # fx (zoom 1.0)
+    assert "5000.0" in out  # fx (zoom 5.0)
+    assert "only 2 usable line(s)" in out  # skipped-zoom reason
+    assert "zooms_calibrated=2" in out
+    assert "skipped=1" in out
+
+
+def test_run_self_calibration_applies_zoom_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frames = _canned_frames()
+    result = _canned_result("cam01")
+    captured_pairs = _install_doubles(monkeypatch, frames=frames, result=result)
+
+    cmd._run_self_calibration(
+        run_id="run-1",
+        camera_id="cam01",
+        frame_store=object(),
+        session_factory=_fake_session_factory,
+        zoom_filter=[1.0],
+    )
+
+    # Only the two zoom==1.0 frames reach the calibrator.
+    assert len(captured_pairs) == 1
+    pairs = captured_pairs[0]
+    assert [z for _img, z in pairs] == [1.0, 1.0]
+
+
+def test_run_self_calibration_empty_frames_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import typer
+
+    result = _canned_result("cam01")
+    _install_doubles(monkeypatch, frames=[], result=result)
+
+    with pytest.raises(typer.Exit):
+        cmd._run_self_calibration(
+            run_id="run-1",
+            camera_id="cam01",
+            frame_store=object(),
+            session_factory=_fake_session_factory,
+        )
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+def test_run_self_calibration_persists_to_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DB round-trip: the real Postgres repo persists and re-reads the table."""
+    from pathlib import Path
+
+    from sqlalchemy.orm import Session as SASession
+
+    from poc_homography.domain.entities.camera_config import CameraConfig
+    from poc_homography.domain.entities.map import Map
+    from poc_homography.domain.entities.tenant import Tenant
+    from poc_homography.domain.enums import CameraSpec
+    from poc_homography.domain.vo.credential import Credential
+    from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+    from poc_homography.domain.vo.photo import Photo
+    from poc_homography.infrastructure.database import get_engine
+    from poc_homography.infrastructure.repositories import (
+        RepoPostgresCameraConfig,
+        RepoPostgresMap,
+        RepoPostgresTenant,
+    )
+    from poc_homography.infrastructure.repositories.repo_postgres_lens_calibration_table import (
+        RepoPostgresLensCalibrationTable,
+    )
+    from poc_homography.types import Easting, Meters, Northing, Pixels
+
+    engine = get_engine()
+    with SASession(engine) as db_session:
+        db_session.begin()
+        try:
+            # Persist the FK parents (tenant -> map -> camera_config).
+            RepoPostgresTenant(db_session).save(
+                Tenant(
+                    id="sc_tenant",
+                    name="SC Tenant",
+                    description="self-calibrate test tenant",
+                    location_lat="39d38'25.72\"N",
+                    location_lon="0d13'48.63\"W",
+                )
+            )
+            RepoPostgresMap(db_session).save(
+                Map(
+                    id="sc_map",
+                    tenant_id="sc_tenant",
+                    photo=Photo(path=Path("m.png"), width=Pixels(1000), height=Pixels(800)),
+                    geotiff=GeoTiff(
+                        geotransform=GeoTransform(
+                            origin_easting=Easting(500000.0),
+                            pixel_width=Meters(0.5),
+                            row_rotation=Unitless(0.0),
+                            origin_northing=Northing(4400000.0),
+                            col_rotation=Unitless(0.0),
+                            pixel_height=Meters(-0.5),
+                        ),
+                        crs="EPSG:25830",
+                    ),
+                )
+            )
+            camera_id = "sc_map/cam01"
+            RepoPostgresCameraConfig(db_session).save(
+                CameraConfig(
+                    id=camera_id,
+                    tenant_id="sc_tenant",
+                    map_id="sc_map",
+                    name="cam01",
+                    spec=CameraSpec.HIKVISION_DS_2DF8425IX,
+                    credential=Credential(username="admin", password="secret"),
+                    ip_address="192.168.1.100",
+                )
+            )
+
+            result = _canned_result(camera_id)
+            monkeypatch.setattr(cmd, "iter_survey_frames", lambda **_kwargs: iter(_canned_frames()))
+            monkeypatch.setattr(cmd, "calibrate_scene_self", lambda _pairs, *, camera_id: result)
+
+            @contextmanager
+            def real_session_factory() -> Generator[object, None, None]:
+                yield db_session
+
+            cmd._run_self_calibration(
+                run_id="run-1",
+                camera_id=camera_id,
+                frame_store=object(),
+                session_factory=real_session_factory,
+            )
+
+            loaded = RepoPostgresLensCalibrationTable(db_session).get(camera_id)
+            assert loaded is not None
+            assert loaded.id == camera_id
+            assert len(loaded.entries) == 2
+            assert float(loaded.entries[0].validation_rmse) == pytest.approx(0.42)
+        finally:
+            db_session.rollback()

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -196,7 +196,7 @@ calibrate_capture_command  # cli-command (poc_homography/cli/calibrate_capture.p
 reconstruct_command  # cli-command (poc_homography/cli/cleanplate.py:83)
 synth_command  # cli-command (poc_homography/cli/cleanplate.py:169)
 upload_command  # cli-command (poc_homography/cli/maps.py:15)
-self_calibrate_command  # cli-command (poc_homography/cli/self_calibrate.py:57)
+self_calibrate_command  # cli-command (poc_homography/cli/self_calibrate.py:60)
 
 # == domain-api ==
 # Domain public API (value-object / entity / algorithm methods exercised by tests or exported as public surface)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -196,6 +196,7 @@ calibrate_capture_command  # cli-command (poc_homography/cli/calibrate_capture.p
 reconstruct_command  # cli-command (poc_homography/cli/cleanplate.py:83)
 synth_command  # cli-command (poc_homography/cli/cleanplate.py:169)
 upload_command  # cli-command (poc_homography/cli/maps.py:15)
+self_calibrate_command  # cli-command (poc_homography/cli/self_calibrate.py:57)
 
 # == domain-api ==
 # Domain public API (value-object / entity / algorithm methods exercised by tests or exported as public surface)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -196,7 +196,7 @@ calibrate_capture_command  # cli-command (poc_homography/cli/calibrate_capture.p
 reconstruct_command  # cli-command (poc_homography/cli/cleanplate.py:83)
 synth_command  # cli-command (poc_homography/cli/cleanplate.py:169)
 upload_command  # cli-command (poc_homography/cli/maps.py:15)
-self_calibrate_command  # cli-command (poc_homography/cli/self_calibrate.py:60)
+self_calibrate_command  # cli-command (poc_homography/cli/self_calibrate.py:63)
 
 # == domain-api ==
 # Domain public API (value-object / entity / algorithm methods exercised by tests or exported as public surface)


### PR DESCRIPTION
## Summary

Add an unattended `hom calibrate self-calibrate` command that closes the #338→#339 loop: it enumerates a survey run's stored frames offline (iter_survey_frames over RepoPostgresCleanPlateFrame + MinioFrameStore.from_env), feeds the decoded (image, zoom) pairs to calibrate_scene_self, and persists the per-zoom LensCalibrationTable (K(zoom)+distortion) via RepoPostgresLensCalibrationTable (plus optional YAML for inspection). Reuses the env/session bootstrap from calibrate_capture (MinioFrameStore.from_env + DATABASE_URL pre-flight). Prints a per-zoom residual report (num_lines_used, validation_rmse, refined fx/fy, reprojection_error) and lists skipped zooms. All I/O is behind injectable seams (session_factory, frame_store, module-level loader/calibrator/repo refs) for offline testing.

## Test plan

poe ci green (1319 passed, 158 skipped). New tests/survey/test_self_calibrate_cmd.py: offline unit test (fake loader + fake calibrator + fake lens repo + fake session) asserts table persisted and per-zoom report printed; zoom-filter test; empty-frames Exit test; DB integration test (gated on DATABASE_URL) round-trips the table via real RepoPostgresLensCalibrationTable.get(camera_id).

## Closes DoD bullets

- Command against injected fake repos + fake frame store produces + persists a LensCalibrationTable and prints a per-zoom residual report.
- Persisted table retrievable by camera_id via RepoPostgresLensCalibrationTable (test DB).
- poe ci passes.
