### PR TITLE
feat(calib): automatic frame-line↔ortho-line RANSAC matcher (auto-GCP) [#358]

### DIFF
--- a/poc_homography/calibration/extrinsic/__init__.py
+++ b/poc_homography/calibration/extrinsic/__init__.py
@@ -6,10 +6,16 @@ solver into a single per-PTZ-state registration pipeline.
 
 The pipeline does NOT implement homography/RANSAC/ICP/distortion itself — it
 delegates all of that to :class:`MapPointHomography.compute_from_lines`. The
-frame-line ↔ ortho-line correspondence is *seeded* (explicit operator hints);
-fully automatic matching is intentionally out of scope here.
+seeded leaf takes an explicit operator correspondence; the automatic leaf
+(:func:`match_and_register`) discovers the correspondence itself and feeds the
+discovered seed to the seeded core.
 """
 
+from poc_homography.calibration.extrinsic.auto_match import (
+    AutoMatchResult,
+    InsufficientCorrespondenceError,
+    match_and_register,
+)
 from poc_homography.calibration.extrinsic.ptz_registration import (
     PtzRegistrationResult,
     register_frame_lines,
@@ -17,7 +23,10 @@ from poc_homography.calibration.extrinsic.ptz_registration import (
 )
 
 __all__ = [
+    "AutoMatchResult",
+    "InsufficientCorrespondenceError",
     "PtzRegistrationResult",
+    "match_and_register",
     "register_frame_lines",
     "register_ptz_state",
 ]

--- a/poc_homography/calibration/extrinsic/auto_match.py
+++ b/poc_homography/calibration/extrinsic/auto_match.py
@@ -1,0 +1,584 @@
+"""Automatic frame-line ↔ ortho-line RANSAC matcher (the "auto-GCP" core).
+
+This module REPLACES the operator-supplied seed of the SEEDED leaf
+(:func:`poc_homography.calibration.extrinsic.ptz_registration.register_frame_lines`)
+by *discovering* the frame-line ↔ ortho-line correspondence automatically, then
+feeding the discovered seed to that very function. It does NOT implement a new
+homography estimator: it only SELECTS correspondences and delegates the refined
+solve to the existing ICP/RANSAC core in
+:meth:`poc_homography.homography.map_points.MapPointHomography.compute_from_lines`.
+
+Algorithm overview
+------------------
+1. **Candidate generation.** For each frame line, find ortho lines that are
+   plausible matches by descriptor: orientation agreement (angle modulo 180°)
+   and length-ratio compatibility. When a ``pose_prior`` is supplied it is used
+   to *predict* where each frame line projects in ortho space and to gate
+   candidates by midpoint proximity + projected-angle agreement; this is what
+   disambiguates REPETITIVE near-parallel parking lines that pure descriptor
+   gating would happily swap. Without a prior we fall back to pure descriptor
+   (angle/length) gating — line-only matching.
+2. **Seeded RANSAC** over minimal 2-line candidate sets. All sampling uses a
+   :func:`numpy.random.default_rng` seeded with ``rng_seed`` so runs are bit-for-bit
+   reproducible. Each minimal hypothesis is built with ``cv2.getPerspectiveTransform``
+   on the 4 endpoint correspondences (trying both endpoint orientations of the
+   second line and keeping the better) — deliberately NOT ``cv2.findHomography(...,
+   cv2.RANSAC, ...)``, whose internal RNG is not seedable. A (frame, ortho) pair
+   scores as an inlier when projecting the frame line's endpoints by the
+   hypothesis lands within ``ransac_threshold`` map pixels (PERPENDICULAR
+   distance to the ortho *infinite* line — consistent with ``compute_from_lines``).
+   Each frame line resolves to at most one ortho line (lowest-error) so the seed
+   is a clean, injective mapping.
+3. **Fail-fast** BEFORE the refined solve: too few inliers, a "Poor"/"Insufficient"
+   :func:`calculate_distribution` quality over the inlier frame endpoints, or a
+   too-low inlier count all raise :class:`InsufficientCorrespondenceError`.
+4. **Refined solve.** The discovered seed (``frame_index -> "ortho_{i}"``, with
+   ``i`` the positional index of the ortho line in the input sequence, matching
+   ``register_frame_lines``' convention) is handed to ``register_frame_lines`` and
+   wrapped in an :class:`AutoMatchResult`.
+
+pose_prior orientation
+----------------------
+``pose_prior`` is a 3×3 homography in the SAME orientation as the matcher's
+output: **frame-pixel → ortho map-pixel**. A coarse prior of this orientation is
+obtained from the commanded PTZ via
+:meth:`poc_homography.homography.intrinsic_extrinsic.IntrinsicExtrinsicHomography.compute_from_config`.
+The prior need only be approximately correct (a perturbed prior still
+disambiguates) since it gates candidates rather than being solved against.
+
+Scope
+-----
+Line-only matching is in scope. Junction-graph matching (using line
+intersections as point features) is explicitly DEFERRED to a later leaf and is
+NOT implemented here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import cv2
+import numpy as np
+
+from poc_homography.calibration.extrinsic.ptz_registration import register_frame_lines
+from poc_homography.validation.gcp_distribution import calculate_distribution
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    import numpy.typing as npt
+
+    from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+    from poc_homography.calibration.lens_distortion.calibration_table import (
+        CameraCalibrationTable,
+    )
+    from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+    from poc_homography.domain.vo.ortho_line import OrthoLine
+
+# Minimal sample for a perspective hypothesis: 2 lines = 4 endpoint correspondences.
+_MINIMAL_SAMPLE_LINES = 2
+# A "Poor"/"Insufficient" distribution of inlier endpoints fails fast.
+_REJECTED_DISTRIBUTION_QUALITIES = frozenset({"Poor", "Insufficient"})
+
+
+class InsufficientCorrespondenceError(Exception):
+    """Raised when automatic matching cannot yield a trustworthy correspondence.
+
+    This is the typed fail-fast error for the auto-GCP matcher. It carries enough
+    context for the caller to report *why* matching was rejected without parsing
+    the message string.
+
+    Attributes:
+        reason: Human-readable explanation of which gate tripped.
+        num_inliers: Inlier (frame, ortho) pairs found by the best hypothesis.
+        num_candidates: Total descriptor/prior-gated candidate pairs considered.
+        distribution_quality: Distribution quality label of the inlier frame
+            endpoints (one of "Good"/"Fair"/"Poor"/"Insufficient"), or None when
+            the failure occurred before distribution was assessed.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        num_inliers: int,
+        num_candidates: int,
+        distribution_quality: str | None = None,
+    ) -> None:
+        """Initialize with the fail-fast reason and match provenance.
+
+        Args:
+            reason: Human-readable explanation of which gate tripped.
+            num_inliers: Inlier (frame, ortho) pairs from the best hypothesis.
+            num_candidates: Total candidate pairs considered.
+            distribution_quality: Inlier-endpoint distribution quality, if known.
+        """
+        super().__init__(reason)
+        self.reason = reason
+        self.num_inliers = num_inliers
+        self.num_candidates = num_candidates
+        self.distribution_quality = distribution_quality
+
+
+@dataclass(frozen=True)
+class AutoMatchResult:
+    """Outcome of automatic matching + refined registration.
+
+    Wraps the refined :class:`PtzRegistrationResult` together with the provenance
+    of the automatic match: the discovered seed and the candidate/inlier counts.
+
+    Attributes:
+        seed: Discovered correspondence, frame-line index → ``"ortho_{i}"``.
+        num_candidates: Total descriptor/prior-gated candidate pairs considered.
+        num_inliers: Inlier (frame, ortho) pairs the winning hypothesis explained.
+        distribution_quality: Distribution quality label of the inlier frame
+            endpoints ("Good"/"Fair"/"Poor"/"Insufficient").
+        registration: The refined registration result from
+            :func:`register_frame_lines` (carries the homography, inverse, and
+            fit metrics).
+    """
+
+    seed: Mapping[int, str]
+    num_candidates: int
+    num_inliers: int
+    distribution_quality: str
+    registration: PtzRegistrationResult
+
+    @property
+    def homography_matrix(self) -> npt.NDArray[np.float64]:
+        """3x3 matrix mapping frame pixels → ortho map-pixels (refined fit)."""
+        return self.registration.homography_matrix
+
+    @property
+    def inverse_matrix(self) -> npt.NDArray[np.float64]:
+        """3x3 inverse mapping ortho map-pixels → frame pixels (refined fit)."""
+        return self.registration.inverse_matrix
+
+
+def _line_endpoints(
+    line: CandidateLine | OrthoLine,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return a line's (start, end) endpoints as float64 (x, y) arrays.
+
+    Works for both :class:`CandidateLine` (``start``/``end``) and
+    :class:`OrthoLine` (``start_pixel``/``end_pixel``).
+    """
+    start = getattr(line, "start", None)
+    if start is not None:
+        end = line.end  # type: ignore[union-attr]
+    else:
+        start = line.start_pixel  # type: ignore[union-attr]
+        end = line.end_pixel  # type: ignore[union-attr]
+    return (
+        np.asarray([float(start[0]), float(start[1])], dtype=np.float64),
+        np.asarray([float(end[0]), float(end[1])], dtype=np.float64),
+    )
+
+
+def _angle_deg(start: npt.NDArray[np.float64], end: npt.NDArray[np.float64]) -> float:
+    """Orientation of a segment in degrees (atan2 of the endpoint delta)."""
+    delta = end - start
+    return float(np.degrees(np.arctan2(delta[1], delta[0])))
+
+
+def _angle_diff_mod180(angle_a: float, angle_b: float) -> float:
+    """Smallest direction-independent angle difference, in [0, 90] degrees."""
+    diff = abs(angle_a - angle_b) % 180.0
+    return min(diff, 180.0 - diff)
+
+
+def _length(start: npt.NDArray[np.float64], end: npt.NDArray[np.float64]) -> float:
+    """Euclidean length of a segment."""
+    return float(np.linalg.norm(end - start))
+
+
+def _perp_distance(
+    point: npt.NDArray[np.float64],
+    line_start: npt.NDArray[np.float64],
+    line_end: npt.NDArray[np.float64],
+) -> float:
+    """Perpendicular distance from a point to an infinite line through two points.
+
+    Mirrors ``MapPointHomography._point_to_line_distance`` (unclamped projection)
+    so the inlier metric here matches the refined solver's metric exactly.
+    """
+    line_vec = line_end - line_start
+    point_vec = point - line_start
+    line_len_sq = float(np.dot(line_vec, line_vec))
+    if line_len_sq < 1e-10:
+        return float(np.linalg.norm(point_vec))
+    t = float(np.dot(point_vec, line_vec)) / line_len_sq
+    projection = line_start + t * line_vec
+    return float(np.linalg.norm(point - projection))
+
+
+@dataclass(frozen=True)
+class _LineGeom:
+    """Cached geometry for one line (frame or ortho)."""
+
+    start: npt.NDArray[np.float64]
+    end: npt.NDArray[np.float64]
+    mid: npt.NDArray[np.float64]
+    angle_deg: float
+    length: float
+
+
+def _geom(line: CandidateLine | OrthoLine) -> _LineGeom:
+    """Build cached :class:`_LineGeom` for a line."""
+    start, end = _line_endpoints(line)
+    return _LineGeom(
+        start=start,
+        end=end,
+        mid=(start + end) / 2.0,
+        angle_deg=_angle_deg(start, end),
+        length=_length(start, end),
+    )
+
+
+def _apply_homography(
+    homography: npt.NDArray[np.float64], point: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    """Apply a 3x3 homography to a single (x, y) point."""
+    pt = np.asarray([[[point[0], point[1]]]], dtype=np.float64)
+    out = cv2.perspectiveTransform(pt, homography)[0, 0]
+    return np.asarray([float(out[0]), float(out[1])], dtype=np.float64)
+
+
+def _generate_candidates(
+    frame_geoms: Sequence[_LineGeom],
+    ortho_geoms: Sequence[_LineGeom],
+    *,
+    pose_prior: npt.NDArray[np.float64] | None,
+    angle_tolerance_deg: float,
+    length_ratio_tolerance: float,
+    prior_distance_tolerance: float,
+) -> list[tuple[int, int]]:
+    """Enumerate plausible (frame_index, ortho_index) candidate pairs.
+
+    Descriptor gating (always applied): the projected/raw orientation must agree
+    within ``angle_tolerance_deg`` (modulo 180°), and the length ratio must lie
+    within ``[1 - t, 1 + t]`` for ``t = length_ratio_tolerance``. When
+    ``pose_prior`` (frame→ortho) is given, each frame line is projected into ortho
+    space; the length ratio and angle are then compared in ortho space and the
+    projected midpoint must be within ``prior_distance_tolerance`` map pixels of
+    the ortho line's midpoint. This proximity gate is what disambiguates
+    repetitive parallel lines.
+
+    Returns:
+        List of (frame_index, ortho_index) candidate pairs.
+    """
+    candidates: list[tuple[int, int]] = []
+
+    for f_idx, f_geom in enumerate(frame_geoms):
+        if pose_prior is not None:
+            proj_start = _apply_homography(pose_prior, f_geom.start)
+            proj_end = _apply_homography(pose_prior, f_geom.end)
+            f_angle = _angle_deg(proj_start, proj_end)
+            f_length = _length(proj_start, proj_end)
+            f_mid = (proj_start + proj_end) / 2.0
+        else:
+            f_angle = f_geom.angle_deg
+            f_length = f_geom.length
+            f_mid = f_geom.mid
+
+        for o_idx, o_geom in enumerate(ortho_geoms):
+            if _angle_diff_mod180(f_angle, o_geom.angle_deg) > angle_tolerance_deg:
+                continue
+            if o_geom.length < 1e-9 or f_length < 1e-9:
+                continue
+            ratio = f_length / o_geom.length
+            if not (1.0 - length_ratio_tolerance <= ratio <= 1.0 + length_ratio_tolerance):
+                continue
+            if pose_prior is not None:
+                if float(np.linalg.norm(f_mid - o_geom.mid)) > prior_distance_tolerance:
+                    continue
+            candidates.append((f_idx, o_idx))
+
+    return candidates
+
+
+def _minimal_hypothesis(
+    frame_a: _LineGeom,
+    ortho_a: _LineGeom,
+    frame_b: _LineGeom,
+    ortho_b: _LineGeom,
+) -> npt.NDArray[np.float64] | None:
+    """Compute a frame→ortho homography from two line correspondences.
+
+    Builds the 4 endpoint correspondences and solves with
+    ``cv2.getPerspectiveTransform`` (deterministic, no RNG). The two lines'
+    relative endpoint orientation is ambiguous, so all four orientation
+    combinations are tried and the one with the smallest endpoint reprojection
+    residual is kept.
+
+    Returns:
+        A 3x3 frame→ortho homography, or None if every orientation is degenerate.
+    """
+    best_h: npt.NDArray[np.float64] | None = None
+    best_err = float("inf")
+
+    for flip_a in (False, True):
+        for flip_b in (False, True):
+            a_o_start, a_o_end = (
+                (ortho_a.end, ortho_a.start) if flip_a else (ortho_a.start, ortho_a.end)
+            )
+            b_o_start, b_o_end = (
+                (ortho_b.end, ortho_b.start) if flip_b else (ortho_b.start, ortho_b.end)
+            )
+            src = np.asarray(
+                [frame_a.start, frame_a.end, frame_b.start, frame_b.end], dtype=np.float32
+            )
+            dst = np.asarray([a_o_start, a_o_end, b_o_start, b_o_end], dtype=np.float32)
+            try:
+                hyp = cv2.getPerspectiveTransform(src, dst)
+            except cv2.error:
+                continue
+            hyp_arr = np.asarray(hyp, dtype=np.float64)
+            if abs(float(np.linalg.det(hyp_arr))) < 1e-12:
+                continue
+            projected = cv2.perspectiveTransform(
+                src.reshape(-1, 1, 2).astype(np.float64), hyp_arr
+            ).reshape(-1, 2)
+            err = float(np.sum(np.linalg.norm(projected - dst.astype(np.float64), axis=1)))
+            if err < best_err:
+                best_err = err
+                best_h = hyp_arr
+
+    return best_h
+
+
+def _score_hypothesis(
+    homography: npt.NDArray[np.float64],
+    candidates: Sequence[tuple[int, int]],
+    frame_geoms: Sequence[_LineGeom],
+    ortho_geoms: Sequence[_LineGeom],
+    ransac_threshold: float,
+) -> dict[int, tuple[int, float]]:
+    """Score candidates against a hypothesis, resolving one ortho per frame line.
+
+    A (frame, ortho) candidate is an inlier when BOTH frame endpoints, projected
+    by ``homography``, lie within ``ransac_threshold`` of the ortho infinite
+    line. Each frame line keeps only its lowest-error inlier ortho match.
+
+    Returns:
+        Mapping frame_index → (ortho_index, max_endpoint_error) for inliers.
+    """
+    best_for_frame: dict[int, tuple[int, float]] = {}
+
+    for f_idx, o_idx in candidates:
+        f_geom = frame_geoms[f_idx]
+        o_geom = ortho_geoms[o_idx]
+        proj_start = _apply_homography(homography, f_geom.start)
+        proj_end = _apply_homography(homography, f_geom.end)
+        dist_start = _perp_distance(proj_start, o_geom.start, o_geom.end)
+        dist_end = _perp_distance(proj_end, o_geom.start, o_geom.end)
+        worst = max(dist_start, dist_end)
+        if worst >= ransac_threshold:
+            continue
+        prior = best_for_frame.get(f_idx)
+        if prior is None or worst < prior[1]:
+            best_for_frame[f_idx] = (o_idx, worst)
+
+    return best_for_frame
+
+
+def _resolve_injective(
+    matches: Mapping[int, tuple[int, float]],
+) -> dict[int, int]:
+    """Resolve frame→ortho matches to an injective mapping (one ortho per line).
+
+    If two frame lines claim the same ortho line, only the lower-error frame line
+    keeps it; the loser is dropped. Returns frame_index → ortho_index.
+    """
+    # Order frame lines by ascending error so the best claim wins each ortho.
+    ordered = sorted(matches.items(), key=lambda kv: kv[1][1])
+    used_ortho: set[int] = set()
+    resolved: dict[int, int] = {}
+    for f_idx, (o_idx, _err) in ordered:
+        if o_idx in used_ortho:
+            continue
+        used_ortho.add(o_idx)
+        resolved[f_idx] = o_idx
+    return resolved
+
+
+def match_and_register(
+    *,
+    frame_lines: Sequence[CandidateLine],
+    ortho_lines: Sequence[OrthoLine],
+    calibration_table: CameraCalibrationTable,
+    commanded_zoom: float,
+    commanded_tilt: float,
+    map_id: str,
+    image_width: int,
+    image_height: int,
+    pose_prior: npt.NDArray[np.float64] | None = None,
+    run_id: str | None = None,
+    camera_id: str | None = None,
+    rng_seed: int = 0,
+    ransac_iterations: int = 200,
+    ransac_threshold: float = 50.0,
+    min_inlier_ratio: float = 0.5,
+    min_inliers: int = 4,
+    angle_tolerance_deg: float = 10.0,
+    length_ratio_tolerance: float = 0.5,
+    prior_distance_tolerance: float = 200.0,
+) -> AutoMatchResult:
+    """Automatically match frame lines to ortho lines, then register them.
+
+    This is the no-manual-seed entry point: it discovers the frame-line ↔
+    ortho-line correspondence via seeded RANSAC over line descriptors (optionally
+    gated by a coarse ``pose_prior``), fails fast on a weak/poorly-distributed
+    inlier set, and delegates the refined solve to
+    :func:`register_frame_lines`. No homography/RANSAC/ICP is reimplemented here;
+    only candidate SELECTION is.
+
+    Args:
+        frame_lines: Camera frame lines in DISTORTED pixel space.
+        ortho_lines: Orthophoto lines, keyed positionally as ``ortho_{i}``.
+        calibration_table: Per-zoom camera calibration table.
+        commanded_zoom: Zoom the frame was captured at (intrinsics lookup key).
+        commanded_tilt: Tilt the frame was captured at (provenance only).
+        map_id: Orthophoto map identifier for the homography provider.
+        image_width: Frame width in pixels (for inlier distribution analysis).
+        image_height: Frame height in pixels (for inlier distribution analysis).
+        pose_prior: Optional coarse 3x3 homography in **frame-pixel → ortho
+            map-pixel** orientation (same as the output). Used only to gate
+            candidates by projected proximity + angle, disambiguating repetitive
+            parallel lines. A perturbed prior is fine. Obtain a commanded-PTZ
+            prior from ``IntrinsicExtrinsicHomography.compute_from_config``.
+        run_id: Survey run for provenance (optional).
+        camera_id: Camera id for provenance (optional).
+        rng_seed: Seed for ``numpy.random.default_rng`` — fixes ALL sampling so
+            runs are reproducible.
+        ransac_iterations: Number of minimal 2-line samples to try.
+        ransac_threshold: Max perpendicular error (map pixels) for an inlier;
+            also forwarded to the refined solver.
+        min_inlier_ratio: Minimum inlier ratio for a valid refined fit.
+        min_inliers: Minimum inlier (frame, ortho) pairs required before solving.
+        angle_tolerance_deg: Max orientation difference (mod 180°) for a candidate.
+        length_ratio_tolerance: Allowed frame/ortho length-ratio deviation from 1.
+        prior_distance_tolerance: Max projected-midpoint distance (map pixels)
+            for a candidate when ``pose_prior`` is supplied.
+
+    Returns:
+        :class:`AutoMatchResult` with the discovered seed, match provenance, and
+        the refined :class:`PtzRegistrationResult`.
+
+    Raises:
+        InsufficientCorrespondenceError: If the best inlier set is below
+            ``min_inliers``, if too few candidates exist to sample, or if the
+            inlier frame endpoints' distribution quality is "Poor"/"Insufficient".
+        ValueError: Propagated from the refined solver on an otherwise-poor fit
+            (e.g. ``min_inlier_ratio`` not met after ICP).
+    """
+    frame_geoms = [_geom(line) for line in frame_lines]
+    ortho_geoms = [_geom(line) for line in ortho_lines]
+
+    candidates = _generate_candidates(
+        frame_geoms,
+        ortho_geoms,
+        pose_prior=pose_prior,
+        angle_tolerance_deg=angle_tolerance_deg,
+        length_ratio_tolerance=length_ratio_tolerance,
+        prior_distance_tolerance=prior_distance_tolerance,
+    )
+    num_candidates = len(candidates)
+
+    if num_candidates < _MINIMAL_SAMPLE_LINES:
+        raise InsufficientCorrespondenceError(
+            f"Too few candidate matches to sample a hypothesis: {num_candidates} "
+            f"(need >= {_MINIMAL_SAMPLE_LINES})",
+            num_inliers=0,
+            num_candidates=num_candidates,
+        )
+
+    rng = np.random.default_rng(rng_seed)
+    candidate_array = np.asarray(candidates, dtype=np.int64)
+
+    best_resolved: dict[int, int] = {}
+
+    for _ in range(ransac_iterations):
+        sample_idx = rng.choice(num_candidates, size=_MINIMAL_SAMPLE_LINES, replace=False)
+        (fa, oa), (fb, ob) = candidate_array[sample_idx]
+        # Two distinct frame lines AND two distinct ortho lines are required for a
+        # non-degenerate minimal hypothesis.
+        if fa == fb or oa == ob:
+            continue
+
+        hypothesis = _minimal_hypothesis(
+            frame_geoms[fa], ortho_geoms[oa], frame_geoms[fb], ortho_geoms[ob]
+        )
+        if hypothesis is None:
+            continue
+
+        matches = _score_hypothesis(
+            hypothesis, candidates, frame_geoms, ortho_geoms, ransac_threshold
+        )
+        resolved = _resolve_injective(matches)
+        if len(resolved) > len(best_resolved):
+            best_resolved = resolved
+
+    num_inliers = len(best_resolved)
+
+    if num_inliers < min_inliers:
+        raise InsufficientCorrespondenceError(
+            f"Best inlier set too small: {num_inliers} < min_inliers {min_inliers}",
+            num_inliers=num_inliers,
+            num_candidates=num_candidates,
+        )
+
+    # Distribution fail-fast over the inlier frame endpoints. We use
+    # calculate_distribution + an explicit count check rather than
+    # validate_ground_control_points: the latter requires GCP-shaped dicts
+    # (map_id/map_pixel_x/...) and only WARNS (does not raise) on low count, so it
+    # does not fit raw line endpoints nor give us a count fail-fast.
+    inlier_endpoints: list[tuple[float, float]] = []
+    for f_idx in best_resolved:
+        f_geom = frame_geoms[f_idx]
+        inlier_endpoints.append((float(f_geom.start[0]), float(f_geom.start[1])))
+        inlier_endpoints.append((float(f_geom.end[0]), float(f_geom.end[1])))
+
+    distribution = calculate_distribution(inlier_endpoints, image_width, image_height)
+    if distribution.quality in _REJECTED_DISTRIBUTION_QUALITIES:
+        raise InsufficientCorrespondenceError(
+            f"Inlier endpoint distribution quality is {distribution.quality!r}; "
+            f"need better spatial coverage",
+            num_inliers=num_inliers,
+            num_candidates=num_candidates,
+            distribution_quality=distribution.quality,
+        )
+
+    seed: dict[int, str] = {
+        f_idx: f"ortho_{o_idx}" for f_idx, o_idx in sorted(best_resolved.items())
+    }
+
+    registration = register_frame_lines(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        seed=seed,
+        calibration_table=calibration_table,
+        commanded_zoom=commanded_zoom,
+        commanded_tilt=commanded_tilt,
+        map_id=map_id,
+        run_id=run_id,
+        camera_id=camera_id,
+        ransac_threshold=ransac_threshold,
+        min_inlier_ratio=min_inlier_ratio,
+    )
+
+    return AutoMatchResult(
+        seed=seed,
+        num_candidates=num_candidates,
+        num_inliers=num_inliers,
+        distribution_quality=distribution.quality,
+        registration=registration,
+    )
+
+
+__all__ = [
+    "AutoMatchResult",
+    "InsufficientCorrespondenceError",
+    "match_and_register",
+]

--- a/poc_homography/calibration/extrinsic/auto_match.py
+++ b/poc_homography/calibration/extrinsic/auto_match.py
@@ -319,6 +319,11 @@ def _minimal_hypothesis(
     best_h: npt.NDArray[np.float64] | None = None
     best_err = float("inf")
 
+    # The frame endpoints are loop-invariant (only the ortho side is flipped), so
+    # build the source array and its cv shape once, outside the orientation loop.
+    src = np.asarray([frame_a.start, frame_a.end, frame_b.start, frame_b.end], dtype=np.float32)
+    src_cv = src.reshape(-1, 1, 2).astype(np.float64)
+
     for flip_a in (False, True):
         for flip_b in (False, True):
             a_o_start, a_o_end = (
@@ -326,9 +331,6 @@ def _minimal_hypothesis(
             )
             b_o_start, b_o_end = (
                 (ortho_b.end, ortho_b.start) if flip_b else (ortho_b.start, ortho_b.end)
-            )
-            src = np.asarray(
-                [frame_a.start, frame_a.end, frame_b.start, frame_b.end], dtype=np.float32
             )
             dst = np.asarray([a_o_start, a_o_end, b_o_start, b_o_end], dtype=np.float32)
             try:
@@ -338,9 +340,7 @@ def _minimal_hypothesis(
             hyp_arr = np.asarray(hyp, dtype=np.float64)
             if abs(float(np.linalg.det(hyp_arr))) < 1e-12:
                 continue
-            projected = cv2.perspectiveTransform(
-                src.reshape(-1, 1, 2).astype(np.float64), hyp_arr
-            ).reshape(-1, 2)
+            projected = cv2.perspectiveTransform(src_cv, hyp_arr).reshape(-1, 2)
             err = float(np.sum(np.linalg.norm(projected - dst.astype(np.float64), axis=1)))
             if err < best_err:
                 best_err = err
@@ -365,13 +365,25 @@ def _score_hypothesis(
     Returns:
         Mapping frame_index → (ortho_index, max_endpoint_error) for inliers.
     """
+    # Project every frame endpoint once (batched), then index per candidate. This
+    # is numerically identical to a per-point transform but avoids two single-point
+    # cv2 calls per candidate inside the RANSAC loop, where the same frame line is
+    # otherwise re-projected once for every ortho line it is paired with.
+    if frame_geoms:
+        endpoints = np.empty((len(frame_geoms) * 2, 1, 2), dtype=np.float64)
+        for i, g in enumerate(frame_geoms):
+            endpoints[2 * i, 0] = g.start
+            endpoints[2 * i + 1, 0] = g.end
+        projected_all = cv2.perspectiveTransform(endpoints, homography).reshape(-1, 2)
+    else:
+        projected_all = np.empty((0, 2), dtype=np.float64)
+
     best_for_frame: dict[int, tuple[int, float]] = {}
 
     for f_idx, o_idx in candidates:
-        f_geom = frame_geoms[f_idx]
         o_geom = ortho_geoms[o_idx]
-        proj_start = _apply_homography(homography, f_geom.start)
-        proj_end = _apply_homography(homography, f_geom.end)
+        proj_start = projected_all[2 * f_idx]
+        proj_end = projected_all[2 * f_idx + 1]
         dist_start = _perp_distance(proj_start, o_geom.start, o_geom.end)
         dist_end = _perp_distance(proj_end, o_geom.start, o_geom.end)
         worst = max(dist_start, dist_end)

--- a/poc_homography/calibration/extrinsic/auto_match.py
+++ b/poc_homography/calibration/extrinsic/auto_match.py
@@ -29,9 +29,10 @@ Algorithm overview
    distance to the ortho *infinite* line — consistent with ``compute_from_lines``).
    Each frame line resolves to at most one ortho line (lowest-error) so the seed
    is a clean, injective mapping.
-3. **Fail-fast** BEFORE the refined solve: too few inliers, a "Poor"/"Insufficient"
-   :func:`calculate_distribution` quality over the inlier frame endpoints, or a
-   too-low inlier count all raise :class:`InsufficientCorrespondenceError`.
+3. **Fail-fast** BEFORE the refined solve: too few gated candidates to even
+   sample a hypothesis, a best inlier set below the inlier-count threshold, or a
+   "Poor"/"Insufficient" :func:`calculate_distribution` quality over the inlier
+   frame endpoints all raise :class:`InsufficientCorrespondenceError`.
 4. **Refined solve.** The discovered seed (``frame_index -> "ortho_{i}"``, with
    ``i`` the positional index of the ortho line in the input sequence, matching
    ``register_frame_lines``' convention) is handed to ``register_frame_lines`` and
@@ -522,9 +523,13 @@ def match_and_register(
 
     num_inliers = len(best_resolved)
 
-    if num_inliers < min_inliers:
+    # Never hand a sub-minimal seed to register_frame_lines (which would raise an
+    # untyped ValueError): the refined solver needs >= 2 lines, so the typed
+    # fail-fast floor is at least _MINIMAL_SAMPLE_LINES regardless of min_inliers.
+    effective_min_inliers = max(min_inliers, _MINIMAL_SAMPLE_LINES)
+    if num_inliers < effective_min_inliers:
         raise InsufficientCorrespondenceError(
-            f"Best inlier set too small: {num_inliers} < min_inliers {min_inliers}",
+            f"Best inlier set too small: {num_inliers} < min_inliers {effective_min_inliers}",
             num_inliers=num_inliers,
             num_candidates=num_candidates,
         )

--- a/tests/calibration/extrinsic/test_auto_match.py
+++ b/tests/calibration/extrinsic/test_auto_match.py
@@ -1,0 +1,348 @@
+"""Offline, deterministic tests for the automatic frame↔ortho RANSAC matcher.
+
+These mirror ``test_ptz_registration.py``'s conventions: a known homography
+warps ortho map-pixel lines into a synthetic frame (ortho→frame), and the
+matcher must recover the correspondence and the inverse frame→ortho homography
+WITHOUT any operator seed. Intrinsics come from a zero-distortion
+:class:`CameraCalibrationTable` so the math is exact.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from poc_homography.calibration.extrinsic import (
+    AutoMatchResult,
+    InsufficientCorrespondenceError,
+    match_and_register,
+)
+from poc_homography.calibration.lens_distortion.calibration_table import (
+    CameraCalibrationTable,
+    ZoomCalibrationEntry,
+)
+from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+from poc_homography.domain.vo.ortho_line import OrthoLine
+
+# Frame is sized so cx=960, cy=540 sit at the image center.
+_IMAGE_WIDTH = 1920
+_IMAGE_HEIGHT = 1080
+
+# Known perspective warp ORTHO map-pixel -> FRAME pixel; the matcher recovers
+# frame -> ortho (≈ inverse of this).
+_H_ORTHO_TO_FRAME = np.array(
+    [
+        [1.10, 0.05, 40.0],
+        [0.03, 1.20, 25.0],
+        [1.0e-4, 5.0e-5, 1.0],
+    ],
+    dtype=np.float64,
+)
+
+# Well-conditioned ortho segments with varied orientations, spread across the
+# frame so the warped inlier endpoints achieve a "Good"/"Fair" distribution.
+_ORTHO_SEGMENTS: list[tuple[tuple[float, float], tuple[float, float]]] = [
+    ((150.0, 150.0), (1400.0, 180.0)),  # near-horizontal (top)
+    ((200.0, 250.0), (240.0, 850.0)),  # near-vertical (left)
+    ((300.0, 300.0), (1300.0, 820.0)),  # diagonal /
+    ((1350.0, 260.0), (350.0, 800.0)),  # diagonal \
+    ((900.0, 200.0), (940.0, 880.0)),  # another vertical-ish (center)
+]
+
+# Repetitive near-parallel lines (parking-stall style): same orientation,
+# offset sideways, spread across the frame. Descriptor-only matching could swap.
+_REPETITIVE_SEGMENTS: list[tuple[tuple[float, float], tuple[float, float]]] = [
+    ((250.0, 150.0), (280.0, 850.0)),
+    ((650.0, 150.0), (680.0, 850.0)),
+    ((1050.0, 150.0), (1080.0, 850.0)),
+    ((200.0, 180.0), (1300.0, 210.0)),  # one cross line to anchor the fit
+]
+
+
+def _zero_distortion_table(camera_id: str = "cam1") -> CameraCalibrationTable:
+    """Calibration table with real intrinsics but zero distortion (exact math)."""
+    table = CameraCalibrationTable(camera_id=camera_id)
+    table.add_entry(
+        ZoomCalibrationEntry(
+            zoom_factor=1.0,
+            k1=0.0,
+            k2=0.0,
+            k3=0.0,
+            p1=0.0,
+            p2=0.0,
+            calibration_date="2024-01-01T00:00:00",
+            fx=1000.0,
+            fy=1000.0,
+            cx=960.0,
+            cy=540.0,
+        )
+    )
+    return table
+
+
+def _ortho_lines(
+    segments: list[tuple[tuple[float, float], tuple[float, float]]],
+) -> list[OrthoLine]:
+    """Build OrthoLine objects from canned segments (arbitrary UTM)."""
+    lines: list[OrthoLine] = []
+    for i, (start, end) in enumerate(segments):
+        lines.append(
+            OrthoLine.from_endpoints(
+                start_pixel=start,
+                end_pixel=end,
+                start_utm=(500000.0 + i, 4000000.0 + i),
+                end_utm=(500010.0 + i, 4000010.0 + i),
+            )
+        )
+    return lines
+
+
+def _warp_point(point: tuple[float, float], homography: np.ndarray) -> tuple[float, float]:
+    """Apply a homography to a single (x, y) point."""
+    pt = np.array([[[point[0], point[1]]]], dtype=np.float64)
+    out = cv2.perspectiveTransform(pt, homography)[0, 0]
+    return float(out[0]), float(out[1])
+
+
+def _frame_lines_from_ortho(
+    ortho_lines: list[OrthoLine], homography: np.ndarray
+) -> list[CandidateLine]:
+    """Project each ortho line's map-pixel endpoints into frame pixels via H."""
+    frame_lines: list[CandidateLine] = []
+    for line in ortho_lines:
+        start = _warp_point((float(line.start_pixel[0]), float(line.start_pixel[1])), homography)
+        end = _warp_point((float(line.end_pixel[0]), float(line.end_pixel[1])), homography)
+        frame_lines.append(CandidateLine(start=start, end=end))
+    return frame_lines
+
+
+def _max_reprojection_error(
+    result: AutoMatchResult,
+    ortho_lines: list[OrthoLine],
+    frame_lines: list[CandidateLine],
+    seed: dict[int, str],
+) -> float:
+    """Max distance projecting each matched frame endpoint back to its ortho."""
+    max_err = 0.0
+    for f_idx, ortho_id in seed.items():
+        o_idx = int(ortho_id.removeprefix("ortho_"))
+        line = ortho_lines[o_idx]
+        frame_line = frame_lines[f_idx]
+        for frame_pt, ortho_pt in (
+            (frame_line.start, line.start_pixel),
+            (frame_line.end, line.end_pixel),
+        ):
+            recovered = _warp_point(frame_pt, result.homography_matrix)
+            err = float(
+                np.hypot(recovered[0] - float(ortho_pt[0]), recovered[1] - float(ortho_pt[1]))
+            )
+            max_err = max(max_err, err)
+    return max_err
+
+
+# ---------------------------------------------------------------------------
+# DoD: recovery without seeding (incl. repetitive + spurious outlier lines)
+# ---------------------------------------------------------------------------
+
+
+def test_recovers_correspondence_without_seeding() -> None:
+    ortho_lines = _ortho_lines(_ORTHO_SEGMENTS)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_ORTHO_TO_FRAME)
+
+    # Add spurious outlier frame lines that match NO ortho line.
+    frame_lines.append(CandidateLine(start=(1500.0, 50.0), end=(1700.0, 60.0)))
+    frame_lines.append(CandidateLine(start=(50.0, 900.0), end=(60.0, 1000.0)))
+
+    result = match_and_register(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        calibration_table=_zero_distortion_table(),
+        commanded_zoom=1.0,
+        commanded_tilt=-15.0,
+        map_id="map_test",
+        image_width=_IMAGE_WIDTH,
+        image_height=_IMAGE_HEIGHT,
+        rng_seed=0,
+        ransac_threshold=5.0,
+    )
+
+    assert isinstance(result, AutoMatchResult)
+    # Each of the 5 real frame lines (indices 0..4) maps to ortho_i.
+    expected = {i: f"ortho_{i}" for i in range(len(ortho_lines))}
+    assert dict(result.seed) == expected
+    assert result.num_inliers == len(ortho_lines)
+
+    max_err = _max_reprojection_error(result, ortho_lines, frame_lines, dict(result.seed))
+    assert max_err < 1.0, f"max reprojection error {max_err:.4f}px exceeds tolerance"
+
+
+def test_recovers_repetitive_lines_descriptor_only() -> None:
+    """Repetitive parallel lines, recovered by line-only matching (no prior)."""
+    ortho_lines = _ortho_lines(_REPETITIVE_SEGMENTS)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_ORTHO_TO_FRAME)
+
+    result = match_and_register(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        calibration_table=_zero_distortion_table(),
+        commanded_zoom=1.0,
+        commanded_tilt=-15.0,
+        map_id="map_test",
+        image_width=_IMAGE_WIDTH,
+        image_height=_IMAGE_HEIGHT,
+        rng_seed=0,
+        ransac_threshold=5.0,
+    )
+
+    expected = {i: f"ortho_{i}" for i in range(len(ortho_lines))}
+    assert dict(result.seed) == expected
+    max_err = _max_reprojection_error(result, ortho_lines, frame_lines, dict(result.seed))
+    assert max_err < 1.0
+
+
+# ---------------------------------------------------------------------------
+# DoD: disambiguation via pose prior
+# ---------------------------------------------------------------------------
+
+
+def test_pose_prior_disambiguates_repetitive_lines() -> None:
+    ortho_lines = _ortho_lines(_REPETITIVE_SEGMENTS)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_ORTHO_TO_FRAME)
+
+    # Prior is frame->ortho (same orientation as output): inverse of the
+    # ortho->frame warp, then PERTURBED so it is only approximately correct.
+    true_frame_to_ortho = np.linalg.inv(_H_ORTHO_TO_FRAME)
+    perturbation = np.array(
+        [
+            [1.02, 0.01, 8.0],
+            [-0.01, 0.98, -6.0],
+            [1.0e-5, -1.0e-5, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    pose_prior = perturbation @ true_frame_to_ortho
+
+    result = match_and_register(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        calibration_table=_zero_distortion_table(),
+        commanded_zoom=1.0,
+        commanded_tilt=-15.0,
+        map_id="map_test",
+        image_width=_IMAGE_WIDTH,
+        image_height=_IMAGE_HEIGHT,
+        pose_prior=pose_prior,
+        rng_seed=0,
+        ransac_threshold=5.0,
+        # Tight gate that only the prior-correct match survives.
+        prior_distance_tolerance=60.0,
+    )
+
+    expected = {i: f"ortho_{i}" for i in range(len(ortho_lines))}
+    assert dict(result.seed) == expected
+    max_err = _max_reprojection_error(result, ortho_lines, frame_lines, dict(result.seed))
+    assert max_err < 1.0
+
+
+# ---------------------------------------------------------------------------
+# DoD: fail-fast — too few inliers
+# ---------------------------------------------------------------------------
+
+
+def test_fail_fast_too_few_inliers() -> None:
+    # Only two ortho lines -> at most 2 inlier lines, below min_inliers=4.
+    ortho_lines = _ortho_lines(_ORTHO_SEGMENTS[:2])
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_ORTHO_TO_FRAME)
+
+    with pytest.raises(InsufficientCorrespondenceError) as excinfo:
+        match_and_register(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            image_width=_IMAGE_WIDTH,
+            image_height=_IMAGE_HEIGHT,
+            rng_seed=0,
+            ransac_threshold=5.0,
+            min_inliers=4,
+        )
+
+    assert excinfo.value.num_inliers < 4
+
+
+# ---------------------------------------------------------------------------
+# DoD: fail-fast — Poor/Insufficient distribution
+# ---------------------------------------------------------------------------
+
+
+def test_fail_fast_poor_distribution() -> None:
+    """All matched lines clustered in one small image region -> reject."""
+    # Tightly clustered, distinctly-oriented ortho lines in a tiny corner so the
+    # convex hull is minuscule and quadrant coverage is 1 -> "Poor"/"Insufficient".
+    clustered_segments: list[tuple[tuple[float, float], tuple[float, float]]] = [
+        ((100.0, 100.0), (140.0, 102.0)),
+        ((105.0, 100.0), (107.0, 140.0)),
+        ((100.0, 105.0), (138.0, 138.0)),
+        ((138.0, 102.0), (102.0, 138.0)),
+    ]
+    ortho_lines = _ortho_lines(clustered_segments)
+    # Mild warp keeps everything in the top-left frame corner.
+    mild = np.array(
+        [
+            [1.0, 0.0, 5.0],
+            [0.0, 1.0, 5.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    frame_lines = _frame_lines_from_ortho(ortho_lines, mild)
+
+    with pytest.raises(InsufficientCorrespondenceError) as excinfo:
+        match_and_register(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            image_width=_IMAGE_WIDTH,
+            image_height=_IMAGE_HEIGHT,
+            rng_seed=0,
+            ransac_threshold=5.0,
+            min_inliers=4,
+        )
+
+    assert excinfo.value.distribution_quality in {"Poor", "Insufficient"}
+
+
+# ---------------------------------------------------------------------------
+# DoD: determinism
+# ---------------------------------------------------------------------------
+
+
+def test_determinism_same_seed_identical_output() -> None:
+    ortho_lines = _ortho_lines(_ORTHO_SEGMENTS)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_ORTHO_TO_FRAME)
+    frame_lines.append(CandidateLine(start=(1500.0, 50.0), end=(1700.0, 60.0)))
+
+    kwargs = {
+        "frame_lines": frame_lines,
+        "ortho_lines": ortho_lines,
+        "calibration_table": _zero_distortion_table(),
+        "commanded_zoom": 1.0,
+        "commanded_tilt": -15.0,
+        "map_id": "map_test",
+        "image_width": _IMAGE_WIDTH,
+        "image_height": _IMAGE_HEIGHT,
+        "rng_seed": 7,
+        "ransac_threshold": 5.0,
+    }
+
+    result_a = match_and_register(**kwargs)
+    result_b = match_and_register(**kwargs)
+
+    assert dict(result_a.seed) == dict(result_b.seed)
+    np.testing.assert_array_equal(result_a.homography_matrix, result_b.homography_matrix)

--- a/tests/calibration/extrinsic/test_auto_match.py
+++ b/tests/calibration/extrinsic/test_auto_match.py
@@ -273,6 +273,34 @@ def test_fail_fast_too_few_inliers() -> None:
     assert excinfo.value.num_inliers < 4
 
 
+def test_fail_fast_no_candidates() -> None:
+    """No descriptor-compatible pairs -> distinct too-few-candidates gate."""
+    ortho_lines = _ortho_lines(_ORTHO_SEGMENTS)
+    # Frame lines that match NO ortho line by length: ortho segments are
+    # >=600px, these are ~6px, so the length-ratio gate rejects every pair.
+    frame_lines = [
+        CandidateLine(start=(100.0, 100.0), end=(106.0, 100.0)),
+        CandidateLine(start=(800.0, 600.0), end=(800.0, 606.0)),
+    ]
+
+    with pytest.raises(InsufficientCorrespondenceError) as excinfo:
+        match_and_register(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            image_width=_IMAGE_WIDTH,
+            image_height=_IMAGE_HEIGHT,
+            rng_seed=0,
+        )
+
+    # Failed before any inlier was scored: zero inliers, fewer than 2 candidates.
+    assert excinfo.value.num_inliers == 0
+    assert excinfo.value.num_candidates < 2
+
+
 # ---------------------------------------------------------------------------
 # DoD: fail-fast — Poor/Insufficient distribution
 # ---------------------------------------------------------------------------
@@ -344,5 +372,15 @@ def test_determinism_same_seed_identical_output() -> None:
     result_a = match_and_register(**kwargs)
     result_b = match_and_register(**kwargs)
 
+    # Same seed -> bit-for-bit identical output.
     assert dict(result_a.seed) == dict(result_b.seed)
     np.testing.assert_array_equal(result_a.homography_matrix, result_b.homography_matrix)
+
+    # ...and the identical output is the CORRECT correspondence, not equal garbage.
+    expected = {i: f"ortho_{i}" for i in range(len(ortho_lines))}
+    assert dict(result_a.seed) == expected
+
+    # A different seed still recovers the correct correspondence: the RNG is
+    # genuinely consumed (this well-determined problem converges regardless).
+    result_c = match_and_register(**{**kwargs, "rng_seed": 123})
+    assert dict(result_c.seed) == expected


### PR DESCRIPTION
Closes #358

## Summary

Automatic (no-manual-seed) frame-line↔ortho-line matcher: descriptor-gated candidates with an optional commanded-PTZ pose prior, seeded-deterministic RANSAC over minimal 2-line sets to maximize inliers, then hands the discovered seed to register_frame_lines/compute_from_lines for the refined solve. Typed InsufficientCorrespondenceError fail-fast below the inlier threshold or on Poor/Insufficient distribution. Selection only — no homography/RANSAC/ICP/distortion reimplemented. Line-only matching; junctions deferred.

## Test plan

poe ci green (1342 passed, 158 env-gated skips). New offline tests in tests/calibration/extrinsic/test_auto_match.py: recovery without seeding (with outliers), descriptor-only repetitive lines, pose-prior disambiguation, fail-fast on too-few-inliers, fail-fast on poor distribution, determinism across runs with fixed rng_seed.

## Closes DoD bullets

- Synthetic ortho-warped frames recover correct correspondences + H without seeding (offline)
- Fail-fast: below inlier threshold or Insufficient/Poor distribution → typed insufficient-correspondence error
- Seeded RANSAC deterministic across runs in the offline test
- poe ci green
