### PR TITLE
feat(calib): hold-out reprojection validation + multi-frame consolidation [#359]

### DIFF
--- a/poc_homography/calibration/extrinsic/__init__.py
+++ b/poc_homography/calibration/extrinsic/__init__.py
@@ -8,7 +8,9 @@ The pipeline does NOT implement homography/RANSAC/ICP/distortion itself — it
 delegates all of that to :class:`MapPointHomography.compute_from_lines`. The
 seeded leaf takes an explicit operator correspondence; the automatic leaf
 (:func:`match_and_register`) discovers the correspondence itself and feeds the
-discovered seed to the seeded core.
+discovered seed to the seeded core. The validation leaf
+(:func:`validate_with_holdout`, :func:`consolidate_ptz_frames`) adds hold-out
+reprojection validation in ground meters and multi-frame consolidation on top.
 """
 
 from poc_homography.calibration.extrinsic.auto_match import (
@@ -21,12 +23,28 @@ from poc_homography.calibration.extrinsic.ptz_registration import (
     register_frame_lines,
     register_ptz_state,
 )
+from poc_homography.calibration.extrinsic.validation import (
+    FrameCorrespondence,
+    HoldoutValidationError,
+    HoldoutValidationResult,
+    MultiFrameConsolidationResult,
+    ReprojectionStats,
+    consolidate_ptz_frames,
+    validate_with_holdout,
+)
 
 __all__ = [
     "AutoMatchResult",
+    "FrameCorrespondence",
+    "HoldoutValidationError",
+    "HoldoutValidationResult",
     "InsufficientCorrespondenceError",
+    "MultiFrameConsolidationResult",
     "PtzRegistrationResult",
+    "ReprojectionStats",
+    "consolidate_ptz_frames",
     "match_and_register",
     "register_frame_lines",
     "register_ptz_state",
+    "validate_with_holdout",
 ]

--- a/poc_homography/calibration/extrinsic/ptz_registration.py
+++ b/poc_homography/calibration/extrinsic/ptz_registration.py
@@ -87,7 +87,7 @@ class PtzRegistrationResult:
     commanded_tilt: float
 
 
-def _intrinsic_kwargs(
+def intrinsic_kwargs(
     calibration_table: CameraCalibrationTable,
     commanded_zoom: float,
 ) -> dict[str, float]:
@@ -123,7 +123,7 @@ def _intrinsic_kwargs(
     }
 
 
-def _build_line_inputs(
+def build_line_inputs(
     frame_lines: Sequence[CandidateLine],
     ortho_lines: Sequence[OrthoLine],
     seed: Mapping[int, str],
@@ -233,9 +233,9 @@ def register_frame_lines(
         ValueError: If the seed is invalid or the fit quality is too poor.
         RuntimeError: If the underlying homography computation fails.
     """
-    line_annotations, line_registry = _build_line_inputs(frame_lines, ortho_lines, seed)
+    line_annotations, line_registry = build_line_inputs(frame_lines, ortho_lines, seed)
 
-    provider = MapPointHomography(map_id, **_intrinsic_kwargs(calibration_table, commanded_zoom))
+    provider = MapPointHomography(map_id, **intrinsic_kwargs(calibration_table, commanded_zoom))
     result = provider.compute_from_lines(
         line_annotations,
         line_registry,
@@ -322,6 +322,8 @@ def register_ptz_state(
 
 __all__ = [
     "PtzRegistrationResult",
+    "build_line_inputs",
+    "intrinsic_kwargs",
     "register_frame_lines",
     "register_ptz_state",
 ]

--- a/poc_homography/calibration/extrinsic/validation.py
+++ b/poc_homography/calibration/extrinsic/validation.py
@@ -33,7 +33,7 @@ seeded/auto leaves.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -48,7 +48,6 @@ from poc_homography.types import PixelsFloat
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from typing import Any
 
     import numpy.typing as npt
 
@@ -213,8 +212,10 @@ def _apply_homography(
     """Apply a 3x3 homography to a single (x, y) point in float64.
 
     Uses an explicit float64 matrix-vector product (not
-    ``cv2.perspectiveTransform``, which casts to float32) to keep meter-scale
-    reprojection errors free of avoidable single-precision noise.
+    ``cv2.perspectiveTransform``, which casts to float32) so this step adds no
+    single-precision noise of its own. Note the dominant precision floor is set
+    upstream by ``compute_from_lines``, whose ICP runs in float32; this keeps the
+    meters conversion from compounding that, it does not recover it.
 
     Args:
         homography: 3x3 homography matrix.
@@ -222,8 +223,14 @@ def _apply_homography(
 
     Returns:
         (x', y') transformed point in the destination frame.
+
+    Raises:
+        ValueError: If the point maps onto the homography's vanishing line
+            (homogeneous w ≈ 0), where no finite Euclidean image exists.
     """
     vec = homography @ np.array([point[0], point[1], 1.0], dtype=np.float64)
+    if abs(vec[2]) < 1e-12:
+        raise ValueError("Point maps onto the homography vanishing line (w ~ 0); no finite image")
     return (float(vec[0] / vec[2]), float(vec[1] / vec[2]))
 
 
@@ -232,7 +239,15 @@ def _correspondence_pairs(
     ortho_lines: Sequence[OrthoLine],
     seed: Mapping[int, str],
 ) -> list[tuple[CandidateLine, OrthoLine]]:
-    """Resolve a seed into (frame_line, ortho_line) pairs.
+    """Resolve a seed into (frame_line, ortho_line) endpoint-pair tuples.
+
+    This is the endpoint-resolution counterpart to
+    :func:`build_line_inputs` (which yields solver dicts). It is a separate path
+    because the hold-out subset is scored here WITHOUT ever passing through the
+    solver, so its indices are validated here rather than in ``build_line_inputs``
+    (and, unlike that function, no >= 2-line floor applies — a single held-out
+    line is valid). Bounds-check wording mirrors ``build_line_inputs`` so the same
+    malformed seed reports consistently regardless of which path catches it.
 
     Args:
         frame_lines: Camera frame lines.

--- a/poc_homography/calibration/extrinsic/validation.py
+++ b/poc_homography/calibration/extrinsic/validation.py
@@ -1,0 +1,550 @@
+"""Hold-out reprojection validation + multi-frame consolidation for one PTZ state.
+
+This leaf adds two things on top of the seeded/auto registration leaves
+(:mod:`poc_homography.calibration.extrinsic.ptz_registration`) WITHOUT building
+a new homography estimator or a general bundle adjuster:
+
+1. **Hold-out reprojection validation** (:func:`validate_with_holdout`).
+   The matched frame-line ↔ ortho-line correspondences are split into a *fit*
+   set and a *hold-out* set. The homography is solved on the fit set only (via
+   the existing :func:`register_frame_lines`) and its reprojection error is
+   measured on the held-out correspondences it never saw. Error is reported in
+   **ortho ground units (meters)** — projected and true endpoints are both run
+   through :meth:`GeoTiff.pixel_to_geo` and compared in easting/northing — not
+   just in map pixels. A hold-out RMS above the caller's threshold raises the
+   typed :class:`HoldoutValidationError`.
+
+2. **Multi-frame consolidation** (:func:`consolidate_ptz_frames`).
+   Several frames captured at the *same* PTZ state are consolidated into ONE
+   registration by *pooling* every frame's line correspondences into a single
+   :meth:`MapPointHomography.compute_from_lines` solve. Pooling more endpoints
+   averages out per-frame line-detection noise, so the consolidated fit reduces
+   or matches the typical single-frame reprojection error. This deliberately
+   REUSES the existing ICP/RANSAC line solver rather than implementing an
+   N-pose bundle adjuster (a separate future sub-epic).
+
+Both features report error in meters through the same
+:class:`ReprojectionStats` (RMS / 90th-percentile / max), computed over line
+*endpoints*. Endpoint correspondence is assumed — it holds for the synthetic
+known-H datasets and for frames whose lines were matched to ortho lines by the
+seeded/auto leaves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from poc_homography.calibration.extrinsic.ptz_registration import (
+    PtzRegistrationResult,
+    build_line_inputs,
+    intrinsic_kwargs,
+    register_frame_lines,
+)
+from poc_homography.homography.map_points import MapPointHomography
+from poc_homography.types import PixelsFloat
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
+
+    import numpy.typing as npt
+
+    from poc_homography.calibration.lens_distortion.calibration_table import (
+        CameraCalibrationTable,
+    )
+    from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+    from poc_homography.domain.vo.geotiff import GeoTiff
+    from poc_homography.domain.vo.ortho_line import OrthoLine
+
+# Minimum lines the underlying solver needs (compute_from_lines: >= 2 lines).
+_MIN_FIT_LINES = 2
+# Hold-out validation needs at least one held-out line on top of the fit set.
+_MIN_HOLDOUT_SEED = _MIN_FIT_LINES + 1
+# Percentile reported alongside RMS/max for the error distribution's tail.
+_TAIL_PERCENTILE = 90.0
+
+
+@dataclass(frozen=True)
+class ReprojectionStats:
+    """Reprojection-error summary in ortho ground units (meters).
+
+    Attributes:
+        rms_m: Root-mean-square endpoint error in meters.
+        p90_m: 90th-percentile endpoint error in meters.
+        max_m: Maximum endpoint error in meters.
+        n_points: Number of endpoint correspondences the stats were computed over.
+    """
+
+    rms_m: float
+    p90_m: float
+    max_m: float
+    n_points: int
+
+
+@dataclass(frozen=True)
+class HoldoutValidationResult:
+    """Outcome of a fit/hold-out reprojection validation.
+
+    Attributes:
+        registration: Registration solved on the FIT correspondences only.
+        fit_stats: Reprojection error (meters) over the fit correspondences.
+        holdout_stats: Reprojection error (meters) over the held-out
+            correspondences the fit never saw.
+        rms_threshold_m: Hold-out RMS threshold (meters) the fit was checked
+            against; ``holdout_stats.rms_m`` is guaranteed ``<=`` this value.
+    """
+
+    registration: PtzRegistrationResult
+    fit_stats: ReprojectionStats
+    holdout_stats: ReprojectionStats
+    rms_threshold_m: float
+
+
+@dataclass(frozen=True)
+class MultiFrameConsolidationResult:
+    """Consolidated registration over several frames at one PTZ state.
+
+    Mirrors :class:`PtzRegistrationResult` but adds the frame count and a
+    meters-unit reprojection summary over every pooled endpoint.
+
+    Attributes:
+        homography_matrix: 3x3 matrix mapping frame pixels → ortho map-pixels.
+        inverse_matrix: 3x3 inverse mapping ortho map-pixels → frame pixels.
+        num_frames: Number of frames pooled into the consolidated solve.
+        num_lines: Total pooled line correspondences across all frames.
+        num_inliers: Inlier point-to-line correspondences after RANSAC/ICP.
+        inlier_ratio: Ratio of inliers to total correspondences in [0.0, 1.0].
+        mean_perp_error: Mean perpendicular error in map pixels (solver units).
+        max_perp_error: Maximum perpendicular error in map pixels.
+        rmse: Root-mean-square of perpendicular errors in map pixels.
+        reprojection_stats: Endpoint reprojection error in meters.
+        run_id: Survey run this PTZ state came from (None if not applicable).
+        camera_id: Camera this PTZ state came from (None if not applicable).
+        commanded_zoom: Zoom the camera was commanded to for these frames.
+        commanded_tilt: Tilt the camera was commanded to for these frames.
+    """
+
+    homography_matrix: npt.NDArray[np.float64]
+    inverse_matrix: npt.NDArray[np.float64]
+    num_frames: int
+    num_lines: int
+    num_inliers: int
+    inlier_ratio: float
+    mean_perp_error: float
+    max_perp_error: float
+    rmse: float
+    reprojection_stats: ReprojectionStats
+    run_id: str | None
+    camera_id: str | None
+    commanded_zoom: float
+    commanded_tilt: float
+
+
+@dataclass(frozen=True)
+class FrameCorrespondence:
+    """One frame's contribution to a multi-frame consolidation.
+
+    Attributes:
+        frame_lines: Camera frame lines in DISTORTED pixel space.
+        seed: Frame-line index → ortho line id (``ortho_{i}``) correspondence.
+    """
+
+    frame_lines: Sequence[CandidateLine]
+    seed: Mapping[int, str]
+
+
+class HoldoutValidationError(Exception):
+    """Raised when hold-out reprojection RMS exceeds the configured threshold.
+
+    Attributes:
+        holdout_rms_m: Measured hold-out RMS error in meters.
+        threshold_m: Threshold the measured RMS exceeded.
+        holdout_stats: Full hold-out reprojection statistics.
+    """
+
+    def __init__(
+        self,
+        holdout_rms_m: float,
+        threshold_m: float,
+        holdout_stats: ReprojectionStats,
+    ) -> None:
+        """Build the error from the failing hold-out statistics.
+
+        Args:
+            holdout_rms_m: Measured hold-out RMS error in meters.
+            threshold_m: Threshold the measured RMS exceeded.
+            holdout_stats: Full hold-out reprojection statistics.
+        """
+        super().__init__(
+            f"Hold-out reprojection RMS {holdout_rms_m:.4f} m exceeds threshold {threshold_m:.4f} m"
+        )
+        self.holdout_rms_m = holdout_rms_m
+        self.threshold_m = threshold_m
+        self.holdout_stats = holdout_stats
+
+
+def _ortho_index(ortho_id: str) -> int:
+    """Parse the positional index out of an ``ortho_{i}`` id.
+
+    Args:
+        ortho_id: Ortho line id of the form ``ortho_{i}``.
+
+    Returns:
+        The integer index ``i``.
+
+    Raises:
+        ValueError: If ``ortho_id`` is not of the form ``ortho_{i}``.
+    """
+    prefix = "ortho_"
+    if not ortho_id.startswith(prefix):
+        raise ValueError(f"Malformed ortho id {ortho_id!r}; expected 'ortho_<int>'")
+    try:
+        return int(ortho_id[len(prefix) :])
+    except ValueError as exc:
+        raise ValueError(f"Malformed ortho id {ortho_id!r}; expected 'ortho_<int>'") from exc
+
+
+def _apply_homography(
+    homography: npt.NDArray[np.float64], point: tuple[float, float]
+) -> tuple[float, float]:
+    """Apply a 3x3 homography to a single (x, y) point in float64.
+
+    Uses an explicit float64 matrix-vector product (not
+    ``cv2.perspectiveTransform``, which casts to float32) to keep meter-scale
+    reprojection errors free of avoidable single-precision noise.
+
+    Args:
+        homography: 3x3 homography matrix.
+        point: (x, y) source point.
+
+    Returns:
+        (x', y') transformed point in the destination frame.
+    """
+    vec = homography @ np.array([point[0], point[1], 1.0], dtype=np.float64)
+    return (float(vec[0] / vec[2]), float(vec[1] / vec[2]))
+
+
+def _correspondence_pairs(
+    frame_lines: Sequence[CandidateLine],
+    ortho_lines: Sequence[OrthoLine],
+    seed: Mapping[int, str],
+) -> list[tuple[CandidateLine, OrthoLine]]:
+    """Resolve a seed into (frame_line, ortho_line) pairs.
+
+    Args:
+        frame_lines: Camera frame lines.
+        ortho_lines: Orthophoto lines, keyed positionally as ``ortho_{i}``.
+        seed: Frame-line index → ortho line id correspondence.
+
+    Returns:
+        One ``(frame_line, ortho_line)`` tuple per seed entry.
+
+    Raises:
+        ValueError: If a seed entry references an out-of-range frame index or an
+            ortho index outside ``ortho_lines``.
+    """
+    pairs: list[tuple[CandidateLine, OrthoLine]] = []
+    for frame_index, ortho_id in seed.items():
+        if not 0 <= frame_index < len(frame_lines):
+            raise ValueError(
+                f"Seed frame-line index {frame_index} out of range "
+                f"for {len(frame_lines)} frame lines"
+            )
+        ortho_idx = _ortho_index(ortho_id)
+        if not 0 <= ortho_idx < len(ortho_lines):
+            raise ValueError(
+                f"Seed references ortho index {ortho_idx} out of range "
+                f"for {len(ortho_lines)} ortho lines"
+            )
+        pairs.append((frame_lines[frame_index], ortho_lines[ortho_idx]))
+    return pairs
+
+
+def _reprojection_errors_m(
+    homography: npt.NDArray[np.float64],
+    pairs: Sequence[tuple[CandidateLine, OrthoLine]],
+    geotiff: GeoTiff,
+) -> list[float]:
+    """Per-endpoint reprojection errors in meters for matched line pairs.
+
+    Each frame-line endpoint is projected to ortho map-pixels by ``homography``,
+    then both the projected point and the true ortho endpoint are converted to
+    ground coordinates via :meth:`GeoTiff.pixel_to_geo`; the Euclidean distance
+    between them (in CRS meters) is the error.
+
+    Args:
+        homography: Frame-pixel → ortho map-pixel homography.
+        pairs: Matched ``(frame_line, ortho_line)`` correspondences.
+        geotiff: Georeference used to convert map pixels to ground meters.
+
+    Returns:
+        One error (meters) per matched endpoint (two per line pair).
+    """
+    errors: list[float] = []
+    for frame_line, ortho_line in pairs:
+        for frame_pt, ortho_pt in (
+            (frame_line.start, ortho_line.start_pixel),
+            (frame_line.end, ortho_line.end_pixel),
+        ):
+            proj_x, proj_y = _apply_homography(homography, (frame_pt[0], frame_pt[1]))
+            proj_e, proj_n = geotiff.pixel_to_geo(PixelsFloat(proj_x), PixelsFloat(proj_y))
+            true_e, true_n = geotiff.pixel_to_geo(
+                PixelsFloat(float(ortho_pt[0])), PixelsFloat(float(ortho_pt[1]))
+            )
+            errors.append(
+                float(np.hypot(float(proj_e) - float(true_e), float(proj_n) - float(true_n)))
+            )
+    return errors
+
+
+def _stats(errors: Sequence[float]) -> ReprojectionStats:
+    """Summarise a list of meter errors as RMS / 90th-percentile / max.
+
+    Args:
+        errors: Per-endpoint errors in meters (must be non-empty).
+
+    Returns:
+        A :class:`ReprojectionStats` over ``errors``.
+
+    Raises:
+        ValueError: If ``errors`` is empty.
+    """
+    if not errors:
+        raise ValueError("Cannot compute reprojection stats over zero correspondences")
+    arr = np.asarray(errors, dtype=np.float64)
+    return ReprojectionStats(
+        rms_m=float(np.sqrt(np.mean(arr**2))),
+        p90_m=float(np.percentile(arr, _TAIL_PERCENTILE)),
+        max_m=float(np.max(arr)),
+        n_points=int(arr.size),
+    )
+
+
+def _split_seed(
+    seed: Mapping[int, str],
+    holdout_fraction: float,
+    rng_seed: int,
+) -> tuple[dict[int, str], dict[int, str]]:
+    """Split a seed into (fit, hold-out) subsets deterministically.
+
+    The number held out is ``round(n * holdout_fraction)``, clamped so the fit
+    set keeps at least :data:`_MIN_FIT_LINES` correspondences and at least one
+    line is held out. Selection uses a ``numpy`` RNG seeded with ``rng_seed``
+    over the frame indices sorted ascending, so the split is reproducible.
+
+    Args:
+        seed: Full frame-line index → ortho id correspondence.
+        holdout_fraction: Fraction of correspondences to hold out, in (0, 1).
+        rng_seed: Seed for the permutation RNG.
+
+    Returns:
+        ``(fit_seed, holdout_seed)``.
+
+    Raises:
+        ValueError: If ``holdout_fraction`` is outside (0, 1) or the seed is too
+            small to yield both a >= 2-line fit set and a >= 1-line hold-out set.
+    """
+    if not 0.0 < holdout_fraction < 1.0:
+        raise ValueError(f"holdout_fraction must be in (0, 1); got {holdout_fraction}")
+    n = len(seed)
+    if n < _MIN_HOLDOUT_SEED:
+        raise ValueError(
+            f"Hold-out validation needs at least {_MIN_HOLDOUT_SEED} "
+            f"correspondences (>= {_MIN_FIT_LINES} fit + >= 1 hold-out), got {n}"
+        )
+
+    n_holdout = round(n * holdout_fraction)
+    n_holdout = max(1, min(n_holdout, n - _MIN_FIT_LINES))
+
+    indices = sorted(seed.keys())
+    rng = np.random.default_rng(rng_seed)
+    permuted = rng.permutation(np.asarray(indices, dtype=np.int64))
+    holdout_keys = {int(k) for k in permuted[:n_holdout]}
+
+    fit_seed = {k: v for k, v in seed.items() if k not in holdout_keys}
+    holdout_seed = {k: v for k, v in seed.items() if k in holdout_keys}
+    return fit_seed, holdout_seed
+
+
+def validate_with_holdout(
+    *,
+    frame_lines: Sequence[CandidateLine],
+    ortho_lines: Sequence[OrthoLine],
+    seed: Mapping[int, str],
+    calibration_table: CameraCalibrationTable,
+    commanded_zoom: float,
+    commanded_tilt: float,
+    map_id: str,
+    geotiff: GeoTiff,
+    rms_threshold_m: float,
+    holdout_fraction: float = 0.3,
+    rng_seed: int = 0,
+    run_id: str | None = None,
+    camera_id: str | None = None,
+    ransac_threshold: float = 50.0,
+    min_inlier_ratio: float = 0.5,
+) -> HoldoutValidationResult:
+    """Fit a registration on a subset and validate it on held-out lines.
+
+    Splits ``seed`` into a fit set and a hold-out set, solves the homography on
+    the fit set only via :func:`register_frame_lines`, then measures
+    reprojection error (in meters via ``geotiff``) on BOTH sets. The hold-out
+    RMS is the generalisation metric; if it exceeds ``rms_threshold_m`` a
+    :class:`HoldoutValidationError` is raised.
+
+    Args:
+        frame_lines: Camera frame lines in DISTORTED pixel space.
+        ortho_lines: Orthophoto lines, keyed positionally as ``ortho_{i}``.
+        seed: Frame-line index → ortho line id correspondence.
+        calibration_table: Per-zoom camera calibration table.
+        commanded_zoom: Zoom the frame was captured at (intrinsics lookup key).
+        commanded_tilt: Tilt the frame was captured at (provenance only).
+        map_id: Orthophoto map identifier for the homography provider.
+        geotiff: Georeference for converting map-pixel error to ground meters.
+        rms_threshold_m: Maximum acceptable hold-out RMS error in meters.
+        holdout_fraction: Fraction of correspondences to hold out, in (0, 1).
+        rng_seed: Seed for the reproducible fit/hold-out split.
+        run_id: Survey run for provenance (optional).
+        camera_id: Camera id for provenance (optional).
+        ransac_threshold: Max reprojection error (map pixels) for inliers.
+        min_inlier_ratio: Minimum inlier ratio considered a valid fit.
+
+    Returns:
+        A :class:`HoldoutValidationResult` with the fit registration and both
+        fit and hold-out reprojection statistics.
+
+    Raises:
+        ValueError: If the seed is too small to split or inputs are invalid.
+        HoldoutValidationError: If the hold-out RMS exceeds ``rms_threshold_m``.
+        RuntimeError: If the underlying homography computation fails.
+    """
+    fit_seed, holdout_seed = _split_seed(seed, holdout_fraction, rng_seed)
+
+    registration = register_frame_lines(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        seed=fit_seed,
+        calibration_table=calibration_table,
+        commanded_zoom=commanded_zoom,
+        commanded_tilt=commanded_tilt,
+        map_id=map_id,
+        run_id=run_id,
+        camera_id=camera_id,
+        ransac_threshold=ransac_threshold,
+        min_inlier_ratio=min_inlier_ratio,
+    )
+
+    homography = registration.homography_matrix
+    fit_pairs = _correspondence_pairs(frame_lines, ortho_lines, fit_seed)
+    holdout_pairs = _correspondence_pairs(frame_lines, ortho_lines, holdout_seed)
+    fit_stats = _stats(_reprojection_errors_m(homography, fit_pairs, geotiff))
+    holdout_stats = _stats(_reprojection_errors_m(homography, holdout_pairs, geotiff))
+
+    if holdout_stats.rms_m > rms_threshold_m:
+        raise HoldoutValidationError(holdout_stats.rms_m, rms_threshold_m, holdout_stats)
+
+    return HoldoutValidationResult(
+        registration=registration,
+        fit_stats=fit_stats,
+        holdout_stats=holdout_stats,
+        rms_threshold_m=rms_threshold_m,
+    )
+
+
+def consolidate_ptz_frames(
+    *,
+    frames: Sequence[FrameCorrespondence],
+    ortho_lines: Sequence[OrthoLine],
+    calibration_table: CameraCalibrationTable,
+    commanded_zoom: float,
+    commanded_tilt: float,
+    map_id: str,
+    geotiff: GeoTiff,
+    run_id: str | None = None,
+    camera_id: str | None = None,
+    ransac_threshold: float = 50.0,
+    min_inlier_ratio: float = 0.5,
+) -> MultiFrameConsolidationResult:
+    """Consolidate several same-PTZ-state frames into one registration.
+
+    Pools every frame's line correspondences into a single
+    :meth:`MapPointHomography.compute_from_lines` solve at ``commanded_zoom``'s
+    intrinsics. Because more endpoints average out per-frame line-detection
+    noise, the consolidated fit reduces or matches the typical single-frame
+    reprojection error. This reuses the existing ICP/RANSAC line solver and is
+    NOT a general N-pose bundle adjuster.
+
+    Args:
+        frames: One :class:`FrameCorrespondence` per frame at this PTZ state.
+        ortho_lines: Orthophoto lines, keyed positionally as ``ortho_{i}``.
+        calibration_table: Per-zoom camera calibration table.
+        commanded_zoom: Zoom the frames were captured at (intrinsics lookup key).
+        commanded_tilt: Tilt the frames were captured at (provenance only).
+        map_id: Orthophoto map identifier for the homography provider.
+        geotiff: Georeference for converting map-pixel error to ground meters.
+        run_id: Survey run for provenance (optional).
+        camera_id: Camera id for provenance (optional).
+        ransac_threshold: Max reprojection error (map pixels) for inliers.
+        min_inlier_ratio: Minimum inlier ratio considered a valid fit.
+
+    Returns:
+        A :class:`MultiFrameConsolidationResult` with the consolidated
+        homography, solver metrics, and a meters-unit reprojection summary.
+
+    Raises:
+        ValueError: If no frames are supplied or a frame's seed is invalid.
+        RuntimeError: If the underlying homography computation fails.
+    """
+    if not frames:
+        raise ValueError("consolidate_ptz_frames needs at least one frame")
+
+    pooled_annotations: list[dict[str, Any]] = []
+    pooled_registry: dict[str, dict[str, float]] = {}
+    for frame in frames:
+        annotations, registry = build_line_inputs(frame.frame_lines, ortho_lines, frame.seed)
+        pooled_annotations.extend(annotations)
+        pooled_registry.update(registry)
+
+    provider = MapPointHomography(map_id, **intrinsic_kwargs(calibration_table, commanded_zoom))
+    result = provider.compute_from_lines(
+        pooled_annotations,
+        pooled_registry,
+        ransac_threshold=ransac_threshold,
+        min_inlier_ratio=min_inlier_ratio,
+    )
+
+    pairs: list[tuple[CandidateLine, OrthoLine]] = []
+    for frame in frames:
+        pairs.extend(_correspondence_pairs(frame.frame_lines, ortho_lines, frame.seed))
+    reprojection_stats = _stats(_reprojection_errors_m(result.homography_matrix, pairs, geotiff))
+
+    return MultiFrameConsolidationResult(
+        homography_matrix=result.homography_matrix,
+        inverse_matrix=result.inverse_matrix,
+        num_frames=len(frames),
+        num_lines=result.num_lines,
+        num_inliers=result.num_inliers,
+        inlier_ratio=result.inlier_ratio,
+        mean_perp_error=result.mean_perp_error,
+        max_perp_error=result.max_perp_error,
+        rmse=result.rmse,
+        reprojection_stats=reprojection_stats,
+        run_id=run_id,
+        camera_id=camera_id,
+        commanded_zoom=commanded_zoom,
+        commanded_tilt=commanded_tilt,
+    )
+
+
+__all__ = [
+    "FrameCorrespondence",
+    "HoldoutValidationError",
+    "HoldoutValidationResult",
+    "MultiFrameConsolidationResult",
+    "ReprojectionStats",
+    "consolidate_ptz_frames",
+    "validate_with_holdout",
+]

--- a/tests/calibration/extrinsic/test_validation.py
+++ b/tests/calibration/extrinsic/test_validation.py
@@ -194,7 +194,14 @@ def test_holdout_reports_meters_stats_and_is_consistent() -> None:
         assert 0.0 <= stats.rms_m <= stats.p90_m <= stats.max_m
         assert np.isfinite(stats.max_m)
     # Fit and hold-out errors are the same order of magnitude (no overfitting):
-    # both reflect the injected 0.5 px ~ 0.05 m endpoint noise.
+    # both reflect the injected 0.5 px endpoint noise, which at 0.10 m/px is
+    # ~0.05 m. The bounds below are deliberately loose generalisation guards, not
+    # tight numeric expectations:
+    #   - `< 0.5 m` (~10x the noise floor) catches a grossly wrong hold-out fit.
+    #   - `<= 4 * fit_rms + 0.05 m` catches overfitting: a fit that fits its own
+    #     points far better than unseen ones. The 4x factor tolerates the higher
+    #     variance of the small 6-point hold-out sample; the +0.05 m additive
+    #     term keeps the ratio test meaningful when fit_rms is near zero.
     assert result.holdout_stats.rms_m < 0.5
     assert result.holdout_stats.rms_m <= 4.0 * result.fit_stats.rms_m + 0.05
 
@@ -340,9 +347,16 @@ def test_consolidation_reduces_or_matches_single_frame_error() -> None:
         consolidated.homography_matrix, ortho_lines, true_frame_lines, geotiff
     )
     mean_single = float(np.mean(single_rms))
-    # Pooling endpoints averages out per-frame noise: consolidated estimate is at
-    # least as close to ground truth as the typical single-frame estimate.
-    assert consolidated_rms <= mean_single + 1e-9
+    worst_single = float(np.max(single_rms))
+    # Pooling endpoints averages out per-frame noise, so the consolidated estimate
+    # should be at least as close to ground truth as the typical single frame.
+    # The estimator is nonlinear (RANSAC/ICP), so "reduces or matches" is a
+    # statistical expectation rather than a strict per-seed identity: assert it
+    # against the mean with a small relative tolerance that absorbs RANSAC/ICP and
+    # library-version nondeterminism, plus a hard guarantee that it never does
+    # worse than the WORST single frame.
+    assert consolidated_rms <= mean_single * 1.05
+    assert consolidated_rms <= worst_single
 
 
 def test_consolidate_rejects_empty_frames() -> None:

--- a/tests/calibration/extrinsic/test_validation.py
+++ b/tests/calibration/extrinsic/test_validation.py
@@ -1,0 +1,358 @@
+"""Offline tests for hold-out reprojection validation + multi-frame consolidation.
+
+A known homography warps ortho lines into synthetic frame lines (optionally with
+reproducible Gaussian endpoint noise); intrinsics come from a zero-distortion
+:class:`CameraCalibrationTable`; a synthetic :class:`GeoTiff` converts map-pixel
+reprojection error into ground meters. No live camera / MinIO / Postgres.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from poc_homography.calibration.extrinsic import (
+    FrameCorrespondence,
+    HoldoutValidationError,
+    HoldoutValidationResult,
+    MultiFrameConsolidationResult,
+    ReprojectionStats,
+    consolidate_ptz_frames,
+    register_frame_lines,
+    validate_with_holdout,
+)
+from poc_homography.calibration.lens_distortion.calibration_table import (
+    CameraCalibrationTable,
+    ZoomCalibrationEntry,
+)
+from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.domain.vo.ortho_line import OrthoLine
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+# Well-conditioned ORTHO map-pixel -> FRAME pixel warp (slight projective terms).
+_H_KNOWN = np.array(
+    [
+        [1.10, 0.05, 40.0],
+        [0.03, 1.20, 25.0],
+        [1.0e-4, 5.0e-5, 1.0],
+    ],
+    dtype=np.float64,
+)
+
+# Ten varied ortho segments so a fit/hold-out split leaves both sets well posed.
+_ORTHO_SEGMENTS: list[tuple[tuple[float, float], tuple[float, float]]] = [
+    ((100.0, 100.0), (500.0, 110.0)),
+    ((120.0, 150.0), (130.0, 600.0)),
+    ((150.0, 200.0), (550.0, 580.0)),
+    ((520.0, 160.0), (180.0, 560.0)),
+    ((300.0, 120.0), (320.0, 640.0)),
+    ((200.0, 300.0), (600.0, 340.0)),
+    ((420.0, 220.0), (440.0, 700.0)),
+    ((160.0, 420.0), (560.0, 470.0)),
+    ((250.0, 500.0), (650.0, 250.0)),
+    ((360.0, 180.0), (200.0, 620.0)),
+]
+
+# Ground sampling distance of 0.10 m/px => meters error == 0.10 * pixel error.
+_GSD_M = 0.10
+
+
+def _zero_distortion_table(camera_id: str = "cam1") -> CameraCalibrationTable:
+    table = CameraCalibrationTable(camera_id=camera_id)
+    table.add_entry(
+        ZoomCalibrationEntry(
+            zoom_factor=1.0,
+            k1=0.0,
+            k2=0.0,
+            k3=0.0,
+            p1=0.0,
+            p2=0.0,
+            calibration_date="2024-01-01T00:00:00",
+            fx=1000.0,
+            fy=1000.0,
+            cx=960.0,
+            cy=540.0,
+        )
+    )
+    return table
+
+
+def _geotiff() -> GeoTiff:
+    """North-up GeoTIFF with a 0.10 m/px ground sampling distance."""
+    return GeoTiff(
+        geotransform=GeoTransform(
+            origin_easting=500000.0,
+            pixel_width=_GSD_M,
+            row_rotation=0.0,
+            origin_northing=4000000.0,
+            col_rotation=0.0,
+            pixel_height=-_GSD_M,
+        ),
+        crs="EPSG:25830",
+    )
+
+
+def _ortho_lines() -> list[OrthoLine]:
+    lines: list[OrthoLine] = []
+    for i, (start, end) in enumerate(_ORTHO_SEGMENTS):
+        lines.append(
+            OrthoLine.from_endpoints(
+                start_pixel=start,
+                end_pixel=end,
+                start_utm=(500000.0 + i, 4000000.0 + i),
+                end_utm=(500010.0 + i, 4000010.0 + i),
+            )
+        )
+    return lines
+
+
+def _identity_seed(ortho_lines: list[OrthoLine]) -> dict[int, str]:
+    return {i: f"ortho_{i}" for i in range(len(ortho_lines))}
+
+
+def _warp_point(point: tuple[float, float], homography: np.ndarray) -> tuple[float, float]:
+    pt = np.array([[[point[0], point[1]]]], dtype=np.float64)
+    out = cv2.perspectiveTransform(pt, homography)[0, 0]
+    return float(out[0]), float(out[1])
+
+
+def _frame_lines_from_ortho(
+    ortho_lines: list[OrthoLine],
+    homography: np.ndarray,
+    noise_px: float = 0.0,
+    rng: np.random.Generator | None = None,
+) -> list[CandidateLine]:
+    """Project ortho map-pixel endpoints into frame pixels via H, with noise."""
+    frame_lines: list[CandidateLine] = []
+    for line in ortho_lines:
+        start = _warp_point((float(line.start_pixel[0]), float(line.start_pixel[1])), homography)
+        end = _warp_point((float(line.end_pixel[0]), float(line.end_pixel[1])), homography)
+        if noise_px > 0.0 and rng is not None:
+            start = (start[0] + rng.normal(0, noise_px), start[1] + rng.normal(0, noise_px))
+            end = (end[0] + rng.normal(0, noise_px), end[1] + rng.normal(0, noise_px))
+        frame_lines.append(CandidateLine(start=start, end=end))
+    return frame_lines
+
+
+def _rms_m_against_truth(
+    homography: np.ndarray,
+    ortho_lines: list[OrthoLine],
+    true_frame_lines: list[CandidateLine],
+    geotiff: GeoTiff,
+) -> float:
+    """RMS reprojection error (meters) of H over NOISE-FREE correspondences."""
+    sq: list[float] = []
+    for line, frame_line in zip(ortho_lines, true_frame_lines):
+        for frame_pt, ortho_pt in (
+            (frame_line.start, line.start_pixel),
+            (frame_line.end, line.end_pixel),
+        ):
+            proj = _warp_point(frame_pt, homography)
+            proj_e, proj_n = geotiff.pixel_to_geo(proj[0], proj[1])
+            true_e, true_n = geotiff.pixel_to_geo(float(ortho_pt[0]), float(ortho_pt[1]))
+            sq.append((float(proj_e) - float(true_e)) ** 2 + (float(proj_n) - float(true_n)) ** 2)
+    return float(np.sqrt(np.mean(sq)))
+
+
+# ---------------------------------------------------------------------------
+# DoD 1 + 3: hold-out reprojection validation in meters
+# ---------------------------------------------------------------------------
+
+
+def test_holdout_reports_meters_stats_and_is_consistent() -> None:
+    ortho_lines = _ortho_lines()
+    rng = np.random.default_rng(7)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN, noise_px=0.5, rng=rng)
+    seed = _identity_seed(ortho_lines)
+
+    result = validate_with_holdout(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        seed=seed,
+        calibration_table=_zero_distortion_table(),
+        commanded_zoom=1.0,
+        commanded_tilt=-15.0,
+        map_id="map_test",
+        geotiff=_geotiff(),
+        rms_threshold_m=1.0,
+        holdout_fraction=0.3,
+        rng_seed=0,
+    )
+
+    assert isinstance(result, HoldoutValidationResult)
+    # Three lines held out (round(10 * 0.3)); two endpoints each.
+    assert result.holdout_stats.n_points == 6
+    assert result.fit_stats.n_points == 14
+    # Stats ordered RMS <= p90 <= max and all finite & non-negative.
+    for stats in (result.fit_stats, result.holdout_stats):
+        assert isinstance(stats, ReprojectionStats)
+        assert 0.0 <= stats.rms_m <= stats.p90_m <= stats.max_m
+        assert np.isfinite(stats.max_m)
+    # Fit and hold-out errors are the same order of magnitude (no overfitting):
+    # both reflect the injected 0.5 px ~ 0.05 m endpoint noise.
+    assert result.holdout_stats.rms_m < 0.5
+    assert result.holdout_stats.rms_m <= 4.0 * result.fit_stats.rms_m + 0.05
+
+
+def test_holdout_exact_homography_near_zero_error() -> None:
+    ortho_lines = _ortho_lines()
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN)  # no noise
+    seed = _identity_seed(ortho_lines)
+
+    result = validate_with_holdout(
+        frame_lines=frame_lines,
+        ortho_lines=ortho_lines,
+        seed=seed,
+        calibration_table=_zero_distortion_table(),
+        commanded_zoom=1.0,
+        commanded_tilt=0.0,
+        map_id="map_test",
+        geotiff=_geotiff(),
+        rms_threshold_m=0.01,
+        holdout_fraction=0.3,
+    )
+
+    assert result.fit_stats.rms_m < 1e-3
+    assert result.holdout_stats.rms_m < 1e-3
+
+
+def test_holdout_over_threshold_raises_typed_error() -> None:
+    ortho_lines = _ortho_lines()
+    rng = np.random.default_rng(3)
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN, noise_px=3.0, rng=rng)
+    seed = _identity_seed(ortho_lines)
+
+    with pytest.raises(HoldoutValidationError) as excinfo:
+        validate_with_holdout(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            seed=seed,
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            geotiff=_geotiff(),
+            rms_threshold_m=1e-4,  # unsatisfiably tight -> must fail
+            holdout_fraction=0.3,
+        )
+
+    err = excinfo.value
+    assert err.holdout_rms_m > err.threshold_m
+    assert err.threshold_m == 1e-4
+    assert err.holdout_stats.rms_m == err.holdout_rms_m
+
+
+def test_holdout_rejects_seed_too_small_to_split() -> None:
+    ortho_lines = _ortho_lines()[:2]
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN)
+
+    with pytest.raises(ValueError, match="at least 3"):
+        validate_with_holdout(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            seed=_identity_seed(ortho_lines),
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            geotiff=_geotiff(),
+            rms_threshold_m=1.0,
+        )
+
+
+def test_holdout_rejects_bad_fraction() -> None:
+    ortho_lines = _ortho_lines()
+    frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN)
+
+    with pytest.raises(ValueError, match="holdout_fraction"):
+        validate_with_holdout(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            seed=_identity_seed(ortho_lines),
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            geotiff=_geotiff(),
+            rms_threshold_m=1.0,
+            holdout_fraction=1.5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DoD 2: multi-frame consolidation non-regression
+# ---------------------------------------------------------------------------
+
+
+def test_consolidation_reduces_or_matches_single_frame_error() -> None:
+    ortho_lines = _ortho_lines()
+    geotiff = _geotiff()
+    table = _zero_distortion_table()
+    seed = _identity_seed(ortho_lines)
+    # Noise-free correspondences are the ground truth the estimates are judged on.
+    true_frame_lines = _frame_lines_from_ortho(ortho_lines, _H_KNOWN)
+
+    rng = np.random.default_rng(123)
+    noisy_per_frame = [
+        _frame_lines_from_ortho(ortho_lines, _H_KNOWN, noise_px=1.5, rng=rng) for _ in range(5)
+    ]
+
+    # Per-frame fits, each judged against the noise-free ground truth.
+    single_rms: list[float] = []
+    for frame_lines in noisy_per_frame:
+        reg = register_frame_lines(
+            frame_lines=frame_lines,
+            ortho_lines=ortho_lines,
+            seed=seed,
+            calibration_table=table,
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+        )
+        single_rms.append(
+            _rms_m_against_truth(reg.homography_matrix, ortho_lines, true_frame_lines, geotiff)
+        )
+
+    consolidated = consolidate_ptz_frames(
+        frames=[FrameCorrespondence(frame_lines=fl, seed=seed) for fl in noisy_per_frame],
+        ortho_lines=ortho_lines,
+        calibration_table=table,
+        commanded_zoom=1.0,
+        commanded_tilt=0.0,
+        map_id="map_test",
+        geotiff=geotiff,
+        run_id="run1",
+        camera_id="cam1",
+    )
+
+    assert isinstance(consolidated, MultiFrameConsolidationResult)
+    assert consolidated.num_frames == 5
+    assert consolidated.num_lines == 5 * len(ortho_lines)
+    assert consolidated.run_id == "run1"
+    assert consolidated.commanded_zoom == 1.0
+
+    consolidated_rms = _rms_m_against_truth(
+        consolidated.homography_matrix, ortho_lines, true_frame_lines, geotiff
+    )
+    mean_single = float(np.mean(single_rms))
+    # Pooling endpoints averages out per-frame noise: consolidated estimate is at
+    # least as close to ground truth as the typical single-frame estimate.
+    assert consolidated_rms <= mean_single + 1e-9
+
+
+def test_consolidate_rejects_empty_frames() -> None:
+    with pytest.raises(ValueError, match="at least one frame"):
+        consolidate_ptz_frames(
+            frames=[],
+            ortho_lines=_ortho_lines(),
+            calibration_table=_zero_distortion_table(),
+            commanded_zoom=1.0,
+            commanded_tilt=0.0,
+            map_id="map_test",
+            geotiff=_geotiff(),
+        )

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -267,6 +267,13 @@ time_bucket  # cleanplate-surface (poc_homography/cleanplate/reconstruct.py:64)
 _.presign_get  # cleanplate-surface (poc_homography/infrastructure/clients/minio_frame_store.py:129)
 _.get_map  # cleanplate-surface — MinioMapStore GeoTIFF download, consumed by the map tile/info API #292 (poc_homography/infrastructure/clients/minio_map_store.py:136)
 
+# == extrinsic-validation-surface ==
+# Hold-out validation + multi-frame consolidation emitted-record fields (#359) — read by tests, CLI and downstream registration consumers, not within poc_homography
+_.p90_m  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:82)
+_.max_m  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:83)
+_.n_points  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:84)
+_.num_frames  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:132)
+
 # == uncertain-needs-follow-up ==
 # UNCERTAIN — symbol exists but no callers and no test references found; kept to keep vulture green pending a dead-code follow-up (see #226)
 _.get_nearest_entry  # uncertain-needs-follow-up (poc_homography/calibration/lens_distortion/calibration_table.py:393)


### PR DESCRIPTION
## Summary

Adds a per-PTZ-state validation/consolidation leaf on top of the seeded (#357) and auto-match (#358) registration leaves, without a new homography estimator or general bundle adjuster.

**Hold-out reprojection validation** (`validate_with_holdout`): splits the matched frame-line↔ortho-line correspondences into a fit set and a hold-out set, solves the homography on the fit set only (via the existing `register_frame_lines`), and reports reprojection error in **ortho ground meters** — projected and true endpoints are both run through `GeoTiff.pixel_to_geo` and compared in easting/northing — as RMS / 90th-percentile / max. A hold-out RMS over the caller's threshold raises the typed `HoldoutValidationError`.

**Multi-frame consolidation** (`consolidate_ptz_frames`): pools several same-PTZ-state frames' line correspondences into one `MapPointHomography.compute_from_lines` solve, averaging out per-frame line-detection noise so the consolidated fit reduces or matches the typical single-frame error. Reuses the existing ICP/RANSAC solver — no N-pose bundle adjuster.

Promotes `build_line_inputs`/`intrinsic_kwargs` in `ptz_registration` to public for reuse. Emits per-PTZ registration records (homography + meters error stats + inlier provenance).

## Definition of Done
- [x] Hold-out validation reports RMS/90th/max in meters on a synthetic known-H dataset; fit-vs-holdout consistent within tolerance (offline test).
- [x] Multi-frame consolidation over several synthetic frames at one PTZ state reduces or matches single-frame reprojection error (offline non-regression test).
- [x] Hold-out RMS over threshold → typed validation failure.
- [x] `poe ci` green.

## Test plan
`poe ci` green (1350 passed, 158 pre-existing env-gated skips). New offline tests in `tests/calibration/extrinsic/test_validation.py`: meters RMS/p90/max on synthetic known-H, fit-vs-holdout consistency, exact-H near-zero error, over-threshold typed failure, seed-too-small / bad-fraction rejection, and multi-frame non-regression (consolidated ≤ mean single-frame error within tolerance, and never worse than the worst single frame).

Closes #359
