### PR TITLE
feat(persist): extrinsic PTZ registration + validation records (Neon + YAML) [#364]

### DIFF
--- a/alembic/versions/c4e9a1f7d2b3_add_ptz_registrations_table.py
+++ b/alembic/versions/c4e9a1f7d2b3_add_ptz_registrations_table.py
@@ -1,0 +1,59 @@
+"""add ptz_registrations table
+
+Additive migration: creates the ``ptz_registrations`` table — the persistence
+half (#364) of the extrinsic PTZ registration solvers from #340. One row per
+``(camera_id, run_id, PTZ-state)`` keyed by a synthetic ``id``; the homography
+matrices, scalar solver metrics, and optional meters-unit reprojection stats are
+stored as JSONB. No existing table is touched.
+
+Revision ID: c4e9a1f7d2b3
+Revises: 3a9f1c4b2e7d
+Create Date: 2026-06-21
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "c4e9a1f7d2b3"
+down_revision: str | None = "3a9f1c4b2e7d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ptz_registrations",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("camera_id", sa.String(), nullable=False, server_default=""),
+        sa.Column("run_id", sa.String(), nullable=True),
+        sa.Column("commanded_zoom", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("commanded_tilt", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("homography_matrix", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("inverse_matrix", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metrics", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("reprojection_stats", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_date", sa.String(), nullable=False, server_default=""),
+        sa.Column("last_modified", sa.String(), nullable=False, server_default=""),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_ptz_registrations_camera_id"), "ptz_registrations", ["camera_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_ptz_registrations_run_id"), "ptz_registrations", ["run_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_ptz_registrations_run_id"), table_name="ptz_registrations")
+    op.drop_index(op.f("ix_ptz_registrations_camera_id"), table_name="ptz_registrations")
+    op.drop_table("ptz_registrations")

--- a/poc_homography/domain/entities/__init__.py
+++ b/poc_homography/domain/entities/__init__.py
@@ -13,6 +13,7 @@ from poc_homography.domain.entities.lens_calibration_table import LensCalibratio
 from poc_homography.domain.entities.line import Line
 from poc_homography.domain.entities.line_annotation import LineAnnotation
 from poc_homography.domain.entities.map import Map
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
 from poc_homography.domain.entities.tenant import Tenant
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "Line",
     "LineAnnotation",
     "Map",
+    "PtzRegistration",
     "Tenant",
 ]

--- a/poc_homography/domain/entities/ptz_registration.py
+++ b/poc_homography/domain/entities/ptz_registration.py
@@ -1,0 +1,263 @@
+"""Persistence entity for a per-PTZ-state extrinsic registration record.
+
+This entity is purely for persistence (#364). It is the missing storage half of
+the extrinsic solvers shipped in #340: it carries the
+:class:`~poc_homography.calibration.extrinsic.ptz_registration.PtzRegistrationResult`
+produced by ``register_frame_lines`` / ``validate_with_holdout`` /
+``consolidate_ptz_frames`` together with the optional meters-unit
+:class:`~poc_homography.calibration.extrinsic.validation.ReprojectionStats`
+those validation paths report.
+
+The ``calibration/extrinsic`` dataclasses remain the single source of truth —
+this module only (de)serializes them. It deliberately adds **no** new metric
+fields and re-solves nothing.
+
+Records are keyed by ``(camera_id, run_id, PTZ-state)`` via :meth:`make_id`, so a
+single camera can hold many registrations (one per survey run and commanded
+zoom/tilt). The ``camera_id`` is preserved as a first-class attribute so later
+intrinsic+extrinsic joins can group by camera.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+
+# Scalar (non-matrix) metric fields carried verbatim from PtzRegistrationResult.
+_METRIC_FIELDS = (
+    "num_lines",
+    "num_inliers",
+    "inlier_ratio",
+    "mean_perp_error",
+    "max_perp_error",
+    "rmse",
+)
+
+
+def result_to_dict(result: PtzRegistrationResult) -> dict[str, Any]:
+    """Serialize a :class:`PtzRegistrationResult` to a JSON-friendly dict.
+
+    The 3x3 homography/inverse matrices become nested lists; every other field
+    is copied verbatim.
+
+    Args:
+        result: The solver result to serialize.
+
+    Returns:
+        A dict with ``homography_matrix``/``inverse_matrix`` as nested lists and
+        all scalar metrics plus PTZ provenance.
+    """
+    return {
+        "homography_matrix": np.asarray(result.homography_matrix, dtype=np.float64).tolist(),
+        "inverse_matrix": np.asarray(result.inverse_matrix, dtype=np.float64).tolist(),
+        "num_lines": int(result.num_lines),
+        "num_inliers": int(result.num_inliers),
+        "inlier_ratio": float(result.inlier_ratio),
+        "mean_perp_error": float(result.mean_perp_error),
+        "max_perp_error": float(result.max_perp_error),
+        "rmse": float(result.rmse),
+        "run_id": result.run_id,
+        "camera_id": result.camera_id,
+        "commanded_zoom": float(result.commanded_zoom),
+        "commanded_tilt": float(result.commanded_tilt),
+    }
+
+
+def result_from_dict(data: dict[str, Any]) -> PtzRegistrationResult:
+    """Reconstruct a :class:`PtzRegistrationResult` from :func:`result_to_dict`.
+
+    Args:
+        data: A dict produced by :func:`result_to_dict` (matrices as nested
+            lists).
+
+    Returns:
+        The rebuilt result with ``float64`` numpy matrices.
+    """
+    return PtzRegistrationResult(
+        homography_matrix=np.asarray(data["homography_matrix"], dtype=np.float64),
+        inverse_matrix=np.asarray(data["inverse_matrix"], dtype=np.float64),
+        num_lines=int(data["num_lines"]),
+        num_inliers=int(data["num_inliers"]),
+        inlier_ratio=float(data["inlier_ratio"]),
+        mean_perp_error=float(data["mean_perp_error"]),
+        max_perp_error=float(data["max_perp_error"]),
+        rmse=float(data["rmse"]),
+        run_id=data.get("run_id"),
+        camera_id=data.get("camera_id"),
+        commanded_zoom=float(data["commanded_zoom"]),
+        commanded_tilt=float(data["commanded_tilt"]),
+    )
+
+
+def stats_to_dict(stats: ReprojectionStats) -> dict[str, Any]:
+    """Serialize a :class:`ReprojectionStats` to a JSON-friendly dict."""
+    return {
+        "rms_m": float(stats.rms_m),
+        "p90_m": float(stats.p90_m),
+        "max_m": float(stats.max_m),
+        "n_points": int(stats.n_points),
+    }
+
+
+def stats_from_dict(data: dict[str, Any]) -> ReprojectionStats:
+    """Reconstruct a :class:`ReprojectionStats` from :func:`stats_to_dict`."""
+    return ReprojectionStats(
+        rms_m=float(data["rms_m"]),
+        p90_m=float(data["p90_m"]),
+        max_m=float(data["max_m"]),
+        n_points=int(data["n_points"]),
+    )
+
+
+def metrics_of(result: PtzRegistrationResult) -> dict[str, Any]:
+    """Return just the scalar solver metrics of ``result`` (no matrices/PTZ)."""
+    full = result_to_dict(result)
+    return {key: full[key] for key in _METRIC_FIELDS}
+
+
+@dataclass(frozen=True, eq=False)
+class PtzRegistration:
+    """A persisted per-PTZ-state extrinsic registration for one camera.
+
+    Attributes:
+        camera_id: Camera this registration belongs to (the join key). Required.
+        run_id: Survey run this PTZ state came from (None if not applicable).
+        commanded_zoom: Zoom the camera was commanded to for this frame.
+        commanded_tilt: Tilt the camera was commanded to for this frame.
+        registration: The solver result (source of truth for matrices+metrics).
+        reprojection_stats: Optional meters-unit reprojection summary from
+            ``validate_with_holdout`` / ``consolidate_ptz_frames``.
+        created_date: ISO-format creation timestamp.
+        last_modified: ISO-format last modification timestamp.
+    """
+
+    camera_id: str
+    run_id: str | None
+    commanded_zoom: float
+    commanded_tilt: float
+    registration: PtzRegistrationResult
+    reprojection_stats: ReprojectionStats | None = None
+    created_date: str = ""
+    last_modified: str = ""
+
+    @staticmethod
+    def make_id(
+        camera_id: str,
+        run_id: str | None,
+        commanded_zoom: float,
+        commanded_tilt: float,
+    ) -> str:
+        """Build the opaque composite id for a ``(camera, run, PTZ-state)`` key.
+
+        Args:
+            camera_id: Camera identifier.
+            run_id: Survey run id, or None when not run-scoped.
+            commanded_zoom: Commanded zoom of the PTZ state.
+            commanded_tilt: Commanded tilt of the PTZ state.
+
+        Returns:
+            A stable string id of the form ``"{camera}/{run}/z{zoom}/t{tilt}"``.
+            ``repr`` is used for the floats so two distinct ``float64`` PTZ states
+            never collapse to the same key (and the recomputed id always matches
+            the stored one round-trip).
+        """
+        run = run_id if run_id is not None else "_norun"
+        return f"{camera_id}/{run}/z{float(commanded_zoom)!r}/t{float(commanded_tilt)!r}"
+
+    @property
+    def id(self) -> str:
+        """Composite ``(camera_id, run_id, PTZ-state)`` identifier."""
+        return self.make_id(self.camera_id, self.run_id, self.commanded_zoom, self.commanded_tilt)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    @classmethod
+    def from_result(
+        cls,
+        registration: PtzRegistrationResult,
+        *,
+        reprojection_stats: ReprojectionStats | None = None,
+        created_date: str = "",
+        last_modified: str = "",
+    ) -> PtzRegistration:
+        """Build a persistable record from a solver result.
+
+        The camera/run/zoom/tilt key components are taken from ``registration``;
+        a ``camera_id`` is mandatory since it is the join key.
+
+        Args:
+            registration: The solver result to persist.
+            reprojection_stats: Optional meters-unit reprojection summary.
+            created_date: ISO-format creation timestamp.
+            last_modified: ISO-format last modification timestamp.
+
+        Returns:
+            The wrapped :class:`PtzRegistration`.
+
+        Raises:
+            ValueError: If ``registration.camera_id`` is None or empty.
+        """
+        if not registration.camera_id:
+            raise ValueError("registration.camera_id is required to persist a PtzRegistration")
+        return cls(
+            camera_id=registration.camera_id,
+            run_id=registration.run_id,
+            commanded_zoom=registration.commanded_zoom,
+            commanded_tilt=registration.commanded_tilt,
+            registration=registration,
+            reprojection_stats=reprojection_stats,
+            created_date=created_date,
+            last_modified=last_modified,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a dictionary for serialization."""
+        return {
+            "id": self.id,
+            "camera_id": self.camera_id,
+            "run_id": self.run_id,
+            "commanded_zoom": self.commanded_zoom,
+            "commanded_tilt": self.commanded_tilt,
+            "registration": result_to_dict(self.registration),
+            "reprojection_stats": (
+                stats_to_dict(self.reprojection_stats)
+                if self.reprojection_stats is not None
+                else None
+            ),
+            "created_date": self.created_date,
+            "last_modified": self.last_modified,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PtzRegistration:
+        """Create a :class:`PtzRegistration` from a dictionary.
+
+        Raises:
+            ValueError: If ``camera_id`` is missing or empty — the join key is
+                mandatory, mirroring :meth:`from_result`.
+        """
+        camera_id = data.get("camera_id")
+        if not camera_id:
+            raise ValueError("camera_id is required to load a PtzRegistration")
+        stats = data.get("reprojection_stats")
+        return cls(
+            camera_id=camera_id,
+            run_id=data.get("run_id"),
+            commanded_zoom=float(data["commanded_zoom"]),
+            commanded_tilt=float(data["commanded_tilt"]),
+            registration=result_from_dict(data["registration"]),
+            reprojection_stats=stats_from_dict(stats) if stats is not None else None,
+            created_date=data.get("created_date", ""),
+            last_modified=data.get("last_modified", ""),
+        )

--- a/poc_homography/infrastructure/models/__init__.py
+++ b/poc_homography/infrastructure/models/__init__.py
@@ -20,6 +20,7 @@ from poc_homography.infrastructure.models.lens_calibration_table import LensCali
 from poc_homography.infrastructure.models.line import LineModel
 from poc_homography.infrastructure.models.line_annotation import LineAnnotationModel
 from poc_homography.infrastructure.models.map import MapModel
+from poc_homography.infrastructure.models.ptz_registration import PtzRegistrationModel
 from poc_homography.infrastructure.models.stress_test_session import StressTestSessionModel
 from poc_homography.infrastructure.models.survey_run import SurveyRunModel
 from poc_homography.infrastructure.models.survey_session import SurveySessionModel
@@ -39,6 +40,7 @@ __all__ = [
     "LineAnnotationModel",
     "LineModel",
     "MapModel",
+    "PtzRegistrationModel",
     "StressTestSessionModel",
     "SurveyRunModel",
     "SurveySessionModel",

--- a/poc_homography/infrastructure/models/ptz_registration.py
+++ b/poc_homography/infrastructure/models/ptz_registration.py
@@ -1,0 +1,49 @@
+"""SQLAlchemy ORM model for the :class:`PtzRegistration` entity."""
+
+from __future__ import annotations
+
+from sqlalchemy import JSON, Float, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from poc_homography.infrastructure.database import Base
+
+# Postgres uses JSONB; the SQLite variant lets the offline unit tests round-trip
+# the JSON columns against an in-memory database without a live Postgres.
+_JSON = JSONB().with_variant(JSON(), "sqlite")
+
+
+class PtzRegistrationModel(Base):
+    """Per-(camera, run, PTZ-state) extrinsic registration records.
+
+    Domain entity: ``poc_homography.domain.entities.ptz_registration.PtzRegistration``
+
+    Added additively (#364) as the persistence half of the extrinsic solvers
+    from #340. Keyed by a synthetic ``id`` (``PtzRegistration.make_id``) so one
+    camera holds many registrations; ``camera_id`` and ``run_id`` are indexed for
+    later intrinsic+extrinsic joins and run-scoped lookups.
+
+    Value objects stored as JSONB:
+      - homography_matrix / inverse_matrix: 3x3 nested lists.
+      - metrics: scalar ``PtzRegistrationResult`` metrics
+        ``{num_lines, num_inliers, inlier_ratio, mean_perp_error, max_perp_error, rmse}``.
+      - reprojection_stats: optional ``ReprojectionStats``
+        ``{rms_m, p90_m, max_m, n_points}`` (None when not validated).
+    """
+
+    __tablename__ = "ptz_registrations"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    camera_id: Mapped[str] = mapped_column(String, nullable=False, default="", index=True)
+    run_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    commanded_zoom: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    commanded_tilt: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    homography_matrix: Mapped[list] = mapped_column(_JSON, nullable=False)
+    inverse_matrix: Mapped[list] = mapped_column(_JSON, nullable=False)
+    metrics: Mapped[dict] = mapped_column(_JSON, nullable=False)
+    reprojection_stats: Mapped[dict | None] = mapped_column(_JSON, nullable=True)
+    created_date: Mapped[str] = mapped_column(String, nullable=False, default="")
+    last_modified: Mapped[str] = mapped_column(String, nullable=False, default="")
+
+
+__all__ = ["PtzRegistrationModel"]

--- a/poc_homography/infrastructure/repositories/__init__.py
+++ b/poc_homography/infrastructure/repositories/__init__.py
@@ -38,6 +38,9 @@ from poc_homography.infrastructure.repositories.repo_postgres_line_annotation im
 from poc_homography.infrastructure.repositories.repo_postgres_map import (
     RepoPostgresMap,
 )
+from poc_homography.infrastructure.repositories.repo_postgres_ptz_registration import (
+    RepoPostgresPtzRegistration,
+)
 from poc_homography.infrastructure.repositories.repo_postgres_stress_test_session import (
     RepoPostgresStressTestSession,
 )
@@ -81,6 +84,9 @@ from poc_homography.infrastructure.repositories.repo_yaml_line_annotation import
     RepoYamlLineAnnotation,
 )
 from poc_homography.infrastructure.repositories.repo_yaml_map import RepoYamlMap
+from poc_homography.infrastructure.repositories.repo_yaml_ptz_registration import (
+    RepoYamlPtzRegistration,
+)
 from poc_homography.infrastructure.repositories.repo_yaml_stress_test_session import (
     RepoYamlStressTestSession,
 )
@@ -107,6 +113,7 @@ __all__ = [
     "RepoPostgresLine",
     "RepoPostgresLineAnnotation",
     "RepoPostgresMap",
+    "RepoPostgresPtzRegistration",
     "RepoPostgresTenant",
     # Concrete repositories (Postgres) — session repos
     "RepoPostgresDiagnosticSession",
@@ -125,6 +132,7 @@ __all__ = [
     "RepoYamlLine",
     "RepoYamlLineAnnotation",
     "RepoYamlMap",
+    "RepoYamlPtzRegistration",
     "RepoYamlTenant",
     "RepoYamlStressTestSession",
     "RepoYamlSurveyRun",

--- a/poc_homography/infrastructure/repositories/repo_postgres_ptz_registration.py
+++ b/poc_homography/infrastructure/repositories/repo_postgres_ptz_registration.py
@@ -1,0 +1,87 @@
+"""PostgreSQL-backed PtzRegistration repository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from poc_homography.domain.entities.ptz_registration import (
+    PtzRegistration,
+    metrics_of,
+    result_from_dict,
+    result_to_dict,
+    stats_from_dict,
+    stats_to_dict,
+)
+from poc_homography.infrastructure.models.ptz_registration import PtzRegistrationModel
+from poc_homography.infrastructure.repositories.base import RepoPostgres
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from poc_homography.infrastructure.database import Base
+
+
+class RepoPostgresPtzRegistration(RepoPostgres[PtzRegistration]):
+    """Repository for :class:`PtzRegistration` records stored in PostgreSQL.
+
+    The solver matrices and metrics are split across dedicated JSONB columns
+    (``homography_matrix`` / ``inverse_matrix`` / ``metrics``) plus an optional
+    ``reprojection_stats`` JSONB. The inherited ``save`` / ``get`` / ``delete`` /
+    ``exists`` operate by the synthetic primary key; :meth:`get_by_camera` adds a
+    camera-scoped query over the indexed ``camera_id`` column.
+    """
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session, PtzRegistrationModel, PtzRegistration)
+
+    # -- serialisation overrides -------------------------------------------
+
+    def _entity_to_row(self, entity: PtzRegistration) -> dict[str, Any]:
+        reg_dict = result_to_dict(entity.registration)
+        return {
+            "id": entity.id,
+            "camera_id": entity.camera_id,
+            "run_id": entity.run_id,
+            "commanded_zoom": entity.commanded_zoom,
+            "commanded_tilt": entity.commanded_tilt,
+            "homography_matrix": reg_dict["homography_matrix"],
+            "inverse_matrix": reg_dict["inverse_matrix"],
+            "metrics": metrics_of(entity.registration),
+            "reprojection_stats": (
+                stats_to_dict(entity.reprojection_stats)
+                if entity.reprojection_stats is not None
+                else None
+            ),
+            "created_date": entity.created_date,
+            "last_modified": entity.last_modified,
+        }
+
+    def _row_to_entity(self, row: Base) -> PtzRegistration:
+        registration = result_from_dict(
+            {
+                "homography_matrix": row.homography_matrix,  # type: ignore[attr-defined]
+                "inverse_matrix": row.inverse_matrix,  # type: ignore[attr-defined]
+                **row.metrics,  # type: ignore[attr-defined]
+                "run_id": row.run_id,  # type: ignore[attr-defined]
+                "camera_id": row.camera_id,  # type: ignore[attr-defined]
+                "commanded_zoom": row.commanded_zoom,  # type: ignore[attr-defined]
+                "commanded_tilt": row.commanded_tilt,  # type: ignore[attr-defined]
+            }
+        )
+        stats = row.reprojection_stats  # type: ignore[attr-defined]
+        return PtzRegistration(
+            camera_id=row.camera_id,  # type: ignore[attr-defined]
+            run_id=row.run_id,  # type: ignore[attr-defined]
+            commanded_zoom=row.commanded_zoom,  # type: ignore[attr-defined]
+            commanded_tilt=row.commanded_tilt,  # type: ignore[attr-defined]
+            registration=registration,
+            reprojection_stats=stats_from_dict(stats) if stats is not None else None,
+            created_date=row.created_date,  # type: ignore[attr-defined]
+            last_modified=row.last_modified,  # type: ignore[attr-defined]
+        )
+
+    # -- camera-scoped query ------------------------------------------------
+
+    def get_by_camera(self, camera_id: str) -> list[PtzRegistration]:
+        """Return every registration record stored for ``camera_id``."""
+        return list(self._filter_by("camera_id", camera_id).values())

--- a/poc_homography/infrastructure/repositories/repo_yaml_ptz_registration.py
+++ b/poc_homography/infrastructure/repositories/repo_yaml_ptz_registration.py
@@ -1,0 +1,22 @@
+"""YAML-based PtzRegistration repository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.infrastructure.repositories.base import RepoYaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class RepoYamlPtzRegistration(RepoYaml[PtzRegistration]):
+    """Repository for :class:`PtzRegistration` records stored as YAML files."""
+
+    def __init__(self, data_dir: Path) -> None:
+        super().__init__(data_dir, PtzRegistration)
+
+    def get_by_camera(self, camera_id: str) -> list[PtzRegistration]:
+        """Return every registration record stored for ``camera_id``."""
+        return list(self._filter_by("camera_id", camera_id).values())

--- a/tests/infrastructure/test_repo_ptz_registration.py
+++ b/tests/infrastructure/test_repo_ptz_registration.py
@@ -1,0 +1,231 @@
+"""Offline round-trip tests for the PtzRegistration repositories (#364).
+
+These tests need no live database: the Postgres repo is exercised against an
+in-memory SQLite engine (the model's JSONB columns carry a SQLite ``JSON``
+variant), and the YAML repo against a ``tmp_path`` directory. They verify that a
+``PtzRegistrationResult`` plus an optional ``ReprojectionStats`` survive the
+save/get cycle, that camera-scoped lookups return the right records, and that a
+None reprojection summary round-trips.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import pytest
+from sqlalchemy import Table, create_engine
+from sqlalchemy.orm import Session
+
+from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.infrastructure.models.ptz_registration import PtzRegistrationModel
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresPtzRegistration,
+    RepoYamlPtzRegistration,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_result(
+    camera_id: str = "map01/cam01",
+    run_id: str | None = "run_a",
+    zoom: float = 2.0,
+    tilt: float = 15.0,
+) -> PtzRegistrationResult:
+    homography = np.array([[1.2, 0.1, 5.0], [0.0, 1.1, 7.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    inverse = np.linalg.inv(homography)
+    return PtzRegistrationResult(
+        homography_matrix=homography,
+        inverse_matrix=inverse,
+        num_lines=4,
+        num_inliers=3,
+        inlier_ratio=0.75,
+        mean_perp_error=1.2,
+        max_perp_error=3.4,
+        rmse=1.5,
+        run_id=run_id,
+        camera_id=camera_id,
+        commanded_zoom=zoom,
+        commanded_tilt=tilt,
+    )
+
+
+def _make_stats() -> ReprojectionStats:
+    return ReprojectionStats(rms_m=0.12, p90_m=0.2, max_m=0.31, n_points=8)
+
+
+def _assert_round_trip(loaded: PtzRegistration, original: PtzRegistration) -> None:
+    assert loaded is not None
+    assert loaded.id == original.id
+    assert loaded.camera_id == original.camera_id
+    assert loaded.run_id == original.run_id
+    assert loaded.commanded_zoom == pytest.approx(original.commanded_zoom)
+    assert loaded.commanded_tilt == pytest.approx(original.commanded_tilt)
+
+    reg, orig_reg = loaded.registration, original.registration
+    assert np.allclose(reg.homography_matrix, orig_reg.homography_matrix)
+    assert np.allclose(reg.inverse_matrix, orig_reg.inverse_matrix)
+    assert reg.num_lines == orig_reg.num_lines
+    assert reg.num_inliers == orig_reg.num_inliers
+    assert reg.inlier_ratio == pytest.approx(orig_reg.inlier_ratio)
+    assert reg.mean_perp_error == pytest.approx(orig_reg.mean_perp_error)
+    assert reg.max_perp_error == pytest.approx(orig_reg.max_perp_error)
+    assert reg.rmse == pytest.approx(orig_reg.rmse)
+
+
+# ---------------------------------------------------------------------------
+# Postgres repo against in-memory SQLite (no live DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_session() -> Iterator[Session]:
+    """Yield a Session over an in-memory SQLite with only the PTZ table created."""
+    engine = create_engine("sqlite://")
+    cast("Table", PtzRegistrationModel.__table__).create(engine)
+    with Session(engine) as session:
+        yield session
+
+
+class TestRepoPostgresPtzRegistration:
+    def test_save_and_get_round_trips_result_and_stats(self, sqlite_session: Session) -> None:
+        repo = RepoPostgresPtzRegistration(sqlite_session)
+        entity = PtzRegistration.from_result(_make_result(), reprojection_stats=_make_stats())
+        repo.save(entity)
+
+        loaded = repo.get(entity.id)
+        _assert_round_trip(loaded, entity)
+        assert loaded.reprojection_stats is not None
+        assert loaded.reprojection_stats.rms_m == pytest.approx(0.12)
+        assert loaded.reprojection_stats.p90_m == pytest.approx(0.2)
+        assert loaded.reprojection_stats.max_m == pytest.approx(0.31)
+        assert loaded.reprojection_stats.n_points == 8
+
+    def test_reprojection_stats_none_round_trips(self, sqlite_session: Session) -> None:
+        repo = RepoPostgresPtzRegistration(sqlite_session)
+        entity = PtzRegistration.from_result(_make_result(), reprojection_stats=None)
+        repo.save(entity)
+
+        loaded = repo.get(entity.id)
+        assert loaded is not None
+        assert loaded.reprojection_stats is None
+
+    def test_get_by_camera_returns_records(self, sqlite_session: Session) -> None:
+        repo = RepoPostgresPtzRegistration(sqlite_session)
+        cam = "map01/cam01"
+        e1 = PtzRegistration.from_result(_make_result(camera_id=cam, run_id="run_a", zoom=2.0))
+        e2 = PtzRegistration.from_result(_make_result(camera_id=cam, run_id="run_b", zoom=4.0))
+        other = PtzRegistration.from_result(_make_result(camera_id="map01/cam02", run_id="run_a"))
+        repo.save(e1)
+        repo.save(e2)
+        repo.save(other)
+
+        records = repo.get_by_camera(cam)
+        ids = {r.id for r in records}
+        assert ids == {e1.id, e2.id}
+        assert all(r.camera_id == cam for r in records)
+
+    def test_get_all(self, sqlite_session: Session) -> None:
+        repo = RepoPostgresPtzRegistration(sqlite_session)
+        e1 = PtzRegistration.from_result(_make_result(run_id="run_a"))
+        e2 = PtzRegistration.from_result(_make_result(run_id="run_b"))
+        repo.save(e1)
+        repo.save(e2)
+
+        ids = {r.id for r in repo.get_all()}
+        assert e1.id in ids
+        assert e2.id in ids
+
+    def test_save_is_upsert(self, sqlite_session: Session) -> None:
+        repo = RepoPostgresPtzRegistration(sqlite_session)
+        entity = PtzRegistration.from_result(_make_result(), reprojection_stats=None)
+        repo.save(entity)
+        repo.save(PtzRegistration.from_result(_make_result(), reprojection_stats=_make_stats()))
+
+        assert len(repo.get_all()) == 1
+        loaded = repo.get(entity.id)
+        assert loaded is not None
+        assert loaded.reprojection_stats is not None
+
+
+# ---------------------------------------------------------------------------
+# YAML repo
+# ---------------------------------------------------------------------------
+
+
+class TestRepoYamlPtzRegistration:
+    def test_save_and_get_round_trip(self, tmp_path: Path) -> None:
+        repo = RepoYamlPtzRegistration(tmp_path)
+        entity = PtzRegistration.from_result(_make_result(), reprojection_stats=_make_stats())
+        repo.save(entity)
+        repo.clear_cache()
+
+        loaded = repo.get(entity.id)
+        _assert_round_trip(loaded, entity)
+        assert loaded.reprojection_stats is not None
+        assert loaded.reprojection_stats.rms_m == pytest.approx(0.12)
+
+    def test_reprojection_stats_none_round_trips(self, tmp_path: Path) -> None:
+        repo = RepoYamlPtzRegistration(tmp_path)
+        entity = PtzRegistration.from_result(_make_result(), reprojection_stats=None)
+        repo.save(entity)
+        repo.clear_cache()
+
+        loaded = repo.get(entity.id)
+        assert loaded is not None
+        assert loaded.reprojection_stats is None
+
+    def test_get_by_camera_returns_records(self, tmp_path: Path) -> None:
+        repo = RepoYamlPtzRegistration(tmp_path)
+        cam = "map01/cam01"
+        e1 = PtzRegistration.from_result(_make_result(camera_id=cam, run_id="run_a", zoom=2.0))
+        e2 = PtzRegistration.from_result(_make_result(camera_id=cam, run_id="run_b", zoom=4.0))
+        other = PtzRegistration.from_result(_make_result(camera_id="map01/cam02", run_id="run_a"))
+        repo.save(e1)
+        repo.save(e2)
+        repo.save(other)
+        repo.clear_cache()
+
+        records = repo.get_by_camera(cam)
+        ids = {r.id for r in records}
+        assert ids == {e1.id, e2.id}
+
+
+# ---------------------------------------------------------------------------
+# Entity factory invariant
+# ---------------------------------------------------------------------------
+
+
+def test_from_result_requires_camera_id() -> None:
+    with pytest.raises(ValueError, match="camera_id is required"):
+        PtzRegistration.from_result(_make_result(camera_id=""))
+
+
+def test_from_dict_requires_camera_id() -> None:
+    data = PtzRegistration.from_result(_make_result()).to_dict()
+    data["camera_id"] = ""
+    with pytest.raises(ValueError, match="camera_id is required"):
+        PtzRegistration.from_dict(data)
+
+
+def test_make_id_distinguishes_close_floats() -> None:
+    """Distinct float64 PTZ states must not collapse to the same key."""
+    id_a = PtzRegistration.make_id("cam", "run", 2.0000001, 15.0)
+    id_b = PtzRegistration.make_id("cam", "run", 2.0000002, 15.0)
+    assert id_a != id_b
+
+
+def test_make_id_round_trips_via_recompute() -> None:
+    """The recomputed id matches the id stored in to_dict (no %g divergence)."""
+    entity = PtzRegistration.from_result(_make_result(zoom=2.0000001, tilt=15.0000003))
+    assert entity.to_dict()["id"] == entity.id

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -273,6 +273,7 @@ _.p90_m  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/va
 _.max_m  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:83)
 _.n_points  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:84)
 _.num_frames  # extrinsic-validation-surface (poc_homography/calibration/extrinsic/validation.py:132)
+_.from_result  # extrinsic-validation-surface (poc_homography/domain/entities/ptz_registration.py:182 — PtzRegistration persistence factory, called by registration writers/tests outside vulture scan, #364)
 
 # == uncertain-needs-follow-up ==
 # UNCERTAIN — symbol exists but no callers and no test references found; kept to keep vulture green pending a dead-code follow-up (see #226)


### PR DESCRIPTION
Closes #364

## Summary

Implements the persistence half of the extrinsic PTZ registration solvers shipped in #340 (which had no persistence).

- PtzRegistration domain entity composes the existing PtzRegistrationResult + optional ReprojectionStats (source of truth; no new metric fields, no re-solve).
- PtzRegistrationModel / ptz_registrations table keyed by a synthetic (camera_id, run_id, PTZ-state) id; camera_id/run_id indexed for later intrinsic+extrinsic joins. Matrices/metrics/stats stored as JSONB (SQLite JSON variant for offline tests).
- RepoPostgresPtzRegistration (mirrors RepoPostgresLensCalibrationTable) with get_by_camera; RepoYamlPtzRegistration mirror.
- Additive Alembic migration c4e9a1f7d2b3 (revises head 3a9f1c4b2e7d).
- No changes to calibration/extrinsic/ solver code.

## Test plan

uv run poe ci green (1362 passed, 158 skipped). New offline tests round-trip PtzRegistrationResult+ReprojectionStats through in-memory SQLite and tmp YAML (no live DB); cover get_by_camera, get_all, upsert, None-stats, camera_id invariants, float-precision id uniqueness.

## Closes DoD bullets

- New model + Postgres repo + Alembic migration; offline unit test round-trips PtzRegistrationResult+ReprojectionStats (SQLite, no live DB).
- get(camera_id) returns saved registration record(s) via get_by_camera.
- YAML mirror repo round-trips.
- No changes to existing calibration/extrinsic/ solver code. poe ci green.
