### PR TITLE
feat(cli): hom calibrate run-camera end-to-end single-camera runner [#365]

### DIFF
--- a/poc_homography/calibration/lens_distortion/ddd_sync.py
+++ b/poc_homography/calibration/lens_distortion/ddd_sync.py
@@ -13,8 +13,59 @@ if TYPE_CHECKING:
     from poc_homography.calibration.lens_distortion.calibration_table import (
         CameraCalibrationTable,
     )
+    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
 
 logger = logging.getLogger(__name__)
+
+
+def lens_table_to_camera_table(lens_table: LensCalibrationTable) -> CameraCalibrationTable:
+    """Convert a DDD :class:`LensCalibrationTable` to the legacy solver table.
+
+    The extrinsic solvers consume the legacy
+    :class:`~poc_homography.calibration.lens_distortion.calibration_table.CameraCalibrationTable`
+    (flat distortion fields, zoom-keyed dict), whereas the calibration repos yield
+    the DDD :class:`~poc_homography.domain.entities.lens_calibration_table.LensCalibrationTable`
+    (nested :class:`LensDistortion` value object). The two ``to_dict`` shapes are
+    NOT interchangeable, so this rebuilds the legacy table field-by-field — the
+    in-memory inverse of :func:`sync_to_ddd_repo`, co-located with it so the
+    bidirectional bridge stays in one place.
+
+    Args:
+        lens_table: The persisted per-zoom DDD lens table.
+
+    Returns:
+        An equivalent :class:`CameraCalibrationTable` the extrinsic solvers accept.
+    """
+    from poc_homography.calibration.lens_distortion.calibration_table import (
+        CameraCalibrationTable,
+        ZoomCalibrationEntry,
+    )
+
+    table = CameraCalibrationTable(
+        camera_id=lens_table.id,
+        created_date=lens_table.created_date,
+        last_modified=lens_table.last_modified,
+    )
+    for entry in lens_table.entries:
+        distortion = entry.distortion
+        table.entries[float(entry.zoom_factor)] = ZoomCalibrationEntry(
+            zoom_factor=float(entry.zoom_factor),
+            k1=float(distortion.k1),
+            k2=float(distortion.k2),
+            k3=float(distortion.k3),
+            p1=float(distortion.p1),
+            p2=float(distortion.p2),
+            calibration_date=entry.calibration_date,
+            source_images=tuple(entry.source_images),
+            validation_rmse=entry.validation_rmse,
+            num_lines_used=entry.num_lines_used,
+            fx=float(entry.fx),
+            fy=float(entry.fy),
+            cx=float(entry.cx),
+            cy=float(entry.cy),
+            reprojection_error_px=entry.reprojection_error_px,
+        )
+    return table
 
 
 def _find_project_root() -> Path:

--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -39,6 +39,7 @@ def _register_commands() -> None:
         line_picker,
         maps,
         point_picker,
+        run_camera,
         self_calibrate,
         survey,
         test_cmds,
@@ -57,6 +58,7 @@ def _register_commands() -> None:
     _ = line_picker
     _ = maps
     _ = point_picker
+    _ = run_camera
     _ = self_calibrate
     _ = survey
     _ = test_cmds

--- a/poc_homography/cli/run_camera.py
+++ b/poc_homography/cli/run_camera.py
@@ -1,0 +1,462 @@
+"""End-to-end single-camera calibration runner CLI command (#365).
+
+Pure composition of the already-merged stages — this leaf adds **no** new
+solver, capture, or calibration logic. It glues, for ONE camera:
+
+1. :func:`calibrate_capture._run_calibration_capture` — live calibration-sweep
+   capture (skipped when ``--offline-run-id`` reuses an already-captured run).
+2. :func:`self_calibrate._run_self_calibration` — per-zoom scene self-calibration
+   into a persisted :class:`LensCalibrationTable`.
+3. :func:`extrinsic.auto_match.match_and_register` — per captured PTZ frame,
+   discover the frame-line ↔ ortho-line correspondence (the AUTO matcher; an
+   optional ``pose_prior`` may be supplied to disambiguate repetitive lines).
+4. :func:`extrinsic.validation.validate_with_holdout` — hold-out reprojection
+   validation in ground meters; a hold-out RMS over the threshold raises the
+   typed :class:`HoldoutValidationError`, failing the whole camera.
+5. :class:`RepoPostgresPtzRegistration` (#364) — persist one
+   :class:`PtzRegistration` per validated frame.
+
+The extracted helper :func:`_run_camera_registration` references every
+collaborator (the calibrate helper, the frame loader, the extrinsic solvers, and
+both repositories) as module-level names so tests can swap them for doubles and
+exercise calibrate→register→validate→persist with NO live network, MinIO, or
+Neon access. ``--offline-run-id`` selects that offline-testable path at the CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import uuid
+from datetime import datetime
+from pathlib import Path  # runtime import: Typer resolves the --plan annotation
+from typing import TYPE_CHECKING, cast
+
+import typer
+
+from poc_homography.calibration.extrinsic import (
+    HoldoutValidationError,
+    InsufficientCorrespondenceError,
+    match_and_register,
+    validate_with_holdout,
+)
+from poc_homography.calibration.lens_distortion.calibration_table import (
+    CameraCalibrationTable,
+    ZoomCalibrationEntry,
+)
+from poc_homography.calibration.lens_distortion.frame_source import iter_survey_frames
+from poc_homography.calibration.lens_distortion.line_detection import LineDetector
+from poc_homography.cli.calibrate_capture import _run_calibration_capture
+from poc_homography.cli.main import calibrate_app
+from poc_homography.cli.self_calibrate import _run_self_calibration
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
+from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_clean_plate_frame import (
+    RepoPostgresCleanPlateFrame,
+)
+from poc_homography.infrastructure.repositories.repo_postgres_ptz_registration import (
+    RepoPostgresPtzRegistration,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from contextlib import AbstractContextManager
+    from typing import Protocol
+
+    import numpy as np
+    import numpy.typing as npt
+    from sqlalchemy.orm import Session
+
+    from poc_homography.calibration.lens_distortion.frame_source import FrameRepo, FrameStore
+    from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+    from poc_homography.domain.vo.geotiff import GeoTiff
+    from poc_homography.domain.vo.ortho_line import OrthoLine
+
+    class _FrameLineDetector(Protocol):
+        """Structural type for a frame line detector (``LineDetector``-shaped)."""
+
+        def detect(self, image: np.ndarray) -> list[CandidateLine]:
+            """Detect candidate frame lines in a BGR image."""
+            ...
+
+    PosePriorProvider = Callable[[float, float], npt.NDArray[np.float64] | None]
+
+
+def _to_camera_calibration_table(lens_table: LensCalibrationTable) -> CameraCalibrationTable:
+    """Bridge a persisted :class:`LensCalibrationTable` to the solver's table.
+
+    The extrinsic solvers consume the legacy
+    :class:`~poc_homography.calibration.lens_distortion.calibration_table.CameraCalibrationTable`
+    (flat distortion fields, zoom-keyed dict), whereas
+    :func:`_run_self_calibration` yields the DDD
+    :class:`~poc_homography.domain.entities.lens_calibration_table.LensCalibrationTable`
+    (nested :class:`LensDistortion` value object). The two ``to_dict`` shapes are
+    NOT interchangeable, so this rebuilds the legacy table field-by-field — the
+    inverse of :func:`poc_homography.calibration.lens_distortion.ddd_sync.sync_to_ddd_repo`.
+
+    Args:
+        lens_table: The persisted per-zoom lens table from self-calibration.
+
+    Returns:
+        An equivalent :class:`CameraCalibrationTable` the extrinsic solvers accept.
+    """
+    table = CameraCalibrationTable(
+        camera_id=lens_table.id,
+        created_date=lens_table.created_date,
+        last_modified=lens_table.last_modified,
+    )
+    for entry in lens_table.entries:
+        distortion = entry.distortion
+        table.entries[float(entry.zoom_factor)] = ZoomCalibrationEntry(
+            zoom_factor=float(entry.zoom_factor),
+            k1=float(distortion.k1),
+            k2=float(distortion.k2),
+            k3=float(distortion.k3),
+            p1=float(distortion.p1),
+            p2=float(distortion.p2),
+            calibration_date=entry.calibration_date,
+            source_images=tuple(entry.source_images),
+            validation_rmse=entry.validation_rmse,
+            num_lines_used=entry.num_lines_used,
+            fx=float(entry.fx),
+            fy=float(entry.fy),
+            cx=float(entry.cx),
+            cy=float(entry.cy),
+            reprojection_error_px=entry.reprojection_error_px,
+        )
+    return table
+
+
+def _run_camera_registration(
+    *,
+    run_id: str,
+    camera_id: str,
+    map_id: str,
+    ortho_lines: Sequence[OrthoLine],
+    geotiff: GeoTiff,
+    frame_store: FrameStore,
+    session_factory: Callable[[], AbstractContextManager[Session]],
+    rms_threshold_m: float,
+    line_detector: _FrameLineDetector | None = None,
+    pose_prior_provider: PosePriorProvider | None = None,
+    holdout_fraction: float = 0.3,
+    rng_seed: int = 0,
+    clock: Callable[[], datetime] | None = None,
+) -> list[PtzRegistration]:
+    """Glue calibrate→register→validate→persist for one camera's stored frames.
+
+    Self-calibrates the run's frames into a lens table, then for every stored
+    frame discovers the frame↔ortho correspondence with the AUTO matcher,
+    hold-out-validates the resulting registration in ground meters, and persists
+    one :class:`PtzRegistration` per validated frame. Every persisted save shares
+    a single session/transaction, so a :class:`HoldoutValidationError` on ANY
+    frame aborts the whole camera and rolls back the run's registrations.
+
+    Extracted from the command body so tests can inject a fake frame store, a
+    fake session factory, and a fake line detector (and monkeypatch the
+    module-level collaborators) with no live MinIO, Neon, or camera access.
+
+    Args:
+        run_id: Survey run whose stored frames are registered.
+        camera_id: Camera id; also the lens-table and registration join key.
+        map_id: Orthophoto map identifier handed to the homography provider.
+        ortho_lines: Orthophoto lines, keyed positionally as ``ortho_{i}``.
+        geotiff: Georeference for converting map-pixel error to ground meters.
+        frame_store: Frame byte store (injected; offline-testable).
+        session_factory: Database session context-manager factory.
+        rms_threshold_m: Maximum acceptable hold-out reprojection RMS (meters).
+        line_detector: Frame line detector; defaults to a real :class:`LineDetector`.
+        pose_prior_provider: Optional ``(zoom, tilt) -> 3x3 frame→ortho prior``
+            used only to gate AUTO-matcher candidates; ``None`` keeps line-only
+            matching.
+        holdout_fraction: Fraction of correspondences held out per frame, in (0, 1).
+        rng_seed: Seed for the reproducible AUTO match + hold-out split.
+        clock: Wall-clock seam for record timestamps (defaults to ``datetime.now``).
+
+    Returns:
+        The list of persisted :class:`PtzRegistration` records, one per frame.
+
+    Raises:
+        HoldoutValidationError: If any frame's hold-out RMS exceeds the threshold.
+        InsufficientCorrespondenceError: If the AUTO matcher cannot match a frame.
+        typer.Exit: If self-calibration finds no frames for the run.
+    """
+    detector = line_detector if line_detector is not None else LineDetector()
+    now = (clock() if clock is not None else datetime.now()).isoformat()
+
+    calibration = _run_self_calibration(
+        run_id=run_id,
+        camera_id=camera_id,
+        frame_store=frame_store,
+        session_factory=session_factory,
+    )
+    calibration_table = _to_camera_calibration_table(calibration.table)
+
+    registrations: list[PtzRegistration] = []
+    with session_factory() as session:
+        # The concrete repo's query surface is wider than the loader's FrameRepo
+        # protocol; cast at the boundary since it structurally satisfies the reads.
+        frame_repo = cast("FrameRepo", RepoPostgresCleanPlateFrame(session))
+        ptz_repo = RepoPostgresPtzRegistration(session)
+
+        for frame in iter_survey_frames(
+            run_id=run_id, camera_id=camera_id, repo=frame_repo, store=frame_store
+        ):
+            frame_lines = detector.detect(frame.image)
+            height, width = frame.image.shape[:2]
+            pose_prior = (
+                pose_prior_provider(frame.commanded_zoom, frame.commanded_tilt)
+                if pose_prior_provider is not None
+                else None
+            )
+
+            auto = match_and_register(
+                frame_lines=frame_lines,
+                ortho_lines=ortho_lines,
+                calibration_table=calibration_table,
+                commanded_zoom=frame.commanded_zoom,
+                commanded_tilt=frame.commanded_tilt,
+                map_id=map_id,
+                image_width=int(width),
+                image_height=int(height),
+                pose_prior=pose_prior,
+                run_id=run_id,
+                camera_id=camera_id,
+                rng_seed=rng_seed,
+            )
+
+            # Hold-out validation re-solves on a fit subset and checks the held-out
+            # RMS; it raises HoldoutValidationError when RMS exceeds the threshold.
+            validation = validate_with_holdout(
+                frame_lines=frame_lines,
+                ortho_lines=ortho_lines,
+                seed=auto.seed,
+                calibration_table=calibration_table,
+                commanded_zoom=frame.commanded_zoom,
+                commanded_tilt=frame.commanded_tilt,
+                map_id=map_id,
+                geotiff=geotiff,
+                rms_threshold_m=rms_threshold_m,
+                holdout_fraction=holdout_fraction,
+                rng_seed=rng_seed,
+                run_id=run_id,
+                camera_id=camera_id,
+            )
+
+            record = PtzRegistration.from_result(
+                validation.registration,
+                reprojection_stats=validation.holdout_stats,
+                created_date=now,
+                last_modified=now,
+            )
+            ptz_repo.save(record)
+            registrations.append(record)
+
+    return registrations
+
+
+def _resolve_camera(camera: str) -> dict:
+    """Resolve a camera name/id to its config dict or exit with a clear error."""
+    from poc_homography.camera_config import get_camera_by_name, get_camera_configs
+
+    cam_info = get_camera_by_name(camera)
+    if not cam_info:
+        available = [c["name"] for c in get_camera_configs()]
+        typer.echo(
+            f"Error: Camera '{camera}' not found. Available cameras: {', '.join(available)}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return cam_info
+
+
+def _live_capture(
+    *,
+    cam_info: dict,
+    plan: Path,
+    frame_store: MinioFrameStore,
+    run_id: str,
+) -> None:
+    """Drive ONE live camera through the calibration sweep (capture → frames).
+
+    Composes the same public collaborators the standalone ``calibrate-capture``
+    command uses (plan-config sidecar, tenant credentials, live ISAPI client,
+    Postgres+MinIO sink) and delegates the sweep to the shared
+    :func:`_run_calibration_capture` helper — it does not re-implement capture.
+    """
+    import yaml
+
+    from poc_homography.camera_config import get_tenant_credentials
+    from poc_homography.domain.entities.camera_config import CameraConfig
+    from poc_homography.domain.enums import CameraSpec
+    from poc_homography.domain.vo.credential import Credential
+    from poc_homography.domain.vo.survey_plan_config import SurveyPlanConfig
+    from poc_homography.infrastructure.clients.hikvision.isapi_client import HikvisionISAPIClient
+    from poc_homography.infrastructure.survey.postgres_phase_sink import PostgresPhaseSink
+    from poc_homography.survey.phases.runner import SurveyPlan
+
+    try:
+        with plan.open() as handle:
+            config = SurveyPlanConfig.from_dict(yaml.safe_load(handle))
+    except (OSError, yaml.YAMLError, ValueError, TypeError) as exc:
+        typer.echo(f"Error: Failed to load plan config: {exc}", err=True)
+        raise typer.Exit(1)
+    runner_plan = SurveyPlan.from_plan_config(config)
+
+    tenant_id = cam_info.get("tenant_id") or ""
+    username, password = get_tenant_credentials(tenant_id)
+    if not username or not password:
+        typer.echo(
+            f"Error: Camera credentials not set for tenant '{tenant_id}'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    camera_config = CameraConfig(
+        id=cam_info["id"],
+        tenant_id=tenant_id,
+        map_id=cam_info.get("map_id", ""),
+        name=cam_info.get("name", cam_info["id"]),
+        spec=CameraSpec.HIKVISION_DS_2DF8425IX,
+        credential=Credential(username, password),
+        ip_address=cam_info["ip"],
+    )
+    try:
+        client = HikvisionISAPIClient.from_config(camera_config)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+
+    sink = PostgresPhaseSink(frame_store)
+    base_output_dir = Path(tempfile.mkdtemp())
+    try:
+        _run_calibration_capture(
+            camera=client,
+            plan_config=config,
+            runner_plan=runner_plan,
+            camera_id=cam_info["id"],
+            run_id=run_id,
+            base_output_dir=base_output_dir,
+            sink=sink,
+            session_factory=get_session,
+        )
+    finally:
+        shutil.rmtree(base_output_dir, ignore_errors=True)
+
+
+def _load_ortho_context(map_id: str) -> tuple[Sequence[OrthoLine], GeoTiff]:
+    """Load a map's ortho lines + georeference from Neon + MinIO (live path).
+
+    Resolves the :class:`Map` entity (its authoritative ``geotiff`` + ``asset_key``)
+    from Neon, downloads the GeoTIFF raster from MinIO, and detects the orthophoto
+    lines. Live-only; the offline runner is fed ortho lines + geotiff directly.
+    """
+    from poc_homography.infrastructure.clients.minio_map_store import MinioMapStore
+    from poc_homography.infrastructure.repositories.repo_postgres_map import RepoPostgresMap
+    from poc_homography.maps.geotiff_io import load_ortho_raster_from_bytes
+    from poc_homography.maps.ortho_line_detection import OrthoLineDetector
+
+    with get_session() as session:
+        map_entity = RepoPostgresMap(session).get(map_id)
+    if map_entity is None or not map_entity.asset_key:
+        typer.echo(
+            f"Error: Map '{map_id}' not found or has no uploaded GeoTIFF asset.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    try:
+        raster = MinioMapStore.from_env().get_map(map_entity.asset_key)
+    except (RuntimeError, OSError) as exc:
+        typer.echo(f"Error: Failed to load map asset: {exc}", err=True)
+        raise typer.Exit(1)
+
+    image, _raster_geotiff = load_ortho_raster_from_bytes(raster)
+    ortho_lines = OrthoLineDetector().detect(image, map_entity.geotiff)
+    return ortho_lines, map_entity.geotiff
+
+
+@calibrate_app.command("run-camera")
+def run_camera_command(
+    camera: str = typer.Option(..., "--camera", help="Camera name or id (e.g., 'valte_cam01')"),
+    plan: Path | None = typer.Option(
+        None, "--plan", help="YAML survey plan config (required for live capture)"
+    ),
+    offline_run_id: str | None = typer.Option(
+        None,
+        "--offline-run-id",
+        help="Skip live capture and reuse an already-captured survey run id",
+    ),
+    rms_threshold_m: float = typer.Option(
+        1.0,
+        "--rms-threshold-m",
+        help="Maximum acceptable hold-out reprojection RMS in meters",
+    ),
+) -> None:
+    """Run the end-to-end single-camera calibration→registration pipeline.
+
+    With ``--offline-run-id`` the live capture is skipped and the pipeline runs
+    calibrate→register→validate→persist over the already-captured frames. Live
+    runs require ``--plan`` and drive the camera through the calibration sweep
+    first. A hold-out RMS over ``--rms-threshold-m`` fails the camera with a
+    non-zero exit and a clear message.
+    """
+    cam_info = _resolve_camera(camera)
+    camera_id = cam_info["id"]
+    map_id = cam_info.get("map_id") or ""
+    if not map_id:
+        typer.echo(f"Error: Camera '{camera}' has no map_id configured.", err=True)
+        raise typer.Exit(1)
+
+    # Pre-flight the env contracts up front so a misconfiguration fails fast.
+    try:
+        frame_store = MinioFrameStore.from_env()
+    except RuntimeError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    if not os.environ.get("DATABASE_URL"):
+        typer.echo("Error: DATABASE_URL environment variable is not set.", err=True)
+        raise typer.Exit(1)
+
+    if offline_run_id:
+        run_id = offline_run_id
+    else:
+        if plan is None:
+            typer.echo(
+                "Error: --plan is required for a live run (omit only with --offline-run-id).",
+                err=True,
+            )
+            raise typer.Exit(1)
+        run_id = uuid.uuid4().hex
+        _live_capture(cam_info=cam_info, plan=plan, frame_store=frame_store, run_id=run_id)
+
+    ortho_lines, geotiff = _load_ortho_context(map_id)
+
+    try:
+        registrations = _run_camera_registration(
+            run_id=run_id,
+            camera_id=camera_id,
+            map_id=map_id,
+            ortho_lines=ortho_lines,
+            geotiff=geotiff,
+            frame_store=frame_store,
+            session_factory=get_session,
+            rms_threshold_m=rms_threshold_m,
+        )
+    except HoldoutValidationError as exc:
+        typer.echo(
+            f"Error: Hold-out validation failed for camera {camera_id}: {exc}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    except InsufficientCorrespondenceError as exc:
+        typer.echo(f"Error: Automatic matching failed for camera {camera_id}: {exc}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo(f"Done: camera_id={camera_id} run_id={run_id} registrations={len(registrations)}")
+
+
+__all__ = ["run_camera_command"]

--- a/poc_homography/cli/run_camera.py
+++ b/poc_homography/cli/run_camera.py
@@ -41,10 +41,7 @@ from poc_homography.calibration.extrinsic import (
     match_and_register,
     validate_with_holdout,
 )
-from poc_homography.calibration.lens_distortion.calibration_table import (
-    CameraCalibrationTable,
-    ZoomCalibrationEntry,
-)
+from poc_homography.calibration.lens_distortion.ddd_sync import lens_table_to_camera_table
 from poc_homography.calibration.lens_distortion.frame_source import iter_survey_frames
 from poc_homography.calibration.lens_distortion.line_detection import LineDetector
 from poc_homography.cli.calibrate_capture import _run_calibration_capture
@@ -71,7 +68,6 @@ if TYPE_CHECKING:
 
     from poc_homography.calibration.lens_distortion.frame_source import FrameRepo, FrameStore
     from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
-    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
     from poc_homography.domain.vo.geotiff import GeoTiff
     from poc_homography.domain.vo.ortho_line import OrthoLine
 
@@ -83,51 +79,6 @@ if TYPE_CHECKING:
             ...
 
     PosePriorProvider = Callable[[float, float], npt.NDArray[np.float64] | None]
-
-
-def _to_camera_calibration_table(lens_table: LensCalibrationTable) -> CameraCalibrationTable:
-    """Bridge a persisted :class:`LensCalibrationTable` to the solver's table.
-
-    The extrinsic solvers consume the legacy
-    :class:`~poc_homography.calibration.lens_distortion.calibration_table.CameraCalibrationTable`
-    (flat distortion fields, zoom-keyed dict), whereas
-    :func:`_run_self_calibration` yields the DDD
-    :class:`~poc_homography.domain.entities.lens_calibration_table.LensCalibrationTable`
-    (nested :class:`LensDistortion` value object). The two ``to_dict`` shapes are
-    NOT interchangeable, so this rebuilds the legacy table field-by-field — the
-    inverse of :func:`poc_homography.calibration.lens_distortion.ddd_sync.sync_to_ddd_repo`.
-
-    Args:
-        lens_table: The persisted per-zoom lens table from self-calibration.
-
-    Returns:
-        An equivalent :class:`CameraCalibrationTable` the extrinsic solvers accept.
-    """
-    table = CameraCalibrationTable(
-        camera_id=lens_table.id,
-        created_date=lens_table.created_date,
-        last_modified=lens_table.last_modified,
-    )
-    for entry in lens_table.entries:
-        distortion = entry.distortion
-        table.entries[float(entry.zoom_factor)] = ZoomCalibrationEntry(
-            zoom_factor=float(entry.zoom_factor),
-            k1=float(distortion.k1),
-            k2=float(distortion.k2),
-            k3=float(distortion.k3),
-            p1=float(distortion.p1),
-            p2=float(distortion.p2),
-            calibration_date=entry.calibration_date,
-            source_images=tuple(entry.source_images),
-            validation_rmse=entry.validation_rmse,
-            num_lines_used=entry.num_lines_used,
-            fx=float(entry.fx),
-            fy=float(entry.fy),
-            cx=float(entry.cx),
-            cy=float(entry.cy),
-            reprojection_error_px=entry.reprojection_error_px,
-        )
-    return table
 
 
 def _run_camera_registration(
@@ -142,9 +93,6 @@ def _run_camera_registration(
     rms_threshold_m: float,
     line_detector: _FrameLineDetector | None = None,
     pose_prior_provider: PosePriorProvider | None = None,
-    holdout_fraction: float = 0.3,
-    rng_seed: int = 0,
-    clock: Callable[[], datetime] | None = None,
 ) -> list[PtzRegistration]:
     """Glue calibrate→register→validate→persist for one camera's stored frames.
 
@@ -172,9 +120,6 @@ def _run_camera_registration(
         pose_prior_provider: Optional ``(zoom, tilt) -> 3x3 frame→ortho prior``
             used only to gate AUTO-matcher candidates; ``None`` keeps line-only
             matching.
-        holdout_fraction: Fraction of correspondences held out per frame, in (0, 1).
-        rng_seed: Seed for the reproducible AUTO match + hold-out split.
-        clock: Wall-clock seam for record timestamps (defaults to ``datetime.now``).
 
     Returns:
         The list of persisted :class:`PtzRegistration` records, one per frame.
@@ -185,7 +130,7 @@ def _run_camera_registration(
         typer.Exit: If self-calibration finds no frames for the run.
     """
     detector = line_detector if line_detector is not None else LineDetector()
-    now = (clock() if clock is not None else datetime.now()).isoformat()
+    now = datetime.now().isoformat()
 
     calibration = _run_self_calibration(
         run_id=run_id,
@@ -193,7 +138,7 @@ def _run_camera_registration(
         frame_store=frame_store,
         session_factory=session_factory,
     )
-    calibration_table = _to_camera_calibration_table(calibration.table)
+    calibration_table = lens_table_to_camera_table(calibration.table)
 
     registrations: list[PtzRegistration] = []
     with session_factory() as session:
@@ -225,7 +170,6 @@ def _run_camera_registration(
                 pose_prior=pose_prior,
                 run_id=run_id,
                 camera_id=camera_id,
-                rng_seed=rng_seed,
             )
 
             # Hold-out validation re-solves on a fit subset and checks the held-out
@@ -240,8 +184,6 @@ def _run_camera_registration(
                 map_id=map_id,
                 geotiff=geotiff,
                 rms_threshold_m=rms_threshold_m,
-                holdout_fraction=holdout_fraction,
-                rng_seed=rng_seed,
                 run_id=run_id,
                 camera_id=camera_id,
             )

--- a/tests/cli/test_run_camera.py
+++ b/tests/cli/test_run_camera.py
@@ -1,0 +1,353 @@
+"""Offline, deterministic tests for the end-to-end single-camera runner (#365).
+
+The runner glues calibrate→register→validate→persist for one camera. These tests
+exercise that glue with a fake frame store, a fake session, and canned doubles
+for the self-calibrate stage / frame loader / repositories — with NO live
+network, MinIO, or Neon. The extrinsic AUTO matcher and hold-out validator run
+for REAL over a synthetic known-homography dataset (mirroring
+``tests/calibration/extrinsic/test_validation.py``), so the registration and
+validation math is genuinely exercised, not stubbed.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import cv2
+import numpy as np
+import pytest
+from typer.testing import CliRunner
+
+from poc_homography.calibration.extrinsic import HoldoutValidationError
+from poc_homography.calibration.lens_distortion.frame_source import SurveyFrame
+from poc_homography.calibration.lens_distortion.line_detection import CandidateLine
+from poc_homography.calibration.lens_distortion.scene_self_calibration import SceneCalibrationResult
+from poc_homography.cli import run_camera as cmd
+from poc_homography.cli.main import app
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.ortho_line import OrthoLine
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_IMAGE_WIDTH = 1920
+_IMAGE_HEIGHT = 1080
+_GSD_M = 0.10  # 0.10 m/px ground sampling distance.
+
+# Known perspective warp ORTHO map-pixel -> FRAME pixel; the AUTO matcher must
+# recover frame -> ortho (~ inverse of this) with no operator seed.
+_H_ORTHO_TO_FRAME = np.array(
+    [
+        [1.10, 0.05, 40.0],
+        [0.03, 1.20, 25.0],
+        [1.0e-4, 5.0e-5, 1.0],
+    ],
+    dtype=np.float64,
+)
+
+# Well-conditioned ortho segments spread across the frame so the warped inlier
+# endpoints achieve a "Good"/"Fair" distribution.
+_ORTHO_SEGMENTS: list[tuple[tuple[float, float], tuple[float, float]]] = [
+    ((150.0, 150.0), (1400.0, 180.0)),
+    ((200.0, 250.0), (240.0, 850.0)),
+    ((300.0, 300.0), (1300.0, 820.0)),
+    ((1350.0, 260.0), (350.0, 800.0)),
+    ((900.0, 200.0), (940.0, 880.0)),
+]
+
+
+def _lens_table(camera_id: str = "cam1") -> LensCalibrationTable:
+    """DDD lens table with real intrinsics + zero distortion (exact math)."""
+    entry = ZoomCalibrationEntry(
+        zoom_factor=1.0,
+        distortion=LensDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0),
+        calibration_date="2024-01-01T00:00:00",
+        source_images=(),
+        fx=1000.0,
+        fy=1000.0,
+        cx=960.0,
+        cy=540.0,
+    )
+    return LensCalibrationTable(
+        id=camera_id,
+        entries=(entry,),
+        created_date="2024-01-01T00:00:00",
+        last_modified="2024-01-01T00:00:00",
+    )
+
+
+def _ortho_lines() -> list[OrthoLine]:
+    lines: list[OrthoLine] = []
+    for i, (start, end) in enumerate(_ORTHO_SEGMENTS):
+        lines.append(
+            OrthoLine.from_endpoints(
+                start_pixel=start,
+                end_pixel=end,
+                start_utm=(500000.0 + i, 4000000.0 + i),
+                end_utm=(500010.0 + i, 4000010.0 + i),
+            )
+        )
+    return lines
+
+
+def _geotiff() -> GeoTiff:
+    """North-up GeoTIFF with a 0.10 m/px ground sampling distance."""
+    return GeoTiff(
+        geotransform=GeoTransform(
+            origin_easting=500000.0,
+            pixel_width=_GSD_M,
+            row_rotation=0.0,
+            origin_northing=4000000.0,
+            col_rotation=0.0,
+            pixel_height=-_GSD_M,
+        ),
+        crs="EPSG:25830",
+    )
+
+
+def _warp_point(point: tuple[float, float], homography: np.ndarray) -> tuple[float, float]:
+    pt = np.array([[[point[0], point[1]]]], dtype=np.float64)
+    out = cv2.perspectiveTransform(pt, homography)[0, 0]
+    return float(out[0]), float(out[1])
+
+
+def _frame_lines(
+    ortho_lines: list[OrthoLine],
+    noise_px: float = 0.0,
+    rng: np.random.Generator | None = None,
+) -> list[CandidateLine]:
+    """Project ortho map-pixel endpoints into frame pixels via the known H."""
+    lines: list[CandidateLine] = []
+    for line in ortho_lines:
+        start = _warp_point(
+            (float(line.start_pixel[0]), float(line.start_pixel[1])), _H_ORTHO_TO_FRAME
+        )
+        end = _warp_point((float(line.end_pixel[0]), float(line.end_pixel[1])), _H_ORTHO_TO_FRAME)
+        if noise_px > 0.0 and rng is not None:
+            start = (start[0] + rng.normal(0, noise_px), start[1] + rng.normal(0, noise_px))
+            end = (end[0] + rng.normal(0, noise_px), end[1] + rng.normal(0, noise_px))
+        lines.append(CandidateLine(start=start, end=end))
+    return lines
+
+
+class _FakeDetector:
+    """Frame line detector double: returns the same canned lines for any image."""
+
+    def __init__(self, lines: list[CandidateLine]) -> None:
+        self._lines = lines
+
+    def detect(self, image: np.ndarray) -> list[CandidateLine]:
+        return self._lines
+
+
+class _CapturingPtzRepo:
+    """RepoPostgresPtzRegistration double that records every saved record."""
+
+    saved: list = []
+
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+    def save(self, record: object) -> None:
+        type(self).saved.append(record)
+
+
+class _FakeFrameRepo:
+    """RepoPostgresCleanPlateFrame double; never queried (loader is patched)."""
+
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+
+class _FakeSession:
+    """Minimal session object handed to the repository doubles."""
+
+
+@contextmanager
+def _fake_session_factory() -> Iterator[_FakeSession]:
+    yield _FakeSession()
+
+
+class _FakeFrameStore:
+    """FrameStore double; iter_survey_frames is patched so this is never read."""
+
+    def get_frame(self, key: str, *, bucket: str | None = None) -> bytes:
+        raise AssertionError("frame store should not be read when the loader is faked")
+
+
+def _install_doubles(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    frames: list[SurveyFrame],
+    lens_table: LensCalibrationTable | None = None,
+) -> None:
+    """Patch the runner's module-level seams to offline doubles."""
+    table = lens_table if lens_table is not None else _lens_table()
+    result = SceneCalibrationResult(table=table, skipped_zooms=())
+
+    def fake_self_calibration(*, run_id, camera_id, frame_store, session_factory):
+        return result
+
+    monkeypatch.setattr(cmd, "_run_self_calibration", fake_self_calibration)
+    monkeypatch.setattr(cmd, "iter_survey_frames", lambda **_kwargs: iter(frames))
+    monkeypatch.setattr(cmd, "RepoPostgresCleanPlateFrame", _FakeFrameRepo)
+    monkeypatch.setattr(cmd, "RepoPostgresPtzRegistration", _CapturingPtzRepo)
+    _CapturingPtzRepo.saved = []
+
+
+def _survey_frame(zoom: float = 1.0, tilt: float = -15.0) -> SurveyFrame:
+    image = np.zeros((_IMAGE_HEIGHT, _IMAGE_WIDTH, 3), dtype=np.uint8)
+    return SurveyFrame(image=image, commanded_zoom=zoom, commanded_tilt=tilt)
+
+
+# ---------------------------------------------------------------------------
+# DoD 2: offline calibrate -> register -> validate -> persist
+# ---------------------------------------------------------------------------
+
+
+def test_run_camera_registration_persists_one_record_per_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ortho_lines = _ortho_lines()
+    frame_lines = _frame_lines(ortho_lines)
+    frames = [_survey_frame(), _survey_frame()]
+    _install_doubles(monkeypatch, frames=frames)
+
+    registrations = cmd._run_camera_registration(
+        run_id="run1",
+        camera_id="cam1",
+        map_id="map1",
+        ortho_lines=ortho_lines,
+        geotiff=_geotiff(),
+        frame_store=_FakeFrameStore(),
+        session_factory=_fake_session_factory,
+        rms_threshold_m=1.0,
+        line_detector=_FakeDetector(frame_lines),
+    )
+
+    # One persisted registration per frame, captured by the repo double.
+    assert len(registrations) == 2
+    assert len(_CapturingPtzRepo.saved) == 2
+    for record in _CapturingPtzRepo.saved:
+        assert record.camera_id == "cam1"
+        assert record.run_id == "run1"
+        # Hold-out reprojection stats accompany every persisted record.
+        assert record.reprojection_stats is not None
+        assert record.reprojection_stats.rms_m <= 1.0
+
+
+def test_run_camera_registration_uses_self_calibrated_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A lens table whose camera_id round-trips into each persisted record proves
+    # the self-calibration output drove the (real) registration solve.
+    ortho_lines = _ortho_lines()
+    frames = [_survey_frame()]
+    _install_doubles(monkeypatch, frames=frames, lens_table=_lens_table("cam1"))
+
+    registrations = cmd._run_camera_registration(
+        run_id="run1",
+        camera_id="cam1",
+        map_id="map1",
+        ortho_lines=ortho_lines,
+        geotiff=_geotiff(),
+        frame_store=_FakeFrameStore(),
+        session_factory=_fake_session_factory,
+        rms_threshold_m=1.0,
+        line_detector=_FakeDetector(_frame_lines(ortho_lines)),
+    )
+
+    assert len(registrations) == 1
+    reg = registrations[0].registration
+    # A 3x3 homography was actually solved (not a stub identity passthrough).
+    assert reg.homography_matrix.shape == (3, 3)
+    assert reg.num_inliers >= 2
+
+
+# ---------------------------------------------------------------------------
+# DoD 3: hold-out RMS over threshold fails the camera
+# ---------------------------------------------------------------------------
+
+
+def test_holdout_over_threshold_raises_and_persists_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ortho_lines = _ortho_lines()
+    rng = np.random.default_rng(7)
+    noisy_lines = _frame_lines(ortho_lines, noise_px=1.0, rng=rng)
+    frames = [_survey_frame()]
+    _install_doubles(monkeypatch, frames=frames)
+
+    with pytest.raises(HoldoutValidationError):
+        cmd._run_camera_registration(
+            run_id="run1",
+            camera_id="cam1",
+            map_id="map1",
+            ortho_lines=ortho_lines,
+            geotiff=_geotiff(),
+            frame_store=_FakeFrameStore(),
+            session_factory=_fake_session_factory,
+            rms_threshold_m=1.0e-6,  # any real reprojection error exceeds this
+            line_detector=_FakeDetector(noisy_lines),
+        )
+
+
+# ---------------------------------------------------------------------------
+# DoD 1: command is wired and exits non-zero on hold-out failure
+# ---------------------------------------------------------------------------
+
+
+def _wire_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the live-only collaborators so the CLI reaches the runner."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    monkeypatch.setattr(
+        cmd,
+        "_resolve_camera",
+        lambda _camera: {"id": "cam1", "map_id": "map1", "name": "Cam1", "ip": "10.0.0.1"},
+    )
+    monkeypatch.setattr(cmd.MinioFrameStore, "from_env", classmethod(lambda _cls: object()))
+    monkeypatch.setattr(cmd, "_load_ortho_context", lambda _map_id: (_ortho_lines(), _geotiff()))
+
+
+def test_command_offline_run_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+    monkeypatch.setattr(cmd, "_run_camera_registration", lambda **_kwargs: ["rec_a", "rec_b"])
+
+    result = CliRunner().invoke(
+        app, ["calibrate", "run-camera", "--camera", "cam1", "--offline-run-id", "run1"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "registrations=2" in result.output
+
+
+def test_command_holdout_failure_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+
+    def boom(**_kwargs):
+        from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+
+        stats = ReprojectionStats(rms_m=2.0, p90_m=2.0, max_m=2.0, n_points=4)
+        raise HoldoutValidationError(2.0, 1.0, stats)
+
+    monkeypatch.setattr(cmd, "_run_camera_registration", boom)
+
+    result = CliRunner().invoke(
+        app, ["calibrate", "run-camera", "--camera", "cam1", "--offline-run-id", "run1"]
+    )
+
+    assert result.exit_code != 0
+    assert "Hold-out validation failed" in result.output
+
+
+def test_command_live_run_requires_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+
+    result = CliRunner().invoke(app, ["calibrate", "run-camera", "--camera", "cam1"])
+
+    assert result.exit_code != 0
+    assert "--plan is required" in result.output


### PR DESCRIPTION
## Summary

Build the absent end-to-end single-camera runner `hom calibrate run-camera --camera <id> [--plan ...] [--offline-run-id ...]` (wired into `main.py:_register_commands`). It composes the already-merged stages for ONE camera — no solver, capture, or calibrate body is reimplemented:

- capture via `calibrate_capture._run_calibration_capture` (live; skipped when `--offline-run-id` reuses an already-captured run)
- self-calibration via `self_calibrate._run_self_calibration` → `LensCalibrationTable`
- AUTO match per PTZ frame via `extrinsic.auto_match.match_and_register` (optional `pose_prior` seam; defaults to line-only AUTO matching)
- hold-out reprojection validation in ground meters via `extrinsic.validation.validate_with_holdout`
- persistence of one `PtzRegistration` per validated frame via the #364 repo

Adds a small `LensCalibrationTable` (DDD, nested `LensDistortion`) → `CameraCalibrationTable` (legacy, flat) bridge — the inverse of `ddd_sync.sync_to_ddd_repo` — because the two `to_dict` shapes are not interchangeable. A hold-out RMS over `--rms-threshold-m` raises `HoldoutValidationError`, failing the camera with a non-zero exit + clear message; all per-frame saves share one transaction so a failure rolls back the run.

## Test plan

`poe ci` green (lint, format-check, pyright, pylint, vulture, 1368 tests pass). New `tests/cli/test_run_camera.py` exercises calibrate→register→validate→persist offline with a fake frame store + fake session + canned self-calibrate/loader/repo doubles, running the REAL AUTO matcher + hold-out validator over a synthetic known-homography dataset (no live network/MinIO/Neon): asserts one persisted record per frame, that the self-calibrated table drove a real 3×3 solve, that an over-threshold hold-out RMS raises `HoldoutValidationError`, and that the CLI command is wired and exits non-zero on hold-out failure / missing `--plan`.

## Definition of Done

- [x] `hom calibrate run-camera` exists + wired in `main.py`.
- [x] Offline test (fake frame store + fake session) exercises calibrate→register→validate→persist with NO live network/MinIO/Neon.
- [x] Hold-out RMS over threshold fails the camera with non-zero exit + clear message (`HoldoutValidationError`).
- [x] `poe ci` green.

Closes #365
