### PR TITLE
feat(cli): per-camera calibration-confidence report [#366]

### DIFF
--- a/poc_homography/calibration/confidence.py
+++ b/poc_homography/calibration/confidence.py
@@ -23,8 +23,14 @@ Three independent quality axes are derived from the persisted summaries:
 
   * Intrinsic axis, from the worst per-zoom intrinsic error in pixels. The
     per-zoom error of an entry is ``max(validation_rmse, reprojection_error_px)``.
+    A persisted entry can carry a ``0.0`` error simply because no metric was
+    recorded (both fields default to ``0.0``); a physically-implausible perfect
+    ``0.0`` is therefore treated as *unmeasured* and excluded from the summary,
+    so a camera whose entries carry no positive error is reported
+    ``Uncalibrated`` rather than misreported as perfect.
   * Extrinsic axis, from the worst hold-out reprojection RMS in ground meters.
-  * Inlier axis, from the minimum RANSAC/ICP inlier ratio across registrations.
+  * Inlier axis, from the minimum RANSAC/ICP inlier ratio across the validated
+    registrations (those carrying hold-out reprojection stats).
 
 The overall ``label`` is the WORST band across the three axes (order
 Poor < Fair < Good). The overall ``score`` in [0, 1] is the mean of three
@@ -226,8 +232,15 @@ def _inlier_label(min_inlier_ratio: float) -> str:
     return POOR
 
 
-def _build_intrinsic_summary(lens_table: LensCalibrationTable) -> IntrinsicSummary:
-    """Aggregate a non-empty lens table into an :class:`IntrinsicSummary`."""
+def _build_intrinsic_summary(lens_table: LensCalibrationTable) -> IntrinsicSummary | None:
+    """Aggregate a non-empty lens table into an :class:`IntrinsicSummary`.
+
+    Worst/mean are computed over entries with a *positive* per-zoom error only:
+    a ``0.0`` error means the metric was not recorded (both source fields default
+    to ``0.0``), not a perfect calibration. Returns None when no entry carries a
+    positive error, so the camera is reported as uncalibrated rather than scored
+    as perfect. ``per_zoom`` still carries every entry for display.
+    """
     per_zoom = tuple(
         ZoomIntrinsicPoint(
             zoom_factor=float(entry.zoom_factor),
@@ -236,13 +249,17 @@ def _build_intrinsic_summary(lens_table: LensCalibrationTable) -> IntrinsicSumma
         )
         for entry in lens_table.entries
     )
-    errors = [
-        _entry_error_px(point.validation_rmse, point.reprojection_error_px) for point in per_zoom
+    measured = [
+        error
+        for point in per_zoom
+        if (error := _entry_error_px(point.validation_rmse, point.reprojection_error_px)) > 0.0
     ]
+    if not measured:
+        return None
     return IntrinsicSummary(
         num_zoom_entries=len(per_zoom),
-        worst_rmse_px=max(errors),
-        mean_rmse_px=sum(errors) / len(errors),
+        worst_rmse_px=max(measured),
+        mean_rmse_px=sum(measured) / len(measured),
         per_zoom=per_zoom,
     )
 
@@ -306,7 +323,7 @@ def build_camera_confidence(
     if not calibrated:
         notes: list[str] = []
         if intrinsic is None:
-            notes.append("no persisted intrinsic calibration")
+            notes.append("no persisted intrinsic calibration metric")
         if extrinsic is None:
             notes.append("no persisted extrinsic validation records")
         return CameraConfidenceReport(

--- a/poc_homography/calibration/confidence.py
+++ b/poc_homography/calibration/confidence.py
@@ -1,0 +1,367 @@
+"""Per-camera calibration-confidence aggregation (#366).
+
+This module is the canonical, freshly-authored aggregation that JOINS a camera's
+already-persisted intrinsic calibration (its
+:class:`~poc_homography.domain.entities.lens_calibration_table.LensCalibrationTable`)
+with its already-persisted extrinsic registration records (its
+:class:`~poc_homography.domain.entities.ptz_registration.PtzRegistration` list)
+into ONE per-camera confidence record carrying a derived Good/Fair/Poor label
+and a [0, 1] score.
+
+It is **read-only**: it recomputes NO calibration, re-solves NO homography, and
+reads NO camera, MinIO, or database directly. It consumes whatever the
+repositories already returned and summarizes it. Cameras missing either half of
+the calibration are reported as ``"Uncalibrated"`` with a zero score.
+
+The Good/Fair/Poor vocabulary is reused verbatim from
+:mod:`poc_homography.validation.gcp_distribution`; ``"Uncalibrated"`` is used for
+cameras with no persisted calibration to summarize.
+
+Scoring
+-------
+Three independent quality axes are derived from the persisted summaries:
+
+  * Intrinsic axis, from the worst per-zoom intrinsic error in pixels. The
+    per-zoom error of an entry is ``max(validation_rmse, reprojection_error_px)``.
+  * Extrinsic axis, from the worst hold-out reprojection RMS in ground meters.
+  * Inlier axis, from the minimum RANSAC/ICP inlier ratio across registrations.
+
+The overall ``label`` is the WORST band across the three axes (order
+Poor < Fair < Good). The overall ``score`` in [0, 1] is the mean of three
+clamped sub-scores:
+
+    intr_sub   = clamp01(1 - worst_rmse_px / FAIR_INTRINSIC_PX)
+    extr_sub   = clamp01(1 - worst_rms_m / FAIR_EXTRINSIC_M)
+    inlier_sub = clamp01(min_inlier_ratio)
+
+Thresholds (freshly authored)
+-----------------------------
+    Intrinsic px  : worst_rmse_px <= GOOD_INTRINSIC_PX (2.0)  -> Good
+                    worst_rmse_px <= FAIR_INTRINSIC_PX (5.0)  -> Fair
+                    otherwise                                 -> Poor
+    Extrinsic m   : worst_rms_m   <= GOOD_EXTRINSIC_M (0.25)  -> Good
+                    worst_rms_m   <= FAIR_EXTRINSIC_M (1.0)   -> Fair
+                    otherwise                                 -> Poor
+    Inlier ratio  : min_inlier_ratio >= GOOD_INLIER_RATIO (0.8) -> Good
+                    min_inlier_ratio >= FAIR_INLIER_RATIO (0.5) -> Fair
+                    otherwise                                    -> Poor
+
+The intrinsic Fair band is anchored on the project-wide
+:data:`~poc_homography.calibration.TARGET_ERROR_THRESHOLD_PX` (5.0 px).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from poc_homography.calibration import TARGET_ERROR_THRESHOLD_PX
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+    from poc_homography.domain.entities.ptz_registration import PtzRegistration
+
+# --- Quality labels (reused verbatim from gcp_distribution) -------------------
+
+#: Best intrinsic+extrinsic confidence band.
+GOOD = "Good"
+#: Acceptable but not best confidence band.
+FAIR = "Fair"
+#: Below-acceptable confidence band.
+POOR = "Poor"
+#: Label for a camera missing persisted intrinsic and/or extrinsic calibration.
+UNCALIBRATED = "Uncalibrated"
+
+#: Ordered worst-to-best so the overall label can pick the worst axis.
+_LABEL_RANK: dict[str, int] = {POOR: 0, FAIR: 1, GOOD: 2}
+
+# --- Intrinsic thresholds (pixels) --------------------------------------------
+
+#: worst per-zoom intrinsic error at/below this (px) -> Good intrinsic axis.
+GOOD_INTRINSIC_PX = 2.0
+#: worst per-zoom intrinsic error at/below this (px) -> Fair; anchored on the
+#: project-wide target reprojection-error threshold (5.0 px).
+FAIR_INTRINSIC_PX = TARGET_ERROR_THRESHOLD_PX
+
+# --- Extrinsic thresholds (ground meters) -------------------------------------
+
+#: worst hold-out reprojection RMS at/below this (m) -> Good extrinsic axis.
+GOOD_EXTRINSIC_M = 0.25
+#: worst hold-out reprojection RMS at/below this (m) -> Fair extrinsic axis.
+FAIR_EXTRINSIC_M = 1.0
+
+# --- Inlier-ratio thresholds (unitless) ---------------------------------------
+
+#: minimum inlier ratio at/above this -> Good inlier axis.
+GOOD_INLIER_RATIO = 0.8
+#: minimum inlier ratio at/above this -> Fair inlier axis.
+FAIR_INLIER_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class ZoomIntrinsicPoint:
+    """One persisted per-zoom intrinsic-calibration data point.
+
+    Attributes:
+        zoom_factor: Zoom level the entry was calibrated at.
+        validation_rmse: Persisted intrinsic validation RMSE in pixels.
+        reprojection_error_px: Persisted reprojection error in pixels.
+    """
+
+    zoom_factor: float
+    validation_rmse: float
+    reprojection_error_px: float
+
+
+@dataclass(frozen=True)
+class IntrinsicSummary:
+    """Aggregated view of a camera's persisted intrinsic calibration.
+
+    Attributes:
+        num_zoom_entries: Number of per-zoom calibration entries.
+        worst_rmse_px: Worst per-entry intrinsic error in pixels.
+        mean_rmse_px: Mean per-entry intrinsic error in pixels.
+        per_zoom: The per-zoom data points the summary was computed over.
+    """
+
+    num_zoom_entries: int
+    worst_rmse_px: float
+    mean_rmse_px: float
+    per_zoom: tuple[ZoomIntrinsicPoint, ...]
+
+
+@dataclass(frozen=True)
+class ExtrinsicSummary:
+    """Aggregated view of a camera's persisted extrinsic registrations.
+
+    Computed over the *validated* registrations only (those carrying
+    meters-unit reprojection stats).
+
+    Attributes:
+        num_registrations: Total persisted registrations for the camera.
+        num_validated: Registrations carrying hold-out reprojection stats.
+        worst_rms_m: Worst hold-out reprojection RMS in meters.
+        worst_p90_m: Worst hold-out 90th-percentile error in meters.
+        worst_max_m: Worst hold-out maximum error in meters.
+        mean_rms_m: Mean hold-out reprojection RMS in meters.
+        min_inlier_ratio: Minimum RANSAC/ICP inlier ratio across validated regs.
+    """
+
+    num_registrations: int
+    num_validated: int
+    worst_rms_m: float
+    worst_p90_m: float
+    worst_max_m: float
+    mean_rms_m: float
+    min_inlier_ratio: float
+
+
+@dataclass(frozen=True)
+class CameraConfidenceReport:
+    """A per-camera calibration-confidence record (intrinsic ⋈ extrinsic).
+
+    Attributes:
+        camera_id: Camera identifier (the intrinsic/extrinsic join key).
+        camera_name: Human-readable camera name.
+        calibrated: True iff BOTH an intrinsic summary and an extrinsic summary
+            are present.
+        label: Overall confidence label (Good/Fair/Poor, or Uncalibrated).
+        score: Overall confidence score in [0, 1] (0.0 when uncalibrated).
+        intrinsic: Intrinsic summary, or None when no persisted intrinsics.
+        extrinsic: Extrinsic summary, or None when no validated registrations.
+        notes: Human-readable notes (e.g. what is missing).
+    """
+
+    camera_id: str
+    camera_name: str
+    calibrated: bool
+    label: str
+    score: float
+    intrinsic: IntrinsicSummary | None
+    extrinsic: ExtrinsicSummary | None
+    notes: tuple[str, ...]
+
+
+def _clamp01(value: float) -> float:
+    """Clamp a float to the [0, 1] range."""
+    return max(0.0, min(1.0, value))
+
+
+def _worst_label(labels: Sequence[str]) -> str:
+    """Return the worst label across an axis set (order Poor < Fair < Good)."""
+    return min(labels, key=lambda label: _LABEL_RANK[label])
+
+
+def _entry_error_px(validation_rmse: float, reprojection_error_px: float) -> float:
+    """Per-zoom intrinsic error of an entry = ``max`` of its two error fields."""
+    return max(float(validation_rmse), float(reprojection_error_px))
+
+
+def _intrinsic_label(worst_rmse_px: float) -> str:
+    """Map a worst intrinsic error (px) to a Good/Fair/Poor band."""
+    if worst_rmse_px <= GOOD_INTRINSIC_PX:
+        return GOOD
+    if worst_rmse_px <= FAIR_INTRINSIC_PX:
+        return FAIR
+    return POOR
+
+
+def _extrinsic_label(worst_rms_m: float) -> str:
+    """Map a worst extrinsic RMS (m) to a Good/Fair/Poor band."""
+    if worst_rms_m <= GOOD_EXTRINSIC_M:
+        return GOOD
+    if worst_rms_m <= FAIR_EXTRINSIC_M:
+        return FAIR
+    return POOR
+
+
+def _inlier_label(min_inlier_ratio: float) -> str:
+    """Map a minimum inlier ratio to a Good/Fair/Poor band."""
+    if min_inlier_ratio >= GOOD_INLIER_RATIO:
+        return GOOD
+    if min_inlier_ratio >= FAIR_INLIER_RATIO:
+        return FAIR
+    return POOR
+
+
+def _build_intrinsic_summary(lens_table: LensCalibrationTable) -> IntrinsicSummary:
+    """Aggregate a non-empty lens table into an :class:`IntrinsicSummary`."""
+    per_zoom = tuple(
+        ZoomIntrinsicPoint(
+            zoom_factor=float(entry.zoom_factor),
+            validation_rmse=float(entry.validation_rmse),
+            reprojection_error_px=float(entry.reprojection_error_px),
+        )
+        for entry in lens_table.entries
+    )
+    errors = [
+        _entry_error_px(point.validation_rmse, point.reprojection_error_px) for point in per_zoom
+    ]
+    return IntrinsicSummary(
+        num_zoom_entries=len(per_zoom),
+        worst_rmse_px=max(errors),
+        mean_rmse_px=sum(errors) / len(errors),
+        per_zoom=per_zoom,
+    )
+
+
+def _build_extrinsic_summary(
+    registrations: Sequence[PtzRegistration],
+    validated: Sequence[PtzRegistration],
+) -> ExtrinsicSummary:
+    """Aggregate validated registrations into an :class:`ExtrinsicSummary`."""
+    # Validated regs are guaranteed to carry reprojection_stats by the caller.
+    rms = [float(reg.reprojection_stats.rms_m) for reg in validated]  # type: ignore[union-attr]
+    p90 = [float(reg.reprojection_stats.p90_m) for reg in validated]  # type: ignore[union-attr]
+    max_m = [float(reg.reprojection_stats.max_m) for reg in validated]  # type: ignore[union-attr]
+    inliers = [float(reg.registration.inlier_ratio) for reg in validated]
+    return ExtrinsicSummary(
+        num_registrations=len(registrations),
+        num_validated=len(validated),
+        worst_rms_m=max(rms),
+        worst_p90_m=max(p90),
+        worst_max_m=max(max_m),
+        mean_rms_m=sum(rms) / len(rms),
+        min_inlier_ratio=min(inliers),
+    )
+
+
+def build_camera_confidence(
+    *,
+    camera_id: str,
+    camera_name: str,
+    lens_table: LensCalibrationTable | None,
+    registrations: Sequence[PtzRegistration],
+) -> CameraConfidenceReport:
+    """Join persisted intrinsics with persisted extrinsic stats for one camera.
+
+    This is a pure read-only aggregation: it summarizes whatever the
+    repositories already returned and recomputes no calibration. A camera is
+    ``calibrated`` only when it has BOTH a non-empty intrinsic calibration and at
+    least one validated extrinsic registration; otherwise it is reported as
+    ``"Uncalibrated"`` with a zero score (the partial summary, if any, is still
+    attached and the missing half is named in ``notes``).
+
+    Args:
+        camera_id: Camera identifier (the join key).
+        camera_name: Human-readable camera name.
+        lens_table: The camera's persisted lens calibration table, or None.
+        registrations: The camera's persisted extrinsic registration records.
+
+    Returns:
+        A populated :class:`CameraConfidenceReport`.
+    """
+    intrinsic = (
+        _build_intrinsic_summary(lens_table)
+        if lens_table is not None and lens_table.entries
+        else None
+    )
+
+    validated = [reg for reg in registrations if reg.reprojection_stats is not None]
+    extrinsic = _build_extrinsic_summary(registrations, validated) if len(validated) >= 1 else None
+
+    calibrated = intrinsic is not None and extrinsic is not None
+    if not calibrated:
+        notes: list[str] = []
+        if intrinsic is None:
+            notes.append("no persisted intrinsic calibration")
+        if extrinsic is None:
+            notes.append("no persisted extrinsic validation records")
+        return CameraConfidenceReport(
+            camera_id=camera_id,
+            camera_name=camera_name,
+            calibrated=False,
+            label=UNCALIBRATED,
+            score=0.0,
+            intrinsic=intrinsic,
+            extrinsic=extrinsic,
+            notes=tuple(notes),
+        )
+
+    # Both summaries present (narrows the Optionals for type-checkers).
+    assert intrinsic is not None
+    assert extrinsic is not None
+
+    axis_labels = (
+        _intrinsic_label(intrinsic.worst_rmse_px),
+        _extrinsic_label(extrinsic.worst_rms_m),
+        _inlier_label(extrinsic.min_inlier_ratio),
+    )
+    label = _worst_label(axis_labels)
+
+    intr_sub = _clamp01(1.0 - intrinsic.worst_rmse_px / FAIR_INTRINSIC_PX)
+    extr_sub = _clamp01(1.0 - extrinsic.worst_rms_m / FAIR_EXTRINSIC_M)
+    inlier_sub = _clamp01(extrinsic.min_inlier_ratio)
+    score = (intr_sub + extr_sub + inlier_sub) / 3.0
+
+    return CameraConfidenceReport(
+        camera_id=camera_id,
+        camera_name=camera_name,
+        calibrated=True,
+        label=label,
+        score=score,
+        intrinsic=intrinsic,
+        extrinsic=extrinsic,
+        notes=(),
+    )
+
+
+__all__ = [
+    "FAIR",
+    "FAIR_EXTRINSIC_M",
+    "FAIR_INLIER_RATIO",
+    "FAIR_INTRINSIC_PX",
+    "GOOD",
+    "GOOD_EXTRINSIC_M",
+    "GOOD_INLIER_RATIO",
+    "GOOD_INTRINSIC_PX",
+    "POOR",
+    "UNCALIBRATED",
+    "CameraConfidenceReport",
+    "ExtrinsicSummary",
+    "IntrinsicSummary",
+    "ZoomIntrinsicPoint",
+    "build_camera_confidence",
+]

--- a/poc_homography/cli/confidence_report.py
+++ b/poc_homography/cli/confidence_report.py
@@ -1,0 +1,285 @@
+"""Per-camera calibration-confidence report CLI command (#366).
+
+A thin, read-only CLI over the pure aggregation in
+:mod:`poc_homography.calibration.confidence`. For one camera (``--camera``) or
+every camera of a tenant (``--tenant``), it reads the already-persisted intrinsic
+lens table and extrinsic registration records, JOINS them into one per-camera
+:class:`~poc_homography.calibration.confidence.CameraConfidenceReport`, and emits
+a human-readable or JSON report. It recomputes NO calibration.
+
+The data-access seam (:func:`_run_confidence_report`) references both
+repositories and the session factory as module-level names so tests can swap them
+for offline doubles and exercise the intrinsic⋈extrinsic join with NO live Neon
+access. The pure join itself lives in :func:`_collect_reports`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import typer
+
+from poc_homography.calibration.confidence import build_camera_confidence
+from poc_homography.camera_config import (
+    get_camera_by_name,
+    get_camera_configs,
+    get_cameras_for_tenant,
+)
+from poc_homography.cli.main import calibrate_app
+from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_lens_calibration_table import (
+    RepoPostgresLensCalibrationTable,
+)
+from poc_homography.infrastructure.repositories.repo_postgres_ptz_registration import (
+    RepoPostgresPtzRegistration,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from contextlib import AbstractContextManager
+
+    from sqlalchemy.orm import Session
+
+    from poc_homography.calibration.confidence import CameraConfidenceReport
+
+
+class OutputFormat(str, Enum):
+    """Output format options."""
+
+    HUMAN = "human"
+    JSON = "json"
+
+
+def _collect_reports(
+    camera_specs: Sequence[tuple[str, str]],
+    *,
+    lens_repo: RepoPostgresLensCalibrationTable,
+    ptz_repo: RepoPostgresPtzRegistration,
+) -> list[CameraConfidenceReport]:
+    """Build one confidence report per ``(camera_id, camera_name)`` spec.
+
+    This is the read-only join: for each camera it reads the persisted lens
+    table and registration records and delegates to
+    :func:`build_camera_confidence`. It is the primary offline test target.
+
+    Args:
+        camera_specs: ``(camera_id, camera_name)`` pairs to report on.
+        lens_repo: Intrinsic lens-table repository (its ``id`` is the camera id).
+        ptz_repo: Extrinsic PTZ-registration repository.
+
+    Returns:
+        One :class:`CameraConfidenceReport` per spec, in input order.
+    """
+    reports: list[CameraConfidenceReport] = []
+    for camera_id, camera_name in camera_specs:
+        lens_table = lens_repo.get(camera_id)
+        registrations = ptz_repo.get_by_camera(camera_id)
+        reports.append(
+            build_camera_confidence(
+                camera_id=camera_id,
+                camera_name=camera_name,
+                lens_table=lens_table,
+                registrations=registrations,
+            )
+        )
+    return reports
+
+
+def _run_confidence_report(
+    *,
+    camera_specs: Sequence[tuple[str, str]],
+    session_factory: Callable[[], AbstractContextManager[Session]],
+) -> list[CameraConfidenceReport]:
+    """Open a session, construct both repositories, and collect the reports.
+
+    Extracted from the command body so tests can inject a fake session factory
+    and monkeypatch the module-level repository classes for fully-offline runs.
+
+    Args:
+        camera_specs: ``(camera_id, camera_name)`` pairs to report on.
+        session_factory: Database session context-manager factory.
+
+    Returns:
+        One :class:`CameraConfidenceReport` per spec.
+    """
+    with session_factory() as session:
+        lens_repo = RepoPostgresLensCalibrationTable(session)
+        ptz_repo = RepoPostgresPtzRegistration(session)
+        return _collect_reports(camera_specs, lens_repo=lens_repo, ptz_repo=ptz_repo)
+
+
+def _report_to_dict(report: CameraConfidenceReport) -> dict:
+    """Serialize a :class:`CameraConfidenceReport` to a JSON-friendly dict."""
+    intrinsic = (
+        {
+            "num_zoom_entries": report.intrinsic.num_zoom_entries,
+            "worst_rmse_px": report.intrinsic.worst_rmse_px,
+            "mean_rmse_px": report.intrinsic.mean_rmse_px,
+            "per_zoom": [
+                {
+                    "zoom_factor": point.zoom_factor,
+                    "validation_rmse": point.validation_rmse,
+                    "reprojection_error_px": point.reprojection_error_px,
+                }
+                for point in report.intrinsic.per_zoom
+            ],
+        }
+        if report.intrinsic is not None
+        else None
+    )
+    extrinsic = (
+        {
+            "num_registrations": report.extrinsic.num_registrations,
+            "num_validated": report.extrinsic.num_validated,
+            "worst_rms_m": report.extrinsic.worst_rms_m,
+            "worst_p90_m": report.extrinsic.worst_p90_m,
+            "worst_max_m": report.extrinsic.worst_max_m,
+            "mean_rms_m": report.extrinsic.mean_rms_m,
+            "min_inlier_ratio": report.extrinsic.min_inlier_ratio,
+        }
+        if report.extrinsic is not None
+        else None
+    )
+    return {
+        "camera_id": report.camera_id,
+        "camera_name": report.camera_name,
+        "calibrated": report.calibrated,
+        "label": report.label,
+        "score": report.score,
+        "intrinsic": intrinsic,
+        "extrinsic": extrinsic,
+        "notes": list(report.notes),
+    }
+
+
+def _format_json(reports: Sequence[CameraConfidenceReport], *, tenant: str | None) -> str:
+    """Render the reports as JSON (single dict for ``--camera``, else tenant block)."""
+    if tenant is None:
+        return json.dumps(_report_to_dict(reports[0]), indent=2)
+    return json.dumps(
+        {"tenant": tenant, "cameras": [_report_to_dict(r) for r in reports]},
+        indent=2,
+    )
+
+
+def _format_one_human(report: CameraConfidenceReport) -> list[str]:
+    """Render a single camera's confidence block as a list of text lines."""
+    status = "CALIBRATED" if report.calibrated else "UNCALIBRATED"
+    lines = [
+        "=" * 60,
+        f"{report.camera_name} ({report.camera_id})",
+        "=" * 60,
+        f"Status:     {status}",
+        f"Confidence: {report.label}  (score {report.score:.2f})",
+        "",
+    ]
+
+    lines.append("Intrinsic calibration:")
+    if report.intrinsic is not None:
+        intr = report.intrinsic
+        lines += [
+            f"  Zoom entries:  {intr.num_zoom_entries}",
+            f"  Worst RMSE:    {intr.worst_rmse_px:.2f} px",
+            f"  Mean RMSE:     {intr.mean_rmse_px:.2f} px",
+            "  Per-zoom error (max of validation_rmse, reprojection_error_px):",
+        ]
+        for point in intr.per_zoom:
+            error = max(point.validation_rmse, point.reprojection_error_px)
+            lines.append(f"    zoom {point.zoom_factor:.1f}x: {error:.2f} px")
+    else:
+        lines.append("  (none persisted)")
+    lines.append("")
+
+    lines.append("Extrinsic registration:")
+    if report.extrinsic is not None:
+        extr = report.extrinsic
+        lines += [
+            f"  Registrations: {extr.num_registrations} ({extr.num_validated} validated)",
+            f"  Worst RMS:     {extr.worst_rms_m:.3f} m",
+            f"  Worst p90:     {extr.worst_p90_m:.3f} m",
+            f"  Worst max:     {extr.worst_max_m:.3f} m",
+            f"  Mean RMS:      {extr.mean_rms_m:.3f} m",
+            f"  Min inliers:   {extr.min_inlier_ratio:.2f}",
+        ]
+    else:
+        lines.append("  (none persisted)")
+    lines.append("")
+
+    lines.append("Notes:")
+    if report.notes:
+        lines.extend(f"  - {note}" for note in report.notes)
+    else:
+        lines.append("  (none)")
+    lines.append("=" * 60)
+    return lines
+
+
+def _format_human(reports: Sequence[CameraConfidenceReport]) -> str:
+    """Render the reports as a human-readable block per camera."""
+    blocks: list[str] = []
+    for report in reports:
+        blocks.append("\n".join(_format_one_human(report)))
+    return "\n\n".join(blocks)
+
+
+@calibrate_app.command("confidence-report")
+def confidence_report_command(
+    camera: str | None = typer.Option(
+        None, "--camera", help="Camera name or id (mutually exclusive with --tenant)"
+    ),
+    tenant: str | None = typer.Option(
+        None, "--tenant", help="Tenant id; reports every camera (e.g., 'icozee')"
+    ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.HUMAN,
+        "--format",
+        "-f",
+        help="Output format",
+    ),
+) -> None:
+    """Report per-camera calibration confidence from persisted records only.
+
+    Joins each camera's persisted intrinsic lens table with its persisted
+    extrinsic registration records into one Good/Fair/Poor confidence record;
+    cameras missing either half are reported as ``Uncalibrated``. Recomputes no
+    calibration. Provide EXACTLY ONE of ``--camera`` / ``--tenant``.
+    """
+    if bool(camera) == bool(tenant):
+        typer.echo("Error: provide exactly one of --camera or --tenant.", err=True)
+        raise typer.Exit(1)
+
+    if not os.environ.get("DATABASE_URL"):
+        typer.echo("Error: DATABASE_URL environment variable is not set.", err=True)
+        raise typer.Exit(1)
+
+    if camera:
+        cam_info = get_camera_by_name(camera)
+        if not cam_info:
+            available = [c["name"] for c in get_camera_configs()]
+            typer.echo(
+                f"Error: Camera '{camera}' not found. Available cameras: {', '.join(available)}",
+                err=True,
+            )
+            raise typer.Exit(1)
+        camera_specs = [(cam_info["id"], cam_info.get("name") or cam_info["id"])]
+        tenant_id = None
+    else:
+        cams = get_cameras_for_tenant(tenant or "")
+        if not cams:
+            typer.echo(f"Error: No cameras found for tenant '{tenant}'.", err=True)
+            raise typer.Exit(1)
+        camera_specs = [(c["id"], c.get("name") or c["id"]) for c in cams]
+        tenant_id = tenant
+
+    reports = _run_confidence_report(camera_specs=camera_specs, session_factory=get_session)
+
+    if output_format == OutputFormat.JSON:
+        typer.echo(_format_json(reports, tenant=tenant_id))
+    else:
+        typer.echo(_format_human(reports))
+
+
+__all__ = ["confidence_report_command"]

--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -34,6 +34,7 @@ def _register_commands() -> None:
         calibrate_capture,
         camera,
         cleanplate,
+        confidence_report,
         gcp,
         interactive,
         line_picker,
@@ -53,6 +54,7 @@ def _register_commands() -> None:
     _ = calibrate_capture
     _ = camera
     _ = cleanplate
+    _ = confidence_report
     _ = gcp
     _ = interactive
     _ = line_picker

--- a/tests/calibration/test_confidence.py
+++ b/tests/calibration/test_confidence.py
@@ -141,6 +141,39 @@ def test_uncalibrated_when_no_validated_registrations() -> None:
     assert any("extrinsic" in note for note in report.notes)
 
 
+def test_uncalibrated_when_intrinsic_metrics_are_all_zero() -> None:
+    """All-zero (unrecorded) intrinsic errors are unmeasured, not perfect."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(validation_rmse=0.0, reprojection_error_px=0.0)),
+        registrations=[_registration(inlier_ratio=0.95, rms_m=0.1)],
+    )
+    assert report.calibrated is False
+    assert report.label == "Uncalibrated"
+    assert report.score == 0.0
+    assert report.intrinsic is None  # zero error is treated as unmeasured
+    assert report.extrinsic is not None  # partial summary still attached
+    assert any("intrinsic" in note for note in report.notes)
+
+
+def test_intrinsic_summary_ignores_zero_metric_entries() -> None:
+    """Worst/mean intrinsic error skip zero-error (unrecorded) entries."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(
+            _entry(zoom=1.0, validation_rmse=0.0),  # unrecorded -> excluded
+            _entry(zoom=2.0, validation_rmse=3.0),  # measured
+        ),
+        registrations=[_registration(inlier_ratio=0.95, rms_m=0.1)],
+    )
+    assert report.intrinsic is not None
+    assert report.intrinsic.num_zoom_entries == 2  # both kept for display
+    assert report.intrinsic.worst_rmse_px == 3.0
+    assert report.intrinsic.mean_rmse_px == 3.0
+
+
 def test_uncalibrated_when_no_records_at_all() -> None:
     report = build_camera_confidence(
         camera_id="cam1",

--- a/tests/calibration/test_confidence.py
+++ b/tests/calibration/test_confidence.py
@@ -1,0 +1,192 @@
+"""Unit tests for the per-camera calibration-confidence aggregation (#366).
+
+These tests exercise the pure join + threshold logic of
+:mod:`poc_homography.calibration.confidence` with hand-built persisted-record
+fixtures. No DB, no CLI, no recomputation: only aggregation and labeling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from poc_homography.calibration.confidence import build_camera_confidence
+from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+
+
+def _entry(
+    zoom: float = 1.0,
+    *,
+    validation_rmse: float = 0.0,
+    reprojection_error_px: float = 0.0,
+) -> ZoomCalibrationEntry:
+    return ZoomCalibrationEntry(
+        zoom_factor=zoom,
+        distortion=LensDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0),
+        calibration_date="2024-01-01T00:00:00",
+        source_images=(),
+        validation_rmse=validation_rmse,
+        reprojection_error_px=reprojection_error_px,
+    )
+
+
+def _lens_table(*entries: ZoomCalibrationEntry, camera_id: str = "cam1") -> LensCalibrationTable:
+    return LensCalibrationTable(
+        id=camera_id,
+        entries=entries,
+        created_date="2024-01-01T00:00:00",
+        last_modified="2024-01-01T00:00:00",
+    )
+
+
+def _registration(
+    *,
+    inlier_ratio: float = 1.0,
+    rms_m: float | None = 0.1,
+    camera_id: str = "cam1",
+    zoom: float = 1.0,
+) -> PtzRegistration:
+    result = PtzRegistrationResult(
+        homography_matrix=np.eye(3, dtype=np.float64),
+        inverse_matrix=np.eye(3, dtype=np.float64),
+        num_lines=4,
+        num_inliers=4,
+        inlier_ratio=inlier_ratio,
+        mean_perp_error=0.0,
+        max_perp_error=0.0,
+        rmse=0.0,
+        run_id="run1",
+        camera_id=camera_id,
+        commanded_zoom=zoom,
+        commanded_tilt=-15.0,
+    )
+    stats = (
+        ReprojectionStats(rms_m=rms_m, p90_m=rms_m, max_m=rms_m, n_points=4)
+        if rms_m is not None
+        else None
+    )
+    return PtzRegistration.from_result(result, reprojection_stats=stats)
+
+
+def test_good_case() -> None:
+    """Low px error, low meters error, high inlier ratio -> Good, high score."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(validation_rmse=1.0, reprojection_error_px=1.5)),
+        registrations=[_registration(inlier_ratio=0.95, rms_m=0.1)],
+    )
+    assert report.calibrated is True
+    assert report.label == "Good"
+    assert 0.0 <= report.score <= 1.0
+    assert report.score > 0.7
+
+
+def test_fair_boundary() -> None:
+    """Worst intrinsic at the Fair threshold downgrades the overall label."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(reprojection_error_px=5.0)),  # == FAIR_INTRINSIC_PX
+        registrations=[_registration(inlier_ratio=0.95, rms_m=0.1)],
+    )
+    assert report.calibrated is True
+    assert report.label == "Fair"
+    assert 0.0 <= report.score <= 1.0
+
+
+def test_poor_case_worst_axis_dominates() -> None:
+    """A single Poor axis (low inlier ratio) drives the overall label to Poor."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(validation_rmse=1.0)),  # Good intrinsic
+        registrations=[_registration(inlier_ratio=0.2, rms_m=0.1)],  # Poor inlier
+    )
+    assert report.label == "Poor"
+    assert 0.0 <= report.score <= 1.0
+
+
+def test_uncalibrated_when_no_lens_table() -> None:
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=None,
+        registrations=[_registration()],
+    )
+    assert report.calibrated is False
+    assert report.label == "Uncalibrated"
+    assert report.score == 0.0
+    assert report.intrinsic is None
+    assert report.extrinsic is not None  # partial summary still attached
+    assert any("intrinsic" in note for note in report.notes)
+
+
+def test_uncalibrated_when_no_validated_registrations() -> None:
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(validation_rmse=1.0)),
+        registrations=[_registration(rms_m=None)],  # no reprojection stats
+    )
+    assert report.calibrated is False
+    assert report.label == "Uncalibrated"
+    assert report.score == 0.0
+    assert report.intrinsic is not None  # partial summary still attached
+    assert report.extrinsic is None
+    assert any("extrinsic" in note for note in report.notes)
+
+
+def test_uncalibrated_when_no_records_at_all() -> None:
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=None,
+        registrations=[],
+    )
+    assert report.label == "Uncalibrated"
+    assert report.score == 0.0
+    assert report.intrinsic is None
+    assert report.extrinsic is None
+    assert len(report.notes) == 2
+
+
+def test_aggregation_picks_worst_and_mean_across_entries() -> None:
+    """Intrinsic summary uses max(error) for worst and the mean across entries."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(
+            _entry(zoom=1.0, validation_rmse=1.0, reprojection_error_px=0.5),  # error 1.0
+            _entry(zoom=2.0, validation_rmse=2.0, reprojection_error_px=4.0),  # error 4.0
+        ),
+        registrations=[_registration(inlier_ratio=0.9, rms_m=0.1)],
+    )
+    assert report.intrinsic is not None
+    assert report.intrinsic.num_zoom_entries == 2
+    assert report.intrinsic.worst_rmse_px == 4.0
+    assert report.intrinsic.mean_rmse_px == (1.0 + 4.0) / 2.0
+
+
+def test_aggregation_picks_worst_and_min_across_registrations() -> None:
+    """Extrinsic summary takes worst meters fields and the minimum inlier ratio."""
+    report = build_camera_confidence(
+        camera_id="cam1",
+        camera_name="Cam 1",
+        lens_table=_lens_table(_entry(validation_rmse=1.0)),
+        registrations=[
+            _registration(inlier_ratio=0.9, rms_m=0.2),
+            _registration(inlier_ratio=0.6, rms_m=0.8, zoom=2.0),
+            _registration(rms_m=None, zoom=3.0),  # unvalidated -> counted but excluded from stats
+        ],
+    )
+    assert report.extrinsic is not None
+    assert report.extrinsic.num_registrations == 3
+    assert report.extrinsic.num_validated == 2
+    assert report.extrinsic.worst_rms_m == 0.8
+    assert report.extrinsic.mean_rms_m == (0.2 + 0.8) / 2.0
+    assert report.extrinsic.min_inlier_ratio == 0.6

--- a/tests/cli/test_confidence_report.py
+++ b/tests/cli/test_confidence_report.py
@@ -1,0 +1,243 @@
+"""Offline tests for the per-camera calibration-confidence report CLI (#366).
+
+These tests exercise the read-only intrinsic⋈extrinsic join (``_collect_reports``)
+and the Typer command (human + JSON, single-camera + tenant) with fake repos and
+a fake session factory -- NO live Neon access and no recomputation.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest  # noqa: TC002  (used only in test-param annotations under future-annotations)
+from typer.testing import CliRunner
+
+from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+from poc_homography.cli import confidence_report as cmd
+from poc_homography.cli.main import app
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _lens_table(camera_id: str) -> LensCalibrationTable:
+    entry = ZoomCalibrationEntry(
+        zoom_factor=1.0,
+        distortion=LensDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0),
+        calibration_date="2024-01-01T00:00:00",
+        source_images=(),
+        validation_rmse=1.0,
+        reprojection_error_px=1.0,
+    )
+    return LensCalibrationTable(
+        id=camera_id,
+        entries=(entry,),
+        created_date="2024-01-01T00:00:00",
+        last_modified="2024-01-01T00:00:00",
+    )
+
+
+def _registration(camera_id: str) -> PtzRegistration:
+    result = PtzRegistrationResult(
+        homography_matrix=np.eye(3, dtype=np.float64),
+        inverse_matrix=np.eye(3, dtype=np.float64),
+        num_lines=4,
+        num_inliers=4,
+        inlier_ratio=0.95,
+        mean_perp_error=0.0,
+        max_perp_error=0.0,
+        rmse=0.0,
+        run_id="run1",
+        camera_id=camera_id,
+        commanded_zoom=1.0,
+        commanded_tilt=-15.0,
+    )
+    stats = ReprojectionStats(rms_m=0.1, p90_m=0.1, max_m=0.1, n_points=4)
+    return PtzRegistration.from_result(result, reprojection_stats=stats)
+
+
+class _FakeLensRepo:
+    """RepoPostgresLensCalibrationTable double keyed by camera id."""
+
+    def __init__(self, tables: dict[str, LensCalibrationTable]) -> None:
+        self._tables = tables
+
+    def get(self, camera_id: str) -> LensCalibrationTable | None:
+        return self._tables.get(camera_id)
+
+
+class _FakePtzRepo:
+    """RepoPostgresPtzRegistration double keyed by camera id."""
+
+    def __init__(self, regs: dict[str, list[PtzRegistration]]) -> None:
+        self._regs = regs
+
+    def get_by_camera(self, camera_id: str) -> list[PtzRegistration]:
+        return self._regs.get(camera_id, [])
+
+
+class _FakeSession:
+    """Minimal session object handed to the repository doubles."""
+
+
+@contextmanager
+def _fake_session_factory() -> Iterator[_FakeSession]:
+    yield _FakeSession()
+
+
+# ---------------------------------------------------------------------------
+# _collect_reports: the read-only join
+# ---------------------------------------------------------------------------
+
+
+def test_collect_reports_joins_intrinsic_and_extrinsic() -> None:
+    lens_repo = _FakeLensRepo({"cam1": _lens_table("cam1")})
+    ptz_repo = _FakePtzRepo({"cam1": [_registration("cam1")]})
+
+    reports = cmd._collect_reports([("cam1", "Cam 1")], lens_repo=lens_repo, ptz_repo=ptz_repo)
+
+    assert len(reports) == 1
+    assert reports[0].camera_id == "cam1"
+    assert reports[0].calibrated is True
+    assert reports[0].label == "Good"
+
+
+def test_collect_reports_marks_uncalibrated_when_missing_half() -> None:
+    lens_repo = _FakeLensRepo({})  # no intrinsics
+    ptz_repo = _FakePtzRepo({"cam1": [_registration("cam1")]})
+
+    reports = cmd._collect_reports([("cam1", "Cam 1")], lens_repo=lens_repo, ptz_repo=ptz_repo)
+
+    assert reports[0].calibrated is False
+    assert reports[0].label == "Uncalibrated"
+
+
+# ---------------------------------------------------------------------------
+# CLI command: --camera human + json
+# ---------------------------------------------------------------------------
+
+
+def _patch_repos(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    tables: dict[str, LensCalibrationTable],
+    regs: dict[str, list[PtzRegistration]],
+) -> None:
+    """Wire the module-level repo classes + session factory to offline doubles."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    monkeypatch.setattr(cmd, "RepoPostgresLensCalibrationTable", lambda _s: _FakeLensRepo(tables))
+    monkeypatch.setattr(cmd, "RepoPostgresPtzRegistration", lambda _s: _FakePtzRepo(regs))
+    monkeypatch.setattr(cmd, "get_session", _fake_session_factory)
+
+
+def test_command_camera_human(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_repos(
+        monkeypatch,
+        tables={"cam1": _lens_table("cam1")},
+        regs={"cam1": [_registration("cam1")]},
+    )
+    monkeypatch.setattr(cmd, "get_camera_by_name", lambda _n: {"id": "cam1", "name": "Cam 1"})
+
+    result = CliRunner().invoke(app, ["calibrate", "confidence-report", "--camera", "cam1"])
+
+    assert result.exit_code == 0, result.output
+    assert "CALIBRATED" in result.output
+    assert "Good" in result.output
+    assert "cam1" in result.output
+
+
+def test_command_camera_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_repos(
+        monkeypatch,
+        tables={"cam1": _lens_table("cam1")},
+        regs={"cam1": [_registration("cam1")]},
+    )
+    monkeypatch.setattr(cmd, "get_camera_by_name", lambda _n: {"id": "cam1", "name": "Cam 1"})
+
+    result = CliRunner().invoke(
+        app, ["calibrate", "confidence-report", "--camera", "cam1", "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["camera_id"] == "cam1"
+    assert payload["calibrated"] is True
+    assert payload["label"] == "Good"
+    assert "tenant" not in payload  # single-camera JSON is a bare dict
+
+
+# ---------------------------------------------------------------------------
+# CLI command: --tenant reports all, marking uncalibrated ones
+# ---------------------------------------------------------------------------
+
+
+def test_command_tenant_marks_uncalibrated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_repos(
+        monkeypatch,
+        tables={"cam1": _lens_table("cam1")},  # cam2 has no intrinsics
+        regs={"cam1": [_registration("cam1")], "cam2": [_registration("cam2")]},
+    )
+    monkeypatch.setattr(
+        cmd,
+        "get_cameras_for_tenant",
+        lambda _t: [{"id": "cam1", "name": "Cam 1"}, {"id": "cam2", "name": "Cam 2"}],
+    )
+
+    result = CliRunner().invoke(
+        app, ["calibrate", "confidence-report", "--tenant", "icozee", "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["tenant"] == "icozee"
+    labels = {c["camera_id"]: c["label"] for c in payload["cameras"]}
+    assert labels["cam1"] == "Good"
+    assert labels["cam2"] == "Uncalibrated"
+
+
+def test_command_tenant_human_marks_uncalibrated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_repos(
+        monkeypatch,
+        tables={"cam1": _lens_table("cam1")},
+        regs={"cam1": [_registration("cam1")], "cam2": [_registration("cam2")]},
+    )
+    monkeypatch.setattr(
+        cmd,
+        "get_cameras_for_tenant",
+        lambda _t: [{"id": "cam1", "name": "Cam 1"}, {"id": "cam2", "name": "Cam 2"}],
+    )
+
+    result = CliRunner().invoke(app, ["calibrate", "confidence-report", "--tenant", "icozee"])
+
+    assert result.exit_code == 0, result.output
+    assert "UNCALIBRATED" in result.output
+    assert "CALIBRATED" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI command: argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_command_requires_exactly_one_target_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    result = CliRunner().invoke(app, ["calibrate", "confidence-report"])
+    assert result.exit_code != 0
+    assert "exactly one" in result.output
+
+
+def test_command_requires_exactly_one_target_both(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    result = CliRunner().invoke(
+        app, ["calibrate", "confidence-report", "--camera", "cam1", "--tenant", "icozee"]
+    )
+    assert result.exit_code != 0
+    assert "exactly one" in result.output


### PR DESCRIPTION
## Summary

Add a read-only per-camera calibration-confidence report joining persisted intrinsics (per-zoom validation_rmse/reprojection_error_px) with persisted extrinsic hold-out ReprojectionStats (rms_m/p90_m/max_m, inlier_ratio) into one per-camera record with a derived Good/Fair/Poor/Uncalibrated label+score. New 'hom calibrate confidence-report --camera <id> | --tenant <id>' command emits human + JSON; tenant mode iterates get_cameras_for_tenant marking uncalibrated cams. Recomputes nothing.

## Test plan

poe ci green (1384 passed, 158 skipped). New offline tests: tests/calibration/test_confidence.py (aggregation + label thresholds) and tests/cli/test_confidence_report.py (human+JSON, tenant marks uncalibrated, exactly-one-of guard).

## Closes DoD bullets

- Command emits per-camera confidence (intrinsic+extrinsic metrics + label) in human + JSON.
- Offline test with fake repos asserts aggregation + label thresholds.
- Tenant mode reports all available cams, marking uncalibrated ones.
- poe ci green.
