### PR TITLE
feat(calib): idempotent DB bootstrap (tenant+map+camera_configs) for automatic pipeline [#341]

### DIFF
--- a/poc_homography/cli/bootstrap.py
+++ b/poc_homography/cli/bootstrap.py
@@ -1,0 +1,240 @@
+"""Idempotent DB bootstrap CLI command for the calibration pipeline (#374).
+
+The automatic calibration pipeline persists ``lens_calibration_tables`` and
+``ptz_registrations`` keyed by camera id, but those tables sit at the bottom of
+an FK chain: ``tenants(id)`` <- ``maps.tenant_id``; ``maps(id)`` <-
+``camera_configs.map_id``; ``camera_configs(id)`` <-
+``lens_calibration_tables.id``. When the reference tables are empty, the
+pipeline cannot persist anything (FK violation).
+
+This command ensures the three reference rows a tenant's pipeline requires —
+the tenant, its map, and one ``camera_config`` per registry camera — exist in
+the database, sourced entirely from the EXISTING registry + map sidecars. It
+authors **no** new data. Every row is keyed by its stable id and persisted via
+:meth:`RepoPostgres.save` (an upsert), so the command is idempotent: re-running
+it updates rows in place and never duplicates.
+
+The offline-testable seam :func:`_run_bootstrap` references the three repo
+classes as module-level names so tests can swap them for in-memory doubles and
+exercise tenant -> map -> camera_configs upsert ordering with NO live Neon
+access. The Typer command resolves the registry + sidecar inputs and delegates
+to that seam.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+from poc_homography.camera_config import (
+    get_cameras_for_tenant,
+    get_tenant_by_id,
+    get_tenant_credentials,
+)
+from poc_homography.cli.main import calibrate_app
+from poc_homography.domain.entities.camera_config import CameraConfig
+from poc_homography.domain.entities.tenant import Tenant
+from poc_homography.domain.enums import CameraSpec
+from poc_homography.domain.vo.credential import Credential
+from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresCameraConfig,
+    RepoPostgresMap,
+    RepoPostgresTenant,
+    RepoYamlMap,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from contextlib import AbstractContextManager
+
+    from sqlalchemy.orm import Session
+
+    from poc_homography.domain.entities.map import Map
+
+_DEFAULT_MAPS_DIR = Path("data/maps")
+
+
+@dataclass(frozen=True)
+class BootstrapSummary:
+    """The reference rows ensured by one bootstrap run.
+
+    Attributes:
+        tenant_id: The bootstrapped tenant id.
+        map_id: The stable map id (the sidecar's internal ``id``).
+        camera_ids: The camera ids whose ``camera_config`` rows were upserted.
+    """
+
+    tenant_id: str
+    map_id: str
+    camera_ids: list[str]
+
+
+def _build_camera_configs(
+    *,
+    tenant_id: str,
+    map_id: str,
+    cameras: Sequence[dict],
+    credential: Credential,
+) -> list[CameraConfig]:
+    """Build one :class:`CameraConfig` per registry camera dict.
+
+    Each config is anchored to the resolved ``map_id`` (the cameras' FK target)
+    and carries the tenant credential plaintext so the live pipeline can reach
+    the camera. Authors no new data — every field is sourced from the registry.
+
+    Args:
+        tenant_id: The owning tenant id.
+        map_id: The stable map id the cameras reference.
+        cameras: Registry camera dicts (``id``, ``name``, ``ip``).
+        credential: The tenant camera credential.
+
+    Returns:
+        The list of camera configs, one per input camera, in input order.
+    """
+    configs: list[CameraConfig] = []
+    for cam in cameras:
+        configs.append(
+            CameraConfig(
+                id=str(cam["id"]),
+                tenant_id=tenant_id,
+                map_id=map_id,
+                name=str(cam.get("name") or cam["id"]),
+                spec=CameraSpec.HIKVISION_DS_2DF8425IX,
+                credential=credential,
+                ip_address=cam.get("ip"),
+            )
+        )
+    return configs
+
+
+def _run_bootstrap(
+    *,
+    tenant_id: str,
+    tenant: Tenant,
+    tenant_map: Map,
+    cameras: Sequence[dict],
+    credential: Credential,
+    session_factory: Callable[[], AbstractContextManager[Session]],
+) -> BootstrapSummary:
+    """Upsert the tenant, its map, and each camera config in FK order.
+
+    Opens one session and upserts in the order the FK chain requires: tenant ->
+    map -> camera_configs. Every save is an upsert keyed by id, so re-running is
+    idempotent (rows are updated in place, never duplicated). The three repo
+    classes are module-level names so tests can swap them for in-memory doubles.
+
+    Args:
+        tenant_id: The tenant id (also the summary key).
+        tenant: The tenant entity to upsert.
+        tenant_map: The map entity to upsert (FK child of the tenant).
+        cameras: Registry camera dicts to turn into camera configs.
+        credential: The tenant camera credential for each camera config.
+        session_factory: Database session context-manager factory.
+
+    Returns:
+        A :class:`BootstrapSummary` of the rows ensured.
+    """
+    configs = _build_camera_configs(
+        tenant_id=tenant_id,
+        map_id=tenant_map.id,
+        cameras=cameras,
+        credential=credential,
+    )
+    with session_factory() as session:
+        RepoPostgresTenant(session).save(tenant)
+        RepoPostgresMap(session).save(tenant_map)
+        camera_repo = RepoPostgresCameraConfig(session)
+        for config in configs:
+            camera_repo.save(config)
+
+    return BootstrapSummary(
+        tenant_id=tenant_id,
+        map_id=tenant_map.id,
+        camera_ids=[config.id for config in configs],
+    )
+
+
+def _load_tenant_map(tenant_id: str, maps_dir: Path) -> Map:
+    """Load a tenant's map entity from its ``data/maps/<tenant>.yaml`` sidecar.
+
+    ``RepoYamlMap`` reads by filename stem (the tenant), and the loaded
+    ``Map.id`` is the sidecar's internal ``id`` (the stable map id). Derives the
+    ``{tenant_id}/{photo.path}`` asset key when the sidecar omits it.
+
+    Args:
+        tenant_id: The tenant whose sidecar to load.
+        maps_dir: The directory holding the ``<tenant>.yaml`` sidecars.
+
+    Returns:
+        The map entity with a guaranteed ``asset_key``.
+
+    Raises:
+        typer.Exit: If the sidecar is missing.
+    """
+    tenant_map = RepoYamlMap(maps_dir).get(tenant_id)
+    if tenant_map is None:
+        typer.echo(
+            f"Error: Map sidecar for tenant '{tenant_id}' not found at "
+            f"data/maps/{tenant_id}.yaml — run bootstrap requires the sidecar.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if not tenant_map.asset_key:
+        tenant_map = dataclasses.replace(
+            tenant_map, asset_key=f"{tenant_map.tenant_id}/{tenant_map.photo.path}"
+        )
+    return tenant_map
+
+
+@calibrate_app.command("bootstrap")
+def bootstrap_command(
+    tenant: str = typer.Option(..., "--tenant", help="Tenant id (e.g., 'icozee')"),
+) -> None:
+    """Ensure the reference rows the tenant's calibration pipeline FKs require.
+
+    Idempotently upserts the tenant, its map, and one ``camera_config`` per
+    registry camera (in FK order), sourced from the existing registry + map
+    sidecar. Re-running updates rows in place and never duplicates. Run this
+    once per tenant before ``run-camera`` / ``rollout``.
+    """
+    if not os.environ.get("DATABASE_URL"):
+        typer.echo("Error: DATABASE_URL environment variable is not set.", err=True)
+        raise typer.Exit(1)
+
+    tenant_dict = get_tenant_by_id(tenant)
+    if not tenant_dict:
+        typer.echo(f"Error: Tenant '{tenant}' not found.", err=True)
+        raise typer.Exit(1)
+
+    cameras = get_cameras_for_tenant(tenant)
+    if not cameras:
+        typer.echo(f"Error: No cameras found for tenant '{tenant}'.", err=True)
+        raise typer.Exit(1)
+
+    username, password = get_tenant_credentials(tenant)
+    credential = Credential(username or "", password or "")
+
+    tenant_map = _load_tenant_map(tenant, _DEFAULT_MAPS_DIR)
+
+    summary = _run_bootstrap(
+        tenant_id=tenant,
+        tenant=Tenant.from_dict(tenant_dict),
+        tenant_map=tenant_map,
+        cameras=cameras,
+        credential=credential,
+        session_factory=get_session,
+    )
+
+    typer.echo(
+        f"Bootstrap: tenant={summary.tenant_id} map={summary.map_id} "
+        f"cameras={len(summary.camera_ids)}"
+    )
+
+
+__all__ = ["bootstrap_command"]

--- a/poc_homography/cli/bootstrap.py
+++ b/poc_homography/cli/bootstrap.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import dataclasses
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import typer
@@ -48,16 +47,16 @@ from poc_homography.infrastructure.repositories import (
     RepoPostgresTenant,
     RepoYamlMap,
 )
+from poc_homography.maps import DEFAULT_MAPS_DIR
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from contextlib import AbstractContextManager
+    from pathlib import Path
 
     from sqlalchemy.orm import Session
 
     from poc_homography.domain.entities.map import Map
-
-_DEFAULT_MAPS_DIR = Path("data/maps")
 
 
 @dataclass(frozen=True)
@@ -220,7 +219,7 @@ def bootstrap_command(
     username, password = get_tenant_credentials(tenant)
     credential = Credential(username or "", password or "")
 
-    tenant_map = _load_tenant_map(tenant, _DEFAULT_MAPS_DIR)
+    tenant_map = _load_tenant_map(tenant, DEFAULT_MAPS_DIR)
 
     summary = _run_bootstrap(
         tenant_id=tenant,

--- a/poc_homography/cli/main.py
+++ b/poc_homography/cli/main.py
@@ -30,6 +30,7 @@ def _register_commands() -> None:
     themselves when the module is imported.
     """
     from poc_homography.cli import (
+        bootstrap,
         calibrate,
         calibrate_capture,
         camera,
@@ -51,6 +52,7 @@ def _register_commands() -> None:
     app.add_typer(maps.maps_app, name="maps")
 
     # Avoid "imported but unused" warnings by explicitly using the module
+    _ = bootstrap
     _ = calibrate
     _ = calibrate_capture
     _ = camera

--- a/poc_homography/cli/rollout.py
+++ b/poc_homography/cli/rollout.py
@@ -46,6 +46,12 @@ from poc_homography.cli.main import calibrate_app
 from poc_homography.cli.run_camera import _load_ortho_context, _run_camera_registration
 from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
 from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_camera_config import (
+    RepoPostgresCameraConfig,
+)
+from poc_homography.infrastructure.repositories.repo_postgres_map import (
+    RepoPostgresMap,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -380,6 +386,50 @@ def _format_summary(outcomes: Sequence[CameraOutcome]) -> str:
     return "\n".join(lines)
 
 
+def _require_reference_rows(
+    tenant: str,
+    targets: Sequence[RolloutTarget],
+    *,
+    session_factory: Callable[[], AbstractContextManager[Session]],
+) -> None:
+    """Fail fast with a clear fix when a target's FK reference rows are absent.
+
+    Each resolved target persists registrations under an FK chain rooted at the
+    tenant -> map -> camera_config rows. When any target's ``camera_config`` or
+    its ``map`` row is missing, persistence would raise a ForeignKeyViolation
+    inside the loop; this preflight surfaces the missing rows up front and names
+    the bootstrap fix instead of auto-mutating the DB.
+
+    Args:
+        tenant: The tenant id, named in the remediation message.
+        targets: The resolved cameras whose reference rows must exist.
+        session_factory: Database session context-manager factory.
+
+    Raises:
+        typer.Exit: If any target's camera_config or map row is missing.
+    """
+    missing: list[str] = []
+    with session_factory() as session:
+        camera_repo = RepoPostgresCameraConfig(session)
+        map_repo = RepoPostgresMap(session)
+        map_seen: dict[str, bool] = {}
+        for target in targets:
+            if camera_repo.get(target.camera_id) is None:
+                missing.append(target.camera_id)
+                continue
+            if target.map_id and target.map_id not in map_seen:
+                map_seen[target.map_id] = map_repo.get(target.map_id) is not None
+            if target.map_id and not map_seen.get(target.map_id, False):
+                missing.append(target.camera_id)
+    if missing:
+        typer.echo(
+            f"Error: reference rows missing for cameras {sorted(set(missing))}. "
+            f"Run: hom calibrate bootstrap --tenant {tenant} first.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
 def _load_cameras_file(cameras_file: Path) -> dict:
     """Load and parse the ``calib_cameras.json`` file or exit with a clear error.
 
@@ -446,6 +496,7 @@ def rollout_command(
         raise typer.Exit(1)
 
     targets, annotations = _resolve_targets(spec, tenant_cameras)
+    _require_reference_rows(tenant, targets, session_factory=get_session)
     outcomes = _run_rollout(
         targets,
         annotations,

--- a/poc_homography/cli/run_camera.py
+++ b/poc_homography/cli/run_camera.py
@@ -53,8 +53,14 @@ from poc_homography.cli.self_calibrate import _run_self_calibration
 from poc_homography.domain.entities.ptz_registration import PtzRegistration
 from poc_homography.infrastructure.clients.minio_frame_store import MinioFrameStore
 from poc_homography.infrastructure.database import get_session
+from poc_homography.infrastructure.repositories.repo_postgres_camera_config import (
+    RepoPostgresCameraConfig,
+)
 from poc_homography.infrastructure.repositories.repo_postgres_clean_plate_frame import (
     RepoPostgresCleanPlateFrame,
+)
+from poc_homography.infrastructure.repositories.repo_postgres_map import (
+    RepoPostgresMap,
 )
 from poc_homography.infrastructure.repositories.repo_postgres_ptz_registration import (
     RepoPostgresPtzRegistration,
@@ -201,6 +207,42 @@ def _run_camera_registration(
             registrations.append(record)
 
     return registrations
+
+
+def _require_reference_rows(
+    camera_id: str,
+    map_id: str,
+    *,
+    tenant_id: str,
+    session_factory: Callable[[], AbstractContextManager[Session]],
+) -> None:
+    """Fail fast with a clear fix when the pipeline's FK reference rows are absent.
+
+    The pipeline persists registrations keyed by ``camera_id`` under an FK chain
+    rooted at the tenant -> map -> camera_config rows. When either the camera's
+    ``camera_config`` or its ``map`` row is missing, persistence would raise a
+    ForeignKeyViolation deep in the run; this preflight surfaces that up front
+    and names the bootstrap fix instead of auto-mutating the DB.
+
+    Args:
+        camera_id: The camera whose ``camera_config`` row must exist.
+        map_id: The map row the camera references.
+        tenant_id: The tenant id, named in the remediation message.
+        session_factory: Database session context-manager factory.
+
+    Raises:
+        typer.Exit: If either reference row is missing.
+    """
+    with session_factory() as session:
+        camera_exists = RepoPostgresCameraConfig(session).get(camera_id) is not None
+        map_exists = RepoPostgresMap(session).get(map_id) is not None
+    if not (camera_exists and map_exists):
+        typer.echo(
+            f"Error: reference rows missing for camera '{camera_id}'. "
+            f"Run: hom calibrate bootstrap --tenant {tenant_id} first.",
+            err=True,
+        )
+        raise typer.Exit(1)
 
 
 def _resolve_camera(camera: str) -> dict:
@@ -366,6 +408,13 @@ def run_camera_command(
     if not os.environ.get("DATABASE_URL"):
         typer.echo("Error: DATABASE_URL environment variable is not set.", err=True)
         raise typer.Exit(1)
+
+    _require_reference_rows(
+        camera_id,
+        map_id,
+        tenant_id=cam_info.get("tenant_id") or "",
+        session_factory=get_session,
+    )
 
     if offline_run_id:
         run_id = offline_run_id

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -1,0 +1,258 @@
+"""Offline tests for the idempotent DB bootstrap CLI command (#374).
+
+The bootstrap command ensures a tenant's calibration pipeline FK reference rows
+(tenant -> map -> camera_configs) exist, sourced from the registry + map
+sidecar. These tests exercise the upsert seam and the Typer command with
+in-memory repo doubles + a fake session — NO live Neon or network. Idempotency
+is asserted directly: running the seam twice yields no duplicate rows.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from poc_homography.cli import bootstrap as cmd
+from poc_homography.cli.main import app
+from poc_homography.domain.entities.map import Map
+from poc_homography.domain.entities.tenant import Tenant
+from poc_homography.domain.enums import CameraSpec
+from poc_homography.domain.vo.credential import Credential
+from poc_homography.domain.vo.geotiff import GeoTiff, GeoTransform
+from poc_homography.domain.vo.photo import Photo
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# In-memory doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeRepo:
+    """In-memory repo double: ``save`` upserts by id into a shared dict.
+
+    Each repo class gets its OWN class-level ``rows`` dict so the three repo
+    doubles do not collide. ``save`` mirrors RepoPostgres.save (upsert by id).
+    """
+
+    rows: dict[str, object] = {}
+
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+    def save(self, entity: object) -> None:
+        type(self).rows[entity.id] = entity  # type: ignore[attr-defined]
+
+    def get(self, entity_id: str) -> object | None:
+        return type(self).rows.get(entity_id)
+
+
+class _FakeTenantRepo(_FakeRepo):
+    rows: dict[str, object] = {}
+
+
+class _FakeMapRepo(_FakeRepo):
+    rows: dict[str, object] = {}
+
+
+class _FakeCameraRepo(_FakeRepo):
+    rows: dict[str, object] = {}
+
+
+class _FakeSession:
+    """Minimal session object handed to the repo doubles."""
+
+
+@contextmanager
+def _fake_session_factory() -> Iterator[_FakeSession]:
+    yield _FakeSession()
+
+
+def _install_repo_doubles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the bootstrap module's repo seams to fresh in-memory doubles."""
+    _FakeTenantRepo.rows = {}
+    _FakeMapRepo.rows = {}
+    _FakeCameraRepo.rows = {}
+    monkeypatch.setattr(cmd, "RepoPostgresTenant", _FakeTenantRepo)
+    monkeypatch.setattr(cmd, "RepoPostgresMap", _FakeMapRepo)
+    monkeypatch.setattr(cmd, "RepoPostgresCameraConfig", _FakeCameraRepo)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _tenant() -> Tenant:
+    return Tenant(id="icozee", name="Icozee")
+
+
+def _map() -> Map:
+    return Map(
+        id="icozee_cropped",
+        tenant_id="icozee",
+        photo=Photo(path=Path("icozee-cropped.tif"), width=3327, height=2731),
+        geotiff=GeoTiff(
+            geotransform=GeoTransform(
+                origin_easting=69315.30,
+                pixel_width=0.15,
+                row_rotation=0.0,
+                origin_northing=222999.00,
+                col_rotation=0.0,
+                pixel_height=-0.15,
+            ),
+            crs="EPSG:31370",
+        ),
+        asset_key="icozee/icozee-cropped.tif",
+    )
+
+
+def _cameras() -> list[dict]:
+    return [
+        {"id": "icozee-camptz-02", "tenant_id": "icozee", "name": "Cam02", "ip": "10.0.0.2"},
+        {"id": "icozee-camptz-03", "tenant_id": "icozee", "name": "Cam03", "ip": "10.0.0.3"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _run_bootstrap: persists tenant + map + one camera_config per camera
+# ---------------------------------------------------------------------------
+
+
+def test_run_bootstrap_persists_reference_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_repo_doubles(monkeypatch)
+    tenant_map = _map()
+
+    summary = cmd._run_bootstrap(
+        tenant_id="icozee",
+        tenant=_tenant(),
+        tenant_map=tenant_map,
+        cameras=_cameras(),
+        credential=Credential("admin", "pw"),
+        session_factory=_fake_session_factory,
+    )
+
+    # Exactly one tenant row and one map row.
+    assert list(_FakeTenantRepo.rows) == ["icozee"]
+    assert list(_FakeMapRepo.rows) == ["icozee_cropped"]
+    saved_map = _FakeMapRepo.rows["icozee_cropped"]
+    assert saved_map.asset_key == "icozee/icozee-cropped.tif"  # type: ignore[attr-defined]
+
+    # One camera_config per camera, each anchored to the map id + tenant.
+    assert set(_FakeCameraRepo.rows) == {"icozee-camptz-02", "icozee-camptz-03"}
+    cam = _FakeCameraRepo.rows["icozee-camptz-02"]
+    assert cam.tenant_id == "icozee"  # type: ignore[attr-defined]
+    assert cam.map_id == "icozee_cropped"  # type: ignore[attr-defined]
+    assert cam.name == "Cam02"  # type: ignore[attr-defined]
+    assert cam.spec == CameraSpec.HIKVISION_DS_2DF8425IX  # type: ignore[attr-defined]
+    assert cam.ip_address == "10.0.0.2"  # type: ignore[attr-defined]
+
+    assert summary.tenant_id == "icozee"
+    assert summary.map_id == "icozee_cropped"
+    assert summary.camera_ids == ["icozee-camptz-02", "icozee-camptz-03"]
+
+
+def test_run_bootstrap_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_repo_doubles(monkeypatch)
+
+    def run() -> None:
+        cmd._run_bootstrap(
+            tenant_id="icozee",
+            tenant=_tenant(),
+            tenant_map=_map(),
+            cameras=_cameras(),
+            credential=Credential("admin", "pw"),
+            session_factory=_fake_session_factory,
+        )
+
+    run()
+    sizes = (len(_FakeTenantRepo.rows), len(_FakeMapRepo.rows), len(_FakeCameraRepo.rows))
+    run()  # second run upserts the SAME ids -> no duplicates
+    assert (len(_FakeTenantRepo.rows), len(_FakeMapRepo.rows), len(_FakeCameraRepo.rows)) == sizes
+    assert sizes == (1, 1, 2)
+
+
+# ---------------------------------------------------------------------------
+# _load_tenant_map: missing sidecar -> clear typer error
+# ---------------------------------------------------------------------------
+
+
+def test_load_tenant_map_missing_sidecar_raises(tmp_path: Path) -> None:
+    with pytest.raises(cmd.typer.Exit) as excinfo:
+        cmd._load_tenant_map("nope", tmp_path)
+    assert excinfo.value.exit_code == 1
+
+
+def test_load_tenant_map_derives_asset_key(tmp_path: Path) -> None:
+    (tmp_path / "icozee.yaml").write_text(
+        "id: icozee_cropped\n"
+        "tenant_id: icozee\n"
+        "photo:\n"
+        "  path: icozee-cropped.tif\n"
+        "  width: 3327\n"
+        "  height: 2731\n"
+        "geotiff:\n"
+        "  geotransform:\n"
+        "    origin_easting: 69315.30\n"
+        "    pixel_width: 0.15\n"
+        "    row_rotation: 0.0\n"
+        "    origin_northing: 222999.00\n"
+        "    col_rotation: 0.0\n"
+        "    pixel_height: -0.15\n"
+        "  crs: EPSG:31370\n"
+    )
+
+    tenant_map = cmd._load_tenant_map("icozee", tmp_path)
+
+    assert tenant_map.id == "icozee_cropped"
+    assert tenant_map.asset_key == "icozee/icozee-cropped.tif"
+
+
+# ---------------------------------------------------------------------------
+# Typer command wiring
+# ---------------------------------------------------------------------------
+
+
+def _wire_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    _install_repo_doubles(monkeypatch)
+    monkeypatch.setattr(cmd, "get_tenant_by_id", lambda _t: {"id": "icozee", "name": "Icozee"})
+    monkeypatch.setattr(cmd, "get_cameras_for_tenant", lambda _t: _cameras())
+    monkeypatch.setattr(cmd, "get_tenant_credentials", lambda _t: ("admin", "pw"))
+    monkeypatch.setattr(cmd, "get_session", _fake_session_factory)
+    monkeypatch.setattr(cmd, "_load_tenant_map", lambda _t, _d: _map())
+
+
+def test_command_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+
+    result = CliRunner().invoke(app, ["calibrate", "bootstrap", "--tenant", "icozee"])
+
+    assert result.exit_code == 0, result.output
+    assert "Bootstrap: tenant=icozee map=icozee_cropped cameras=2" in result.output
+
+
+def test_command_missing_database_url_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    result = CliRunner().invoke(app, ["calibrate", "bootstrap", "--tenant", "icozee"])
+
+    assert result.exit_code != 0
+    assert "DATABASE_URL" in result.output
+
+
+def test_command_unknown_tenant_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_cli(monkeypatch)
+    monkeypatch.setattr(cmd, "get_tenant_by_id", lambda _t: None)
+
+    result = CliRunner().invoke(app, ["calibrate", "bootstrap", "--tenant", "ghost"])
+
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()

--- a/tests/cli/test_bootstrap_integration.py
+++ b/tests/cli/test_bootstrap_integration.py
@@ -1,0 +1,151 @@
+"""DB-gated integration test for the idempotent bootstrap command (#374).
+
+Proves that after running ``_run_bootstrap`` against the real database for the
+``icozee`` tenant, the downstream pipeline rows (``lens_calibration_tables``,
+``ptz_registrations``) — which sit at the bottom of the tenant -> map ->
+camera_config FK chain — persist with NO ForeignKeyViolation, and that
+re-running bootstrap is a no-op. Everything rolls back at the end.
+
+This file lives under ``tests/cli/`` (no shared ``db_session`` fixture), so it
+inlines a rollback session fixture and carries its own DATABASE_URL skip guard;
+the ``tests/infrastructure`` collection gate does not reach this directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+
+from poc_homography.calibration.extrinsic.ptz_registration import PtzRegistrationResult
+from poc_homography.calibration.extrinsic.validation import ReprojectionStats
+from poc_homography.camera_config import get_cameras_for_tenant, get_tenant_by_id
+from poc_homography.cli import bootstrap as cmd
+from poc_homography.domain.entities.lens_calibration_table import LensCalibrationTable
+from poc_homography.domain.entities.ptz_registration import PtzRegistration
+from poc_homography.domain.entities.tenant import Tenant
+from poc_homography.domain.vo.credential import Credential
+from poc_homography.domain.vo.lens_distortion import LensDistortion
+from poc_homography.domain.vo.zoom_calibration_entry import ZoomCalibrationEntry
+from poc_homography.infrastructure.repositories import (
+    RepoPostgresCameraConfig,
+    RepoPostgresLensCalibrationTable,
+    RepoPostgresPtzRegistration,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.orm import Session
+
+pytestmark = pytest.mark.integration
+
+_CAMERA_ID = "icozee-camptz-03"
+
+
+@pytest.fixture
+def db_session() -> Iterator[Session]:
+    """Yield a DB session that rolls back after the test."""
+    from sqlalchemy.orm import Session as SASession
+
+    from poc_homography.infrastructure.database import get_engine
+
+    engine = get_engine()
+    with SASession(engine) as session:
+        session.begin()
+        yield session
+        session.rollback()
+
+
+def _lens_table(camera_id: str) -> LensCalibrationTable:
+    entry = ZoomCalibrationEntry(
+        zoom_factor=1.0,
+        distortion=LensDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0),
+        calibration_date="2024-01-01T00:00:00",
+        source_images=(),
+        fx=1000.0,
+        fy=1000.0,
+        cx=960.0,
+        cy=540.0,
+    )
+    return LensCalibrationTable(
+        id=camera_id,
+        entries=(entry,),
+        created_date="2024-01-01T00:00:00",
+        last_modified="2024-01-01T00:00:00",
+    )
+
+
+def _ptz_registration(camera_id: str) -> PtzRegistration:
+    homography = np.array([[1.2, 0.1, 5.0], [0.0, 1.1, 7.0], [0.0, 0.0, 1.0]], dtype=np.float64)
+    result = PtzRegistrationResult(
+        homography_matrix=homography,
+        inverse_matrix=np.linalg.inv(homography),
+        num_lines=4,
+        num_inliers=3,
+        inlier_ratio=0.75,
+        mean_perp_error=1.2,
+        max_perp_error=3.4,
+        rmse=1.5,
+        run_id="run_a",
+        camera_id=camera_id,
+        commanded_zoom=2.0,
+        commanded_tilt=15.0,
+    )
+    return PtzRegistration.from_result(
+        result,
+        reprojection_stats=ReprojectionStats(rms_m=0.12, p90_m=0.2, max_m=0.31, n_points=8),
+        created_date="2024-01-01T00:00:00",
+        last_modified="2024-01-01T00:00:00",
+    )
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+def test_bootstrap_enables_pipeline_persistence(db_session: Session) -> None:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def session_factory() -> Iterator[Session]:
+        # Reuse the rolled-back test session so the whole test is one transaction.
+        yield db_session
+
+    tenant_dict = get_tenant_by_id("icozee")
+    assert tenant_dict is not None
+    cameras = get_cameras_for_tenant("icozee")
+    assert cameras
+
+    tenant_map = cmd._load_tenant_map("icozee", Path("data/maps"))
+    tenant = Tenant.from_dict(tenant_dict)
+    credential = Credential("", "")
+
+    summary = cmd._run_bootstrap(
+        tenant_id="icozee",
+        tenant=tenant,
+        tenant_map=tenant_map,
+        cameras=cameras,
+        credential=credential,
+        session_factory=session_factory,
+    )
+    assert _CAMERA_ID in summary.camera_ids
+
+    # The FK-required rows now exist: persisting the bottom-of-chain pipeline
+    # records keyed by the camera id succeeds with no ForeignKeyViolation.
+    RepoPostgresLensCalibrationTable(db_session).save(_lens_table(_CAMERA_ID))
+    RepoPostgresPtzRegistration(db_session).save(_ptz_registration(_CAMERA_ID))
+    db_session.flush()
+
+    # Re-running bootstrap is a no-op (upsert by id; row counts unchanged).
+    before = len(RepoPostgresCameraConfig(db_session).get_all())
+    cmd._run_bootstrap(
+        tenant_id="icozee",
+        tenant=tenant,
+        tenant_map=tenant_map,
+        cameras=cameras,
+        credential=credential,
+        session_factory=session_factory,
+    )
+    after = len(RepoPostgresCameraConfig(db_session).get_all())
+    assert after == before

--- a/tests/cli/test_rollout.py
+++ b/tests/cli/test_rollout.py
@@ -157,6 +157,7 @@ def _wire_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cmd, "_load_ortho_context", lambda _map_id: ([], object()))
     monkeypatch.setattr(cmd, "get_cameras_for_tenant", lambda _t: list(_TENANT_CAMERAS))
     monkeypatch.setattr(cmd, "get_session", _fake_session_factory)
+    monkeypatch.setattr(cmd, "_require_reference_rows", lambda *_args, **_kwargs: None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_run_camera.py
+++ b/tests/cli/test_run_camera.py
@@ -311,6 +311,7 @@ def _wire_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(cmd.MinioFrameStore, "from_env", classmethod(lambda _cls: object()))
     monkeypatch.setattr(cmd, "_load_ortho_context", lambda _map_id: (_ortho_lines(), _geotiff()))
+    monkeypatch.setattr(cmd, "_require_reference_rows", lambda *_args, **_kwargs: None)
 
 
 def test_command_offline_run_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #374

## Summary

Adds `hom calibrate bootstrap --tenant <tenant>`: an idempotent (upsert-by-id) command that ensures the FK-required reference rows the automatic calibration pipeline needs — a tenant row, a map row (from `data/maps/<tenant>.yaml`, stable `map.id`, derived `asset_key` = `{tenant}/{photo.path}`), and one `camera_config` per `get_cameras_for_tenant` camera with `map_id` set — all sourced from the existing registry + map sidecars (authors no new data). Persists in FK order tenant -> map -> camera_configs; re-running is a no-op. `run-camera`/`rollout` now fail fast with a clear 'run bootstrap first' message when reference rows are missing.

## Test plan

- Offline (`tests/cli/test_bootstrap.py`, fakes, no DB): persists exactly 1 tenant / 1 map (with derived asset_key) / N camera_config rows each with the correct map_id; idempotency asserted by stable row counts on a 2nd run; missing-sidecar and missing/unknown-tenant/missing-DATABASE_URL error paths.
- DB-gated integration (`tests/cli/test_bootstrap_integration.py`, `@pytest.mark.integration` + DATABASE_URL skipif): after bootstrap, persisting a LensCalibrationTable + PtzRegistration for an icozee camera raises no ForeignKeyViolation; re-running bootstrap leaves camera_config count unchanged.
- run-camera/rollout offline tests extended to stub the new reference-row preflight.
- `poe ci` green locally (1415 passed, 159 skipped; pyright 0 errors; pylint 8.99; vulture clean).

## Closes DoD bullets

- hom calibrate bootstrap --tenant icozee creates/updates tenant + map + all icozee camera_config rows (with map_id), idempotently.
- After bootstrap, persisting a LensCalibrationTable and a PtzRegistration for an icozee camera succeeds (no FK violation) — offline test with fakes + an integration test gated on DATABASE_URL.
- Re-running bootstrap is a no-op (idempotent) — covered by a test.
- run-camera/rollout ensure-or-clearly-error when reference rows are missing.
- poe ci green.
