### PR TITLE
fix(survey): honor enabled_phases + resolve jitter RTSP + per-phase persistence [#372]

### DIFF
--- a/poc_homography/cli/calibrate_capture.py
+++ b/poc_homography/cli/calibrate_capture.py
@@ -57,14 +57,16 @@ def make_rtsp_url_resolver(camera_name: str) -> Callable[[], str | None]:
     """Build the Phase 8 jitter RTSP-URL resolver for ``camera_name`` (#372).
 
     Wraps :func:`camera_config.get_rtsp_url` (per-camera/tenant credential
-    resolution) and translates a missing-credentials :class:`ValueError` into
-    ``None`` so the runner skips jitter gracefully rather than crashing.
+    resolution). A config-shape problem — missing credentials (``ValueError``)
+    or a camera row lacking an expected field such as ``ip`` (``KeyError``) —
+    becomes ``None`` so the runner skips jitter gracefully rather than crashing,
+    honouring the resolver contract (return ``None``, do not raise).
     """
 
     def resolve() -> str | None:
         try:
             return get_rtsp_url(camera_name)
-        except ValueError:
+        except (ValueError, KeyError):
             return None
 
     return resolve

--- a/poc_homography/cli/calibrate_capture.py
+++ b/poc_homography/cli/calibrate_capture.py
@@ -23,6 +23,7 @@ import yaml
 from poc_homography.camera_config import (
     get_camera_by_name,
     get_camera_configs,
+    get_rtsp_url,
     get_tenant_credentials,
 )
 from poc_homography.cli.cleanplate import cleanplate_app
@@ -50,6 +51,23 @@ if TYPE_CHECKING:
     from poc_homography.domain.protocols.camera_device import CameraDevice
     from poc_homography.survey.phases.common import PhaseSink
     from poc_homography.survey.phases.runner import SurveyExecution
+
+
+def make_rtsp_url_resolver(camera_name: str) -> Callable[[], str | None]:
+    """Build the Phase 8 jitter RTSP-URL resolver for ``camera_name`` (#372).
+
+    Wraps :func:`camera_config.get_rtsp_url` (per-camera/tenant credential
+    resolution) and translates a missing-credentials :class:`ValueError` into
+    ``None`` so the runner skips jitter gracefully rather than crashing.
+    """
+
+    def resolve() -> str | None:
+        try:
+            return get_rtsp_url(camera_name)
+        except ValueError:
+            return None
+
+    return resolve
 
 
 @cleanplate_app.command("calibrate-capture")
@@ -148,6 +166,7 @@ def calibrate_capture_command(
             base_output_dir=base_output_dir,
             sink=sink,
             session_factory=get_session,
+            rtsp_url_resolver=make_rtsp_url_resolver(cam_info.get("name", cam_info["id"])),
         )
     finally:
         # The Postgres+MinIO sink is the real destination; the scratch dir we
@@ -171,6 +190,7 @@ def _run_calibration_capture(
     session_factory: Callable[[], AbstractContextManager[Session]],
     clock: Callable[[], datetime] | None = None,
     uuid_factory: Callable[[], str] | None = None,
+    rtsp_url_resolver: Callable[[], str | None] | None = None,
 ) -> SurveyExecution:
     """Run the sweep and persist the run header + plan-config sidecar.
 
@@ -178,6 +198,8 @@ def _run_calibration_capture(
     sink, and a fake session factory without any live network, MinIO, or Neon
     access. ``clock``/``uuid_factory`` are forwarded to :func:`execute_survey`
     (``None`` keeps the runner's wall-clock defaults) purely as test seams.
+    ``rtsp_url_resolver`` resolves the Phase 8 jitter RTSP URL for the camera
+    (the live wiring wraps ``camera_config.get_rtsp_url``).
     ``execute_survey`` already restores PTZ via :func:`preserve_ptz_position`,
     so no PTZ bracketing is added here.
     """
@@ -190,6 +212,7 @@ def _run_calibration_capture(
         plan=runner_plan,
         clock=clock,
         uuid_factory=uuid_factory,
+        rtsp_url_resolver=rtsp_url_resolver,
     )
 
     with session_factory() as session:

--- a/poc_homography/cli/run_camera.py
+++ b/poc_homography/cli/run_camera.py
@@ -44,7 +44,10 @@ from poc_homography.calibration.extrinsic import (
 from poc_homography.calibration.lens_distortion.ddd_sync import lens_table_to_camera_table
 from poc_homography.calibration.lens_distortion.frame_source import iter_survey_frames
 from poc_homography.calibration.lens_distortion.line_detection import LineDetector
-from poc_homography.cli.calibrate_capture import _run_calibration_capture
+from poc_homography.cli.calibrate_capture import (
+    _run_calibration_capture,
+    make_rtsp_url_resolver,
+)
 from poc_homography.cli.main import calibrate_app
 from poc_homography.cli.self_calibrate import _run_self_calibration
 from poc_homography.domain.entities.ptz_registration import PtzRegistration
@@ -284,6 +287,7 @@ def _live_capture(
             base_output_dir=base_output_dir,
             sink=sink,
             session_factory=get_session,
+            rtsp_url_resolver=make_rtsp_url_resolver(cam_info.get("name", cam_info["id"])),
         )
     finally:
         shutil.rmtree(base_output_dir, ignore_errors=True)

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -11,6 +11,7 @@ the validation set is disjoint from them. It builds and returns the C1
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -51,6 +52,12 @@ _POSE_BURST_PHASES = (2, 3, 4, 5, 6, 7, 9)
 # pan/tilt extent and zoom levels are sourced from the plan-config sidecar.
 _MAIN_SURVEY_PHASE = 5
 
+# All nine phase numbers, in execution order. A :class:`SurveyPlan` with the
+# default :attr:`~SurveyPlan.enabled_phases` runs every one.
+_ALL_PHASE_NUMBERS = frozenset(range(1, 10))
+
+_logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class SurveyPlan:
@@ -63,6 +70,12 @@ class SurveyPlan:
     """
 
     burst_count: int = 1
+
+    # Survey phases (1..9, the :class:`SurveyPhase` numbering) to execute; a
+    # phase absent here is skipped entirely by :func:`execute_survey`. Defaults
+    # to all nine and is sourced from :attr:`SurveyPlanConfig.enabled_phases`
+    # via :meth:`from_plan_config` (#372).
+    enabled_phases: frozenset[int] = _ALL_PHASE_NUMBERS
 
     # Optional per-phase override of ``burst_count`` (phase number -> frames),
     # sourced from :class:`SurveyPlanConfig` via :meth:`from_plan_config`. A
@@ -145,6 +158,10 @@ class SurveyPlan:
         """
         return self.phase_burst_counts.get(phase_number, self.burst_count)
 
+    def is_enabled(self, phase_number: int) -> bool:
+        """Return whether ``phase_number`` (1..9) is in :attr:`enabled_phases`."""
+        return phase_number in self.enabled_phases
+
     @classmethod
     def from_plan_config(
         cls,
@@ -157,6 +174,10 @@ class SurveyPlan:
         Bridges the camera-free :class:`SurveyPlanConfig` sidecar onto the
         runner's in-memory plan:
 
+        * **Enabled phases** (#372) — ``config.enabled_phases`` is forwarded so
+          :func:`execute_survey` runs only the configured subset of phases
+          (e.g. ``{1, 5}`` runs inventory + main survey alone). The default
+          (all nine) reproduces the pre-gating behaviour.
         * **Burst counts** — each pose-based phase's per-pose snapshot-burst
           frame count is taken from ``config.burst_frame_count[phase]`` (falling
           back to ``default_burst_frame_count``) and clamped to at least
@@ -219,6 +240,7 @@ class SurveyPlan:
             main_overlap_fraction = defaults.main_overlap_fraction
         return cls(
             burst_count=default,
+            enabled_phases=frozenset(config.enabled_phases),
             phase_burst_counts=phase_burst_counts,
             main_pan_range=main_pan_range,
             main_tilt_range=main_tilt_range,
@@ -247,8 +269,14 @@ def execute_survey(
     spec: CameraSpec = CameraSpec.HIKVISION_DS_2DF8425IX,
     clock: Callable[[], datetime] | None = None,
     uuid_factory: Callable[[], str] | None = None,
+    rtsp_url_resolver: Callable[[], str | None] | None = None,
 ) -> SurveyExecution:
-    """Run all nine survey phases for one camera, in order.
+    """Run the enabled survey phases for one camera, in order.
+
+    Only the phases in ``plan.enabled_phases`` (the :class:`SurveyPhase`
+    numbering 1..9) execute; the default plan enables all nine (#372). Each
+    phase's records are persisted to ``sink`` as soon as that phase completes,
+    so a later-phase failure never discards the frames already captured (#372).
 
     Args:
         camera: The #256 ``CameraDevice`` to drive.
@@ -261,6 +289,11 @@ def execute_survey(
         spec: Camera specification driving FOV-based pose spacing.
         clock: Returns timezone-aware UTC timestamps; injectable for tests.
         uuid_factory: Returns fresh id strings for bursts; injectable for tests.
+        rtsp_url_resolver: Resolves the Phase 8 jitter RTSP URL for this camera
+            (the live wiring wraps ``camera_config.get_rtsp_url``). Used only
+            when ``plan.jitter_rtsp_url`` is empty; returning ``None`` (or
+            omitting the resolver) makes Phase 8 skip gracefully instead of
+            driving the engine with an empty URL (#372).
 
     Returns:
         A :class:`SurveyExecution` with the C1 :class:`SurveyRun` header and the
@@ -280,127 +313,150 @@ def execute_survey(
     results: list[PhaseResult] = []
     captured_4_to_7: list[CommandedState] = []
 
+    def record(result: PhaseResult) -> None:
+        """Validate, accumulate, and immediately persist one phase's result.
+
+        Emitting per phase (rather than once after the whole sweep) keeps
+        persistence as failure-resilient as the PTZ restore: a later-phase
+        failure cannot discard the frames already captured (#372).
+        """
+        _assert_result_not_cross_tagged(result)
+        results.append(result)
+        _emit_result(result, sink)
+
     # Bracket the whole camera-driving sweep: snapshot the pre-sweep PTZ
     # position and restore it on normal completion, exception, or abort (#342).
     with preserve_ptz_position(camera):
-        inventory = executors.run_inventory(camera, run_id=run_id, camera_id=camera_id, clock=now)
-        results.append(inventory)
+        if plan.is_enabled(1):
+            record(executors.run_inventory(camera, run_id=run_id, camera_id=camera_id, clock=now))
 
-        results.append(
-            executors.run_ptz_characterization(
+        if plan.is_enabled(2):
+            record(
+                executors.run_ptz_characterization(
+                    engine,
+                    run_id=run_id,
+                    camera_id=camera_id,
+                    output_dir=_phase_dir(base_output_dir, SurveyPhase.PTZ_CHARACTERIZATION),
+                    pan_range=plan.ptz_pan_range,
+                    tilt_range=plan.ptz_tilt_range,
+                    small_step=plan.ptz_small_step,
+                    large_step=plan.ptz_large_step,
+                    fixed_tilt=plan.ptz_fixed_tilt,
+                    fixed_pan=plan.ptz_fixed_pan,
+                    fixed_zoom=plan.ptz_fixed_zoom,
+                    repeat_count=plan.ptz_repeat_count,
+                    burst_count=plan.burst_for(2),
+                )
+            )
+
+        if plan.is_enabled(3):
+            record(
+                executors.run_zoom_characterization(
+                    engine,
+                    run_id=run_id,
+                    camera_id=camera_id,
+                    output_dir=_phase_dir(base_output_dir, SurveyPhase.ZOOM_CHARACTERIZATION),
+                    zoom_min=plan.zoom_min,
+                    zoom_max=plan.zoom_max,
+                    zoom_step=plan.zoom_step,
+                    fixed_pan=plan.zoom_fixed_pan,
+                    fixed_tilt=plan.zoom_fixed_tilt,
+                    burst_count=plan.burst_for(3),
+                )
+            )
+
+        if plan.is_enabled(4):
+            nadir = executors.run_dense_nadir(
+                engine,
+                spec,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.DENSE_NADIR),
+                nadir_pan=plan.nadir_pan,
+                nadir_tilt=plan.nadir_tilt,
+                radius_deg=plan.nadir_radius_deg,
+                zoom=plan.nadir_zoom,
+                overlap_fraction=plan.nadir_overlap_fraction,
+                region_id=plan.nadir_region_id,
+                burst_count=plan.burst_for(4),
+            )
+            record(nadir)
+            captured_4_to_7.extend(nadir.commanded_states)
+
+        if plan.is_enabled(5):
+            main = executors.run_main_survey(
+                engine,
+                training,
+                run_id=run_id,
+                camera_id=camera_id,
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
+                burst_count=plan.burst_for(5),
+            )
+            record(main)
+            captured_4_to_7.extend(main.commanded_states)
+
+        if plan.is_enabled(6):
+            cross = executors.run_cross_zoom(
                 engine,
                 run_id=run_id,
                 camera_id=camera_id,
-                output_dir=_phase_dir(base_output_dir, SurveyPhase.PTZ_CHARACTERIZATION),
-                pan_range=plan.ptz_pan_range,
-                tilt_range=plan.ptz_tilt_range,
-                small_step=plan.ptz_small_step,
-                large_step=plan.ptz_large_step,
-                fixed_tilt=plan.ptz_fixed_tilt,
-                fixed_pan=plan.ptz_fixed_pan,
-                fixed_zoom=plan.ptz_fixed_zoom,
-                repeat_count=plan.ptz_repeat_count,
-                burst_count=plan.burst_for(2),
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
+                anchors=plan.cross_zoom_anchors,
+                zoom_levels=plan.cross_zoom_levels,
+                burst_count=plan.burst_for(6),
             )
-        )
+            record(cross)
+            captured_4_to_7.extend(cross.commanded_states)
 
-        results.append(
-            executors.run_zoom_characterization(
+        if plan.is_enabled(7):
+            repeat = executors.run_repeatability(
                 engine,
                 run_id=run_id,
                 camera_id=camera_id,
-                output_dir=_phase_dir(base_output_dir, SurveyPhase.ZOOM_CHARACTERIZATION),
-                zoom_min=plan.zoom_min,
-                zoom_max=plan.zoom_max,
-                zoom_step=plan.zoom_step,
-                fixed_pan=plan.zoom_fixed_pan,
-                fixed_tilt=plan.zoom_fixed_tilt,
-                burst_count=plan.burst_for(3),
+                output_dir=_phase_dir(base_output_dir, SurveyPhase.REPEATABILITY),
+                target_pan=plan.repeat_target_pan,
+                target_tilt=plan.repeat_target_tilt,
+                target_zoom=plan.repeat_target_zoom,
+                approach_deltas=plan.repeat_approach_deltas,
+                burst_count=plan.burst_for(7),
             )
-        )
+            record(repeat)
+            captured_4_to_7.extend(repeat.commanded_states)
 
-        nadir = executors.run_dense_nadir(
-            engine,
-            spec,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.DENSE_NADIR),
-            nadir_pan=plan.nadir_pan,
-            nadir_tilt=plan.nadir_tilt,
-            radius_deg=plan.nadir_radius_deg,
-            zoom=plan.nadir_zoom,
-            overlap_fraction=plan.nadir_overlap_fraction,
-            region_id=plan.nadir_region_id,
-            burst_count=plan.burst_for(4),
-        )
-        results.append(nadir)
-        captured_4_to_7.extend(nadir.commanded_states)
+        if plan.is_enabled(8):
+            jitter_rtsp_url = _resolve_jitter_rtsp_url(plan, rtsp_url_resolver)
+            if jitter_rtsp_url:
+                record(
+                    executors.run_jitter(
+                        engine,
+                        run_id=run_id,
+                        camera_id=camera_id,
+                        output_dir=_phase_dir(base_output_dir, SurveyPhase.STATIC_JITTER),
+                        rtsp_url=jitter_rtsp_url,
+                        poses=plan.jitter_poses,
+                        zoom_levels=plan.jitter_zoom_levels,
+                        burst_duration_s=plan.jitter_burst_duration_s,
+                        target_fps=plan.jitter_target_fps,
+                    )
+                )
+            else:
+                _logger.warning(
+                    "Phase 8 (static jitter) skipped for camera %s: no RTSP URL resolvable",
+                    camera_id,
+                )
 
-        main = executors.run_main_survey(
-            engine,
-            training,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.MAIN_SURVEY),
-            burst_count=plan.burst_for(5),
-        )
-        results.append(main)
-        captured_4_to_7.extend(main.commanded_states)
-
-        cross = executors.run_cross_zoom(
-            engine,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.CROSS_ZOOM),
-            anchors=plan.cross_zoom_anchors,
-            zoom_levels=plan.cross_zoom_levels,
-            burst_count=plan.burst_for(6),
-        )
-        results.append(cross)
-        captured_4_to_7.extend(cross.commanded_states)
-
-        repeat = executors.run_repeatability(
-            engine,
-            run_id=run_id,
-            camera_id=camera_id,
-            output_dir=_phase_dir(base_output_dir, SurveyPhase.REPEATABILITY),
-            target_pan=plan.repeat_target_pan,
-            target_tilt=plan.repeat_target_tilt,
-            target_zoom=plan.repeat_target_zoom,
-            approach_deltas=plan.repeat_approach_deltas,
-            burst_count=plan.burst_for(7),
-        )
-        results.append(repeat)
-        captured_4_to_7.extend(repeat.commanded_states)
-
-        results.append(
-            executors.run_jitter(
-                engine,
-                run_id=run_id,
-                camera_id=camera_id,
-                output_dir=_phase_dir(base_output_dir, SurveyPhase.STATIC_JITTER),
-                rtsp_url=plan.jitter_rtsp_url,
-                poses=plan.jitter_poses,
-                zoom_levels=plan.jitter_zoom_levels,
-                burst_duration_s=plan.jitter_burst_duration_s,
-                target_fps=plan.jitter_target_fps,
+        if plan.is_enabled(9):
+            record(
+                executors.run_validation(
+                    engine,
+                    holdout,
+                    captured_4_to_7,
+                    run_id=run_id,
+                    camera_id=camera_id,
+                    output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
+                    burst_count=plan.burst_for(9),
+                )
             )
-        )
-
-        results.append(
-            executors.run_validation(
-                engine,
-                holdout,
-                captured_4_to_7,
-                run_id=run_id,
-                camera_id=camera_id,
-                output_dir=_phase_dir(base_output_dir, SurveyPhase.VALIDATION),
-                burst_count=plan.burst_for(9),
-            )
-        )
-
-    _emit(results, sink)
-    _assert_no_cross_tagging(results)
 
     run = SurveyRun(
         run_id=run_id,
@@ -444,32 +500,48 @@ def _partition_main_grid(spec: CameraSpec, plan: SurveyPlan) -> tuple[list[Pose]
     return training, holdout
 
 
-def _emit(results: list[PhaseResult], sink: PhaseSink) -> None:
-    """Route every record produced by every phase to the sink."""
-    for result in results:
-        if result.inventory is not None:
-            sink.save_inventory(result.inventory)
-        for burst in result.bursts:
-            sink.save_burst(burst)
-        for frame in result.frames:
-            sink.save_frame(frame)
+def _resolve_jitter_rtsp_url(
+    plan: SurveyPlan, resolver: Callable[[], str | None] | None
+) -> str | None:
+    """Resolve the Phase 8 jitter RTSP URL, preferring the plan's explicit one.
+
+    Falls back to ``resolver`` (the live per-camera/tenant credential lookup)
+    when ``plan.jitter_rtsp_url`` is empty. Returns ``None`` when neither
+    yields a usable URL so the caller skips jitter rather than driving the
+    engine with an empty URL (#372). The resolver contract is to return
+    ``None`` (not raise) when no URL is resolvable.
+    """
+    if plan.jitter_rtsp_url:
+        return plan.jitter_rtsp_url
+    if resolver is not None:
+        return resolver()
+    return None
 
 
-def _assert_no_cross_tagging(results: list[PhaseResult]) -> None:
-    """Assert no phase emitted a record tagged with another phase's identifier."""
-    for result in results:
-        for frame in result.frames:
-            if frame.capture.phase is not result.phase:
-                raise ValueError(
-                    f"phase {result.phase.value} emitted a frame tagged {frame.capture.phase.value}"
-                )
-        for burst in result.bursts:
-            if burst.phase is not result.phase:
-                raise ValueError(
-                    f"phase {result.phase.value} emitted a burst tagged {burst.phase.value}"
-                )
-        if result.inventory is not None and result.inventory.phase is not result.phase:
+def _emit_result(result: PhaseResult, sink: PhaseSink) -> None:
+    """Route every record produced by one phase to the sink."""
+    if result.inventory is not None:
+        sink.save_inventory(result.inventory)
+    for burst in result.bursts:
+        sink.save_burst(burst)
+    for frame in result.frames:
+        sink.save_frame(frame)
+
+
+def _assert_result_not_cross_tagged(result: PhaseResult) -> None:
+    """Assert one phase's records are all tagged with its own identifier."""
+    for frame in result.frames:
+        if frame.capture.phase is not result.phase:
             raise ValueError(
-                f"phase {result.phase.value} emitted an inventory record tagged "
-                f"{result.inventory.phase.value}"
+                f"phase {result.phase.value} emitted a frame tagged {frame.capture.phase.value}"
             )
+    for burst in result.bursts:
+        if burst.phase is not result.phase:
+            raise ValueError(
+                f"phase {result.phase.value} emitted a burst tagged {burst.phase.value}"
+            )
+    if result.inventory is not None and result.inventory.phase is not result.phase:
+        raise ValueError(
+            f"phase {result.phase.value} emitted an inventory record tagged "
+            f"{result.inventory.phase.value}"
+        )

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -312,7 +312,12 @@ def execute_survey(
     engine = SurveyCaptureEngine(camera, clock=clock, uuid_factory=uuid_factory)
     started_at = now()
 
-    training, holdout = _partition_main_grid(spec, plan)
+    # The FOV-grid partition feeds only the main survey (phase 5, training) and
+    # validation (phase 9, holdout); skip building it when both are disabled.
+    training: list[Pose] = []
+    holdout: list[Pose] = []
+    if plan.is_enabled(5) or plan.is_enabled(9):
+        training, holdout = _partition_main_grid(spec, plan)
 
     results: list[PhaseResult] = []
     captured_4_to_7: list[CommandedState] = []

--- a/poc_homography/survey/phases/runner.py
+++ b/poc_homography/survey/phases/runner.py
@@ -52,8 +52,9 @@ _POSE_BURST_PHASES = (2, 3, 4, 5, 6, 7, 9)
 # pan/tilt extent and zoom levels are sourced from the plan-config sidecar.
 _MAIN_SURVEY_PHASE = 5
 
-# All nine phase numbers, in execution order. A :class:`SurveyPlan` with the
-# default :attr:`~SurveyPlan.enabled_phases` runs every one.
+# Every phase number (1..9). A :class:`SurveyPlan` with the default
+# :attr:`~SurveyPlan.enabled_phases` runs every one; the execution order itself
+# is fixed by the sequence of phase blocks in :func:`execute_survey`.
 _ALL_PHASE_NUMBERS = frozenset(range(1, 10))
 
 _logger = logging.getLogger(__name__)
@@ -300,8 +301,11 @@ def execute_survey(
         per-phase results.
 
     Raises:
-        JitterTargetError: If Phase 8 is below the minimum jitter target.
-        ValueError: If the Phase 9 holdout overlaps a captured training state.
+        JitterTargetError: If Phase 8 runs and is below the minimum jitter
+            target (Phase 8 is skipped — never raising — when it is disabled or
+            its RTSP URL is unresolvable).
+        ValueError: If Phase 9 runs and its holdout overlaps a captured
+            training state.
     """
     plan = plan or SurveyPlan()
     now = clock or _utcnow

--- a/tests/survey/test_calibrate_capture_cmd.py
+++ b/tests/survey/test_calibrate_capture_cmd.py
@@ -60,6 +60,28 @@ class _FakeRepo:
         return True
 
 
+def test_rtsp_url_resolver_returns_url_when_resolvable(monkeypatch) -> None:
+    monkeypatch.setattr(cmd, "get_rtsp_url", lambda name: f"rtsp://{name}/stream")
+    assert cmd.make_rtsp_url_resolver("cam01")() == "rtsp://cam01/stream"
+
+
+def test_rtsp_url_resolver_swallows_config_shape_errors(monkeypatch) -> None:
+    # get_rtsp_url raises ValueError on missing credentials and KeyError when a
+    # camera row lacks an expected field (e.g. ``ip``); both must resolve to
+    # None so the runner skips jitter rather than crashing (#372).
+    def raise_value_error(_name: str) -> str:
+        raise ValueError("credentials not set")
+
+    def raise_key_error(_name: str) -> str:
+        raise KeyError("ip")
+
+    monkeypatch.setattr(cmd, "get_rtsp_url", raise_value_error)
+    assert cmd.make_rtsp_url_resolver("cam01")() is None
+
+    monkeypatch.setattr(cmd, "get_rtsp_url", raise_key_error)
+    assert cmd.make_rtsp_url_resolver("cam01")() is None
+
+
 def test_run_calibration_capture_routes_frames_and_saves_run(
     camera: FakeCamera,
     clock: IncrementingClock,

--- a/tests/survey/test_runner.py
+++ b/tests/survey/test_runner.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from poc_homography.domain.enums.survey_phase import SurveyPhase
 from poc_homography.domain.enums.survey_run_status import SurveyRunStatus
 from poc_homography.infrastructure.repositories.repo_yaml_survey_run import (
     RepoYamlSurveyRun,
 )
 from poc_homography.infrastructure.survey.yaml_phase_sink import YamlPhaseSink
-from poc_homography.survey.phases.runner import SurveyExecution, execute_survey
+from poc_homography.survey.phases import executors
+from poc_homography.survey.phases.common import PhaseResult
+from poc_homography.survey.phases.runner import SurveyExecution, SurveyPlan, execute_survey
+
+# Offline jitter (Phase 8) drives the engine through the ``patch_rtsp`` seam, so
+# the URL value is never dialled — any non-empty string enables the phase (#372).
+_FAKE_RTSP_URL = "rtsp://fake/stream"
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -52,6 +60,7 @@ def _run(
     uuid_factory: CountingUuid,
     sink: object,
     base: Path,
+    plan: SurveyPlan | None = None,
 ) -> SurveyExecution:
     return execute_survey(
         camera,
@@ -59,6 +68,7 @@ def _run(
         camera_id="icozee-camptz-04",
         sink=sink,  # type: ignore[arg-type]
         base_output_dir=base,
+        plan=plan or SurveyPlan(jitter_rtsp_url=_FAKE_RTSP_URL),
         clock=clock,
         uuid_factory=uuid_factory,
     )
@@ -173,6 +183,163 @@ class TestExecuteSurvey:
         validation = [f for f in sink.frames if f.capture.phase is SurveyPhase.VALIDATION]
         assert validation
         assert keys(training).isdisjoint(keys(validation))
+
+
+# Executor function name -> the SurveyPhase it produces, in phase-number order.
+_EXECUTOR_BY_PHASE = {
+    1: ("run_inventory", SurveyPhase.CAMERA_INVENTORY),
+    2: ("run_ptz_characterization", SurveyPhase.PTZ_CHARACTERIZATION),
+    3: ("run_zoom_characterization", SurveyPhase.ZOOM_CHARACTERIZATION),
+    4: ("run_dense_nadir", SurveyPhase.DENSE_NADIR),
+    5: ("run_main_survey", SurveyPhase.MAIN_SURVEY),
+    6: ("run_cross_zoom", SurveyPhase.CROSS_ZOOM),
+    7: ("run_repeatability", SurveyPhase.REPEATABILITY),
+    8: ("run_jitter", SurveyPhase.STATIC_JITTER),
+    9: ("run_validation", SurveyPhase.VALIDATION),
+}
+
+
+def _spy_all_executors(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace every phase executor with a spy; return the invocation log.
+
+    Each spy records its name and returns an empty :class:`PhaseResult` tagged
+    with its own phase (so the runner's per-phase cross-tag check passes without
+    driving the C2 engine or a camera).
+    """
+    invoked: list[str] = []
+
+    def make_spy(name: str, phase: SurveyPhase):
+        def spy(*_args: object, **_kwargs: object) -> PhaseResult:
+            invoked.append(name)
+            return PhaseResult(phase=phase)
+
+        return spy
+
+    for name, phase in _EXECUTOR_BY_PHASE.values():
+        monkeypatch.setattr(executors, name, make_spy(name, phase))
+    return invoked
+
+
+class TestEnabledPhasesGating:
+    def test_only_enabled_phase_executors_run(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invoked = _spy_all_executors(monkeypatch)
+        sink = _RecordingSink()
+        plan = SurveyPlan(enabled_phases=frozenset({1, 5}))
+        execution = _run(camera, clock, uuid_factory, sink, tmp_path, plan=plan)
+
+        assert invoked == ["run_inventory", "run_main_survey"]
+        assert execution.run.phases == frozenset(
+            {SurveyPhase.CAMERA_INVENTORY, SurveyPhase.MAIN_SURVEY}
+        )
+
+    def test_default_plan_runs_all_nine(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        invoked = _spy_all_executors(monkeypatch)
+        plan = SurveyPlan(jitter_rtsp_url=_FAKE_RTSP_URL)
+        _run(camera, clock, uuid_factory, _RecordingSink(), tmp_path, plan=plan)
+        assert invoked == [name for name, _ in _EXECUTOR_BY_PHASE.values()]
+
+
+class TestJitterRtspResolution:
+    def test_jitter_uses_resolver_when_plan_url_empty(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def spy_jitter(*_args: object, **kwargs: object) -> PhaseResult:
+            captured["rtsp_url"] = kwargs["rtsp_url"]
+            return PhaseResult(phase=SurveyPhase.STATIC_JITTER)
+
+        monkeypatch.setattr(executors, "run_jitter", spy_jitter)
+        plan = SurveyPlan(enabled_phases=frozenset({8}), jitter_rtsp_url="")
+        execute_survey(
+            camera,
+            run_id="run-1",
+            camera_id="cam-x",
+            sink=_RecordingSink(),  # type: ignore[arg-type]
+            base_output_dir=tmp_path,
+            plan=plan,
+            clock=clock,
+            uuid_factory=uuid_factory,
+            rtsp_url_resolver=lambda: "rtsp://resolved/stream",
+        )
+        assert captured["rtsp_url"] == "rtsp://resolved/stream"
+
+    def test_jitter_skipped_with_warning_when_unresolvable(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def boom(*_args: object, **_kwargs: object) -> PhaseResult:
+            raise AssertionError("run_jitter must not be called when the URL is unresolvable")
+
+        monkeypatch.setattr(executors, "run_jitter", boom)
+        sink = _RecordingSink()
+        plan = SurveyPlan(enabled_phases=frozenset({8}), jitter_rtsp_url="")
+        with caplog.at_level("WARNING", logger="poc_homography.survey.phases.runner"):
+            execution = execute_survey(
+                camera,
+                run_id="run-1",
+                camera_id="cam-x",
+                sink=sink,  # type: ignore[arg-type]
+                base_output_dir=tmp_path,
+                plan=plan,
+                clock=clock,
+                uuid_factory=uuid_factory,
+                rtsp_url_resolver=lambda: None,
+            )
+
+        assert sink.bursts == []
+        assert execution.run.phases == frozenset()
+        messages = [record.getMessage().lower() for record in caplog.records]
+        assert any("static jitter" in message and "skipped" in message for message in messages)
+
+
+class TestPersistenceRobustness:
+    def test_phase_failure_persists_earlier_phases(
+        self,
+        camera: FakeCamera,
+        clock: IncrementingClock,
+        uuid_factory: CountingUuid,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def failing_ptz(*_args: object, **_kwargs: object) -> PhaseResult:
+            raise RuntimeError("phase 2 capture failed mid-run")
+
+        monkeypatch.setattr(executors, "run_ptz_characterization", failing_ptz)
+        sink = _RecordingSink()
+        plan = SurveyPlan(enabled_phases=frozenset({1, 2}))
+
+        with pytest.raises(RuntimeError, match="phase 2 capture failed"):
+            _run(camera, clock, uuid_factory, sink, tmp_path, plan=plan)
+
+        # Phase 1 completed before phase 2 raised, so its inventory was already
+        # persisted — the failure did not discard the captured data (#372).
+        assert len(sink.inventories) == 1
+        assert sink.inventories[0].phase is SurveyPhase.CAMERA_INVENTORY
 
 
 class TestYamlPhaseSinkDataset:


### PR DESCRIPTION
Closes #372

## Summary

Live `execute_survey` had three integration defects found driving a real Hikvision camera end-to-end (all missed offline because the orchestrator stub honored gating and never used RTSP).

This fixes all three in the live runner:

1. **Honor enabled_phases** — `SurveyPlan` gains an `enabled_phases: frozenset[int]` field (default all 1..9) populated from `SurveyPlanConfig.enabled_phases` in `from_plan_config`. `execute_survey` now gates every phase executor call on `plan.is_enabled(n)`, so a plan with `[1,5]` runs ONLY inventory + main survey.
2. **Jitter RTSP** — phase 8 resolves its stream URL via an injected `rtsp_url_resolver` (the CLIs wrap `camera_config.get_rtsp_url`, translating missing-credential ValueError to None) instead of the empty `jitter_rtsp_url`. When no URL is resolvable, jitter is skipped with a logged warning rather than crashing.
3. **Persistence robustness** — each phase's records are emitted to the sink immediately after capture (per-phase `record()` helper) instead of once after the whole sweep, so a later-phase failure no longer discards earlier phases' frames.

## Test plan

`poe ci` green (1406 passed, 158 env-skipped). New offline tests: enabled_phases=[1,5] invokes only inventory+main_survey executors; jitter skipped-with-warning when unresolvable and uses the resolver when provided; a phase failure mid-run still persists earlier phases to a spy sink.

## Closes DoD bullets

- A plan with enabled_phases=[1,5] runs exactly inventory + main_survey (offline test asserting only those phase executors are invoked).
- Jitter with an unresolvable RTSP URL is skipped with a warning, not a crash; when resolvable it uses get_rtsp_url. Covered by an offline test.
- A phase failure mid-run still persists the already-captured phases' frames to the sink (offline test with a failing phase + spy sink).
- poe ci green.
